### PR TITLE
fix(Gtk-WARNING): Theme parsing error

### DIFF
--- a/data/stylesheet.css
+++ b/data/stylesheet.css
@@ -1,10 +1,10 @@
 @define-color headerbar_color #ffe16b;
 
 @define-color colorPrimary @headerbar_color;
-@define-color textColorPrimary #3331;
+@define-color textColorPrimary #331;
 
 .titlebar {
-    padding: 1 6px;
+    padding: 1px 6px;
 }
 
 .task {
@@ -319,5 +319,5 @@
 
 .color-n {
     border-radius: 100px;
-    padding: 1 1px;
+    padding: 1px 1px;
 }


### PR DESCRIPTION
Fix runtime warnings

stylesheet.css:4:35: Missing semicolon at end of color definition
stylesheet.css:7:14: Not using units is deprecated. Assuming 'px'.
stylesheet.css:322:14: Not using units is deprecated. Assuming 'px'.