### PR TITLE
Translation Portuguese (Portugal) pt_PT.po

### DIFF
--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -9,17 +9,17 @@ msgstr ""
 "Project-Id-Version: com.github.alainm23.planner\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2020-03-02 18:53-0500\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: \n"
+"PO-Revision-Date: 2020-03-11 18:09+ZONE\n"
+"Last-Translator: André Tiago Barata <andretiagob@protonmail.com>\n"
+"Language-Team: Portuguese (Portugal) <hLL@li.org>\n"
+"Language: pt_PT\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
 #: src/Application.vala:223 src/Widgets/New.vala:715
 msgid "New area"
-msgstr ""
+msgstr "Nova área"
 
 #: src/MainWindow.vala:45
 msgid "Planner"
@@ -31,23 +31,23 @@ msgstr "Página Inicial"
 
 #: src/Utils.vala:106 src/Utils.vala:116
 msgid "Office"
-msgstr ""
+msgstr "Escritório"
 
 #: src/Utils.vala:107 src/Utils.vala:120
 msgid "Errand"
-msgstr ""
+msgstr "Tarefa"
 
 #: src/Utils.vala:108 src/Utils.vala:124
 msgid "Important"
-msgstr "Importar"
+msgstr "Importante"
 
 #: src/Utils.vala:109 src/Utils.vala:128
 msgid "Pending"
-msgstr "Pending"
+msgstr "Pendente"
 
 #: src/Utils.vala:171
 msgid "Berry Red"
-msgstr ""
+msgstr "Vermelho Amora"
 
 #: src/Utils.vala:172
 msgid "Red"
@@ -63,12 +63,12 @@ msgstr "Amarelo"
 
 #: src/Utils.vala:175
 msgid "Olive Green"
-msgstr ""
+msgstr "Verde Oliva"
 
 #: src/Utils.vala:176
 #, fuzzy
 msgid "Lime Green"
-msgstr "Verde"
+msgstr "Verde Limão"
 
 #: src/Utils.vala:177
 msgid "Green"
@@ -76,19 +76,19 @@ msgstr "Verde"
 
 #: src/Utils.vala:178
 msgid "Mint Green"
-msgstr ""
+msgstr "Verde Menta"
 
 #: src/Utils.vala:179
 msgid "Teal"
-msgstr "Verde azulado"
+msgstr "Verde Azulado"
 
 #: src/Utils.vala:180
 msgid "Sky Blue"
-msgstr "Azul celeste"
+msgstr "Azul Celeste"
 
 #: src/Utils.vala:181
 msgid "Light Blue"
-msgstr "Azul claro"
+msgstr "Azul Claro"
 
 #: src/Utils.vala:182
 msgid "Blue"
@@ -96,27 +96,27 @@ msgstr "Azul"
 
 #: src/Utils.vala:183
 msgid "Grape"
-msgstr ""
+msgstr "Roxo"
 
 #: src/Utils.vala:184
 msgid "Violet"
-msgstr "Roxo"
+msgstr "Violeta"
 
 #: src/Utils.vala:185
 msgid "Lavander"
-msgstr ""
+msgstr "Lavanda"
 
 #: src/Utils.vala:186
 msgid "Magenta"
-msgstr ""
+msgstr "Magenta"
 
 #: src/Utils.vala:187
 msgid "Salmon"
-msgstr ""
+msgstr "Salmão"
 
 #: src/Utils.vala:188
 msgid "Charcoal"
-msgstr "Carvão"
+msgstr "Cinzento Escuro"
 
 #: src/Utils.vala:189
 msgid "Grey"
@@ -124,7 +124,7 @@ msgstr "Cinzento"
 
 #: src/Utils.vala:190
 msgid "Taupe"
-msgstr ""
+msgstr "Castanho Claro"
 
 #: src/Utils.vala:508 src/Widgets/Pane.vala:73 src/Widgets/ItemRow.vala:1322
 #: src/Widgets/DueButton.vala:148 src/Views/Today.vala:52
@@ -140,27 +140,30 @@ msgstr "Amanhã"
 
 #: src/Utils.vala:625
 msgid "Quick Add Activated!"
-msgstr ""
+msgstr "Rápido e ativado!"
 
 #: src/Utils.vala:626
 #, c-format
 msgid "Try %s to activate it. You can change it from the preferences"
-msgstr ""
+msgstr "Tente %s para ativá-lo. Voçê pode alterá-lo nas preferências"
 
 #: src/Utils.vala:643
 msgid "🚀️ Getting Started"
-msgstr ""
+msgstr "Começar"
 
 #: src/Utils.vala:644
 msgid ""
 "This project will help you learn the basics of Planner and get started with "
 "a simple task management system to stay organized and on top of everything "
 "you need to do."
-msgstr ""
+msgstr "" 
+"Este projeto vai ajudá-lo a aprender os conceitos básicos do Planner e "
+"a começar com um sistema simples de gerenciador de tarefas para se manter "
+"organizado e além de tudo fazer o que precisa ser feito."
 
 #: src/Utils.vala:649
 msgid "Keeping track of your tasks"
-msgstr ""
+msgstr "Acompanhe as suas tarefas"
 
 #: src/Utils.vala:650
 msgid ""
@@ -171,10 +174,17 @@ msgid ""
 "your head and onto your to-do list. From there you can begin to organize and "
 "prioritize so you know exactly what to focus on and when."
 msgstr ""
+"Acontece que, os nossos cérebros estão realmente conectados para nos fazer "
+"pensar nas nossas tarefas inacabadas. É útil quando voçê tem apenas uma coisa "
+"em que precisa de trabalhar. Não é tão bom quando tem mais de 30 tarefas "
+"a disputir a sua atenção de uma vez só. É por isso que o primeiro passo para "
+"organizar o seu trabalho e a sua vida é tirar tudo da sua cabeça e colocar numa "
+"lista de tarefas. A partir daí pode começar a organizar e a priorizar "
+"para saber exatamente em que se deve focar e quando."
 
 #: src/Utils.vala:655
 msgid "Adding new tasks"
-msgstr ""
+msgstr "Adicionar novas tarefas"
 
 #: src/Utils.vala:656
 msgid ""
@@ -182,10 +192,13 @@ msgid ""
 "- When your task is created, click on the task to be able to edit it, add a "
 "note or some other options."
 msgstr ""
+"- Para adicionar uma nova tarefa no Planner, clique em + e pressione Enter.\n"
+"- Quando a sua tarefa for criada, clique nela para poder editá-la, adicionar "
+"uma nota ou outras opções."
 
 #: src/Utils.vala:662
 msgid "Due dates"
-msgstr ""
+msgstr "Datas de Vencimento"
 
 #: src/Utils.vala:663
 msgid ""
@@ -194,6 +207,10 @@ msgid ""
 "- If you want to delete the due date, repeat the process and select the "
 "\"undate\" option."
 msgstr ""
+"- Se sabe que precisa executar a tarefa num determinado dia, clique no "
+"ícone do calendário e selecione uma data.\n"
+"- Se deseja excluir a data de vencimento, repita o processo e selecione "
+"a opção \"sem data\"."
 
 #: src/Utils.vala:669
 msgid "How to use projects"
@@ -211,14 +228,23 @@ msgid ""
 "- (Optional) Select a different project color from the color list.\n"
 "- Click Add to create the project."
 msgstr ""
+"- Se está a planear uma apresentação, a preparar-se para um evento ou a "
+"criar um site, crie um projeto para que todos os detalhes importantes "
+"sejam gravados num local central.\n"
+"- No menu de navegação à esquerda, na parte inferior, clique no símbolo +.\n"
+"- No menu de opções, selecione 'Projeto' e digite o nome do seu novo "
+"projeto.\n"
+"- Selecione uma fonte no menu suspenso.\n"
+"- (Opcional) Selecione uma cor diferente do projeto na lista de cores.\n"
+"- Clique em Adicionar para criar o projeto."
 
 #: src/Utils.vala:680
 msgid "Sections"
-msgstr "Seções"
+msgstr "Secções"
 
 #: src/Utils.vala:686
 msgid "Add sections"
-msgstr "Adicionar seções"
+msgstr "Adicionar secções"
 
 #: src/Utils.vala:687
 msgid ""
@@ -232,80 +258,89 @@ msgid ""
 "- At the top right of a project, click the + icon.\n"
 "- Type the name of your section and click Add."
 msgstr ""
+"- É sempre mais fácil assumir um grande projeto quando o divide em várias "
+"partes de fácil gerenciamento usando as secções do Planner.\n"
+"- Organize os seu projetos com secções para agrupar as suas tarefas e obter uma "
+"melhor visão geral do que precisa de ser feito. Adicione secções ao seu projeto, "
+"arraste as tarefas relevantes para a secção em que pertencem e achará "
+"muito mais fácil progredir (em vez de ficar sobrecarregado por uma única "
+"lista longa).\n"
+"- No canto superior direito de um projeto, clique no ícone +.\n"
+"- Digite o nome da sua secção e clique em Adicionar."
 
 #: src/Utils.vala:706
 msgid "Create a new task"
-msgstr ""
+msgstr "Criar nova tarefa"
 
 #: src/Utils.vala:707
 msgid "Create a new task at the top of the list (only works inside projects)"
-msgstr ""
+msgstr "Criar uma nova tarefa no topo da lista (só funciona dentro de projetos)"
 
 #: src/Utils.vala:708
 msgid "Create a new area"
-msgstr ""
+msgstr "Criar uma nova área"
 
 #: src/Utils.vala:709
 msgid "Create a new project"
-msgstr ""
+msgstr "Criar um novo projeto"
 
 #: src/Utils.vala:710
 msgid "Create a new section"
-msgstr ""
+msgstr "Criar uma nova secção"
 
 #: src/Utils.vala:711
 msgid "Open the Inbox"
-msgstr ""
+msgstr "Abrir Caixa de Entrada"
 
 #: src/Utils.vala:712
 #, fuzzy
 msgid "Open Today"
-msgstr "Hoje"
+msgstr "Abrir Hoje"
 
 #: src/Utils.vala:713
 msgid "Open Upcoming"
-msgstr ""
+msgstr "Abrir Próximas"
 
 #: src/Utils.vala:714
 msgid "Open Search"
-msgstr ""
+msgstr "Abrir Procura"
 
 #: src/Utils.vala:715
 msgid "Manually sync"
-msgstr ""
+msgstr "Sincronizar manualmente"
 
 #: src/Utils.vala:716
 msgid "Quit"
-msgstr ""
+msgstr "Sair"
 
 #: src/Utils.vala:724
 msgid "The request was incorrect."
-msgstr ""
+msgstr "O pedido esta incorreto."
 
 #: src/Utils.vala:725
 msgid ""
 "Authentication is required, and has failed, or has not yet been provided."
-msgstr ""
+msgstr "É necessário autenticação, esta falhou, ou ainda não foi fornecida."
 
 #: src/Utils.vala:726
 msgid "The request was valid, but for something that is forbidden."
-msgstr ""
+msgstr "O pedido é valido mas por algum motivo foi proíbido."
 
 #: src/Utils.vala:727
 msgid "The requested resource could not be found."
-msgstr ""
+msgstr "Não foi possível encontrar o recurso pedido."
 
 #: src/Utils.vala:728
 msgid "The user has sent too many requests in a given amount of time."
-msgstr ""
+msgstr "O utilizador enviou demasiados pedidos num curto espaço de tempo."
 
 #: src/Utils.vala:729
 msgid "The request failed due to a server error."
-msgstr ""
+msgstr "O pedido falhou devido a um erro do servidor."
 
 #: src/Utils.vala:730
 msgid "The server is currently unable to handle the request."
-msgstr ""
+msgstr "De momento, o servidor não consegue processar o pedido."
 
 #. search_row = new Widgets.ActionRow (_("Quick Find"), "system-search-symbolic", "search", _("Your Inbox is the default place to add new tasks so you can get them out of your head quickly, then come back and make a plan to take care of them later. It’s a great way to declutter your mind so you can focus on whatever you’re doing right now."));
 #: src/Services/Database.vala:966 src/Widgets/Pane.vala:65
@@ -313,15 +348,15 @@ msgstr ""
 #: src/Views/Inbox.vala:71 src/Dialogs/Preferences/Preferences.vala:223
 #: src/Dialogs/Preferences/Preferences.vala:331
 msgid "Inbox"
-msgstr ""
+msgstr "Caixa de Entrada"
 
 #: src/Services/Notifications.vala:28
 msgid "task"
-msgstr "Tarefa"
+msgstr "tarefa"
 
 #: src/Services/Notifications.vala:30
 msgid "tasks"
-msgstr "Tarefas"
+msgstr "tarefas"
 
 #: src/Services/Calendar/Util.vala:227
 msgid "On this computer"
@@ -329,7 +364,7 @@ msgstr "Neste computador"
 
 #: src/Widgets/ActionRow.vala:85 src/Widgets/ProjectRow.vala:147
 msgid "Todoist Project"
-msgstr ""
+msgstr "Projeto Todoist"
 
 #: src/Widgets/Pane.vala:65
 msgid ""
@@ -338,6 +373,11 @@ msgid ""
 "later. It’s a great way to declutter your mind so you can focus on whatever "
 "you’re doing right now."
 msgstr ""
+"A sua Caixa de Entrada é o local predefinido para adicionar novas tarefas "
+"para que as possa tirar rápidamente da sua cabeça, mais tarde volte e faça um "
+"plano para lidar com elas. É uma ótima maneira de organizar a sua mente para "
+"que se possa concentrar no que estiver a fazer no momento."
+
 
 #: src/Widgets/Pane.vala:73
 msgid ""
@@ -345,44 +385,50 @@ msgid ""
 "projects. Check in here every morning to make a realistic plan to tackle "
 "your day."
 msgstr ""
+"A vista de Hoje deixa-o ver todas as tarefas do dia em todos os seus projetos. "
+"Faça check-in aqui todas as manhãs para fazer um plano realista e enfrentar "
+"o seu dia."
 
 #. vala-lint=line-length
 #: src/Widgets/Pane.vala:74 src/Widgets/Pane.vala:75 src/Widgets/Pane.vala:350
 #: src/Views/Upcoming.vala:36 src/Dialogs/Preferences/Preferences.vala:230
 msgid "Upcoming"
-msgstr ""
+msgstr "Próximas"
 
 #: src/Widgets/Pane.vala:74
 msgid ""
 "Plan your week ahead with the Upcoming view. It shows everything on your "
 "agenda for the coming days: scheduled to-dos and calendar events."
 msgstr ""
+"Planeie antecipadamente a sua semana na vista Próximas. Isto mostra-lhe "
+"tudo da sua agenda para os próximos dias: tarefas agendadas e eventos "
+"no calendário."
 
 #. vala-lint=line-length
 #: src/Widgets/Pane.vala:75
 msgid "Back-Pocket"
-msgstr ""
+msgstr "Bolso"
 
 #: src/Widgets/Pane.vala:82
 #, fuzzy
 msgid "Add List"
-msgstr "Adicionar seções"
+msgstr "Adicionar Lista"
 
 #: src/Widgets/Pane.vala:148
 msgid "Quick Find"
-msgstr ""
+msgstr "Procurar Rápido"
 
 #: src/Widgets/Pane.vala:162
 msgid "Preferences"
-msgstr ""
+msgstr "Definições"
 
 #: src/Widgets/Pane.vala:175 src/Widgets/Pane.vala:410
 msgid "Sync"
-msgstr ""
+msgstr "Sincronizar"
 
 #: src/Widgets/Pane.vala:414
 msgid "Offline mode is on"
-msgstr ""
+msgstr "Modo Offline esta ligado"
 
 #: src/Widgets/Pane.vala:414
 msgid ""
@@ -390,25 +436,28 @@ msgid ""
 "internet. Changes you make in offline\n"
 "mode will be synced when you reconnect"
 msgstr ""
+"Parece que não está ligado à internet.\n"
+"Alterações feitas em modo offline irão\n"
+"ser sincronizadas ao reconectar"
 
 #: src/Widgets/New.vala:62 src/Views/Inbox.vala:770 src/Views/Project.vala:1030
 #: src/Dialogs/ProjectSettings.vala:46
 msgid "Name:"
-msgstr ""
+msgstr "Nome"
 
 #: src/Widgets/New.vala:83
 msgid "Area:"
-msgstr ""
+msgstr "Área"
 
 #: src/Widgets/New.vala:97 src/Dialogs/ProjectSettings.vala:54
 msgid "Color:"
-msgstr ""
+msgstr "Cor"
 
 #: src/Widgets/New.vala:257 src/Widgets/NewItem.vala:86
 #: src/Widgets/ReminderButton.vala:208 src/Widgets/NewSection.vala:82
 #: src/Views/Inbox.vala:786 src/Views/Project.vala:1046
 msgid "Add"
-msgstr ""
+msgstr "Adicionar"
 
 #: src/Widgets/New.vala:262 src/Widgets/New.vala:659
 #: src/Widgets/NewItem.vala:91 src/Widgets/SectionRow.vala:132
@@ -417,70 +466,70 @@ msgstr ""
 #: src/Views/Inbox.vala:791 src/Views/Project.vala:159
 #: src/Views/Project.vala:1051
 msgid "Cancel"
-msgstr ""
+msgstr "Cancelar"
 
 #: src/Widgets/New.vala:473
 msgid "Local"
-msgstr ""
+msgstr "Local"
 
 #: src/Widgets/New.vala:544 src/Widgets/ProjectRow.vala:444
 msgid "No Area"
-msgstr ""
+msgstr "Sem Àrea"
 
 #: src/Widgets/New.vala:605
 msgid "Project"
-msgstr ""
+msgstr "Projeto"
 
 #: src/Widgets/New.vala:610
 msgid "Start a new project, create a to do list, organize your notes."
-msgstr ""
+msgstr "Iniciar novo projeto, criar lista de tarefas, organizar notas."
 
 #: src/Widgets/New.vala:636
 msgid "Area"
-msgstr ""
+msgstr "Área"
 
 #: src/Widgets/New.vala:641
 msgid "Organize your projects in groups and keep your panel clean."
-msgstr ""
+msgstr "Organize os seus projetos em grupos e mantenha o painel limpo."
 
 #: src/Widgets/ProjectRow.vala:125 src/Views/Project.vala:145
 msgid "Project Menu"
-msgstr ""
+msgstr "Menu Projeto"
 
 #: src/Widgets/ProjectRow.vala:143
 msgid "Local Project"
-msgstr ""
+msgstr "Projeto Local"
 
 #: src/Widgets/ProjectRow.vala:361 src/Widgets/ItemRow.vala:1214
 #: src/Widgets/ItemRow.vala:1235 src/Widgets/ItemRow.vala:1270
 #: src/Widgets/SectionRow.vala:770
 #, c-format
 msgid "Task moved to <b>%s</b>"
-msgstr ""
+msgstr "Tarefa movida para <b>%s</b>"
 
 #: src/Widgets/ProjectRow.vala:496 src/Widgets/ItemRow.vala:1312
 #: src/Widgets/AreaRow.vala:499 src/Views/Project.vala:830
 msgid "Edit"
-msgstr ""
+msgstr "Editar"
 
 #: src/Widgets/ProjectRow.vala:498
 msgid "Move to Area"
-msgstr ""
+msgstr "Mover para Área"
 
 #: src/Widgets/ProjectRow.vala:502 src/Widgets/ItemRow.vala:1339
 #: src/Widgets/SectionRow.vala:599
 msgid "Share"
-msgstr ""
+msgstr "Partilhar"
 
 #: src/Widgets/ProjectRow.vala:506
 msgid "Send by e-mail"
-msgstr ""
+msgstr "Enviar por e-mail"
 
 #. var share_text_menu = new Widgets.ImageMenuItem (_("Text"), "text-x-generic-symbolic");
 #: src/Widgets/ProjectRow.vala:507 src/Widgets/ItemRow.vala:1344
 #: src/Widgets/SectionRow.vala:604
 msgid "Markdown"
-msgstr ""
+msgstr "Markdown"
 
 #. var archive_menu = new Widgets.ModelButton (_("Archive project"), "planner-archive-symbolic");
 #: src/Widgets/ProjectRow.vala:513 src/Widgets/ProjectRow.vala:538
@@ -489,420 +538,420 @@ msgstr ""
 #: src/Widgets/AreaRow.vala:538 src/Widgets/CheckRow.vala:80
 #: src/Views/Project.vala:833 src/Views/Project.vala:903
 msgid "Delete"
-msgstr ""
+msgstr "Apagar"
 
 #: src/Widgets/ProjectRow.vala:533 src/Views/Project.vala:898
 msgid "Delete project"
-msgstr ""
+msgstr "Apagar projeto"
 
 #: src/Widgets/ProjectRow.vala:534 src/Widgets/SectionRow.vala:643
 #: src/Widgets/AreaRow.vala:526 src/Views/Project.vala:899
 #, c-format
 msgid "Are you sure you want to delete <b>%s</b>?"
-msgstr ""
+msgstr "Tem a certeza que deseja apagar <b>%s</b>?"
 
 #: src/Widgets/NewItem.vala:63 src/Widgets/ItemRow.vala:204
 #: src/Widgets/AreaRow.vala:110 src/Widgets/CheckRow.vala:64
 msgid "Task name"
-msgstr ""
+msgstr "Nome da Tarefa"
 
 #: src/Widgets/ItemRow.vala:170 src/Widgets/ItemRow.vala:994
 msgid "View Details"
-msgstr ""
+msgstr "Ver Detalhes"
 
 #: src/Widgets/ItemRow.vala:372 src/Widgets/ItemCompletedRow.vala:40
 msgid "Note"
-msgstr ""
+msgstr "Nota"
 
 #: src/Widgets/ItemRow.vala:420
 #, fuzzy
 msgid "Add Checklist"
-msgstr "Adicionar seções"
+msgstr "Adicionar lista de verificação"
 
 #: src/Widgets/ItemRow.vala:427
 msgid "Delete Task"
-msgstr ""
+msgstr "Apagar Tarefa"
 
 #: src/Widgets/ItemRow.vala:440
 msgid "Task Menu"
-msgstr ""
+msgstr "Menu de Tarefa"
 
 #: src/Widgets/ItemRow.vala:973
 #, fuzzy
 msgid "Hiding"
-msgstr "Pending"
+msgstr "Ocultar"
 
 #: src/Widgets/ItemRow.vala:1249
 msgid "No Section"
-msgstr ""
+msgstr "Sem Secção"
 
 #: src/Widgets/ItemRow.vala:1311
 msgid "Complete"
-msgstr ""
+msgstr "Completar"
 
 #: src/Widgets/ItemRow.vala:1328 src/Widgets/DueButton.vala:156
 msgid "Undated"
-msgstr ""
+msgstr "Sem data"
 
 #: src/Widgets/ItemRow.vala:1331 src/Widgets/SectionRow.vala:595
 #, fuzzy
 msgid "Move to Project"
-msgstr "Como usar projetos"
+msgstr "Mover para Projeto"
 
 #: src/Widgets/ItemRow.vala:1335
 #, fuzzy
 msgid "Move to Section"
-msgstr "Seções"
+msgstr "Mover para Secções"
 
 #: src/Widgets/ItemRow.vala:1343
 msgid "Text"
-msgstr ""
+msgstr "Texto"
 
 #: src/Widgets/ItemRow.vala:1350
 msgid "Duplicate"
-msgstr ""
+msgstr "Duplicar"
 
 #: src/Widgets/ItemCompletedRow.vala:39
 msgid "Content"
-msgstr ""
+msgstr "Conteúdo"
 
 #: src/Widgets/ItemCompletedRow.vala:41
 msgid "Due date"
-msgstr ""
+msgstr "Data de vencimento"
 
 #: src/Widgets/ItemCompletedRow.vala:42
 msgid "Date completed"
-msgstr ""
+msgstr "Data completa"
 
 #: src/Widgets/SectionRow.vala:77 src/Widgets/SectionRow.vala:693
 msgid "Display Tasks"
-msgstr ""
+msgstr "Mostrar Tarefas"
 
 #: src/Widgets/SectionRow.vala:85 src/Widgets/SectionRow.vala:698
 msgid "Hiding Tasks"
-msgstr ""
+msgstr "Ocultar Tarefas"
 
 #: src/Widgets/SectionRow.vala:96 src/Widgets/NewSection.vala:70
 msgid "Section name"
-msgstr ""
+msgstr "Nome da Secção"
 
 #: src/Widgets/SectionRow.vala:111
 #, fuzzy
 msgid "Section Menu"
-msgstr "Seções"
+msgstr "Menu de Secções"
 
 #. top_box.pack_end (hidden_revealer, false, false, 0);
 #: src/Widgets/SectionRow.vala:128 src/Widgets/AreaRow.vala:135
 #: src/Views/Project.vala:155 src/Dialogs/ProjectSettings.vala:255
 msgid "Save"
-msgstr ""
+msgstr "Gravar"
 
 #: src/Widgets/SectionRow.vala:545 src/Widgets/SectionRow.vala:567
 #, c-format
 msgid "Section moved to <b>%s</b>"
-msgstr ""
+msgstr "Secção movida para <b>%s</b>"
 
 #: src/Widgets/SectionRow.vala:589 src/Widgets/MagicButton.vala:32
 msgid "Add Task"
-msgstr ""
+msgstr "Adicionar Tarefa"
 
 #: src/Widgets/SectionRow.vala:592
 msgid "Rename"
-msgstr ""
+msgstr "Renomear"
 
 #: src/Widgets/SectionRow.vala:593
 #, fuzzy
 msgid "Add Note"
-msgstr "Adicionar seções"
+msgstr "Adicionar Nota"
 
 #: src/Widgets/SectionRow.vala:642
 msgid "Delete section"
-msgstr ""
+msgstr "Apagar secção"
 
 #: src/Widgets/SectionRow.vala:661
 #, fuzzy
 msgid "Section deleted"
-msgstr "Seções"
+msgstr "Secções apagadas"
 
 #: src/Widgets/DueButton.vala:43
 msgid "Due Date"
-msgstr ""
+msgstr "Data de Vencimento"
 
 #: src/Widgets/LabelButton.vala:36 src/Dialogs/Preferences/Preferences.vala:114
 #: src/Dialogs/Preferences/Preferences.vala:721
 msgid "Labels"
-msgstr ""
+msgstr "Etiquetas"
 
 #: src/Widgets/LabelButton.vala:46
 msgid "labels"
-msgstr ""
+msgstr "etiquetas"
 
 #: src/Widgets/LabelButton.vala:92
 msgid "Type a label"
-msgstr ""
+msgstr "Escreva uma etiqueta"
 
 #: src/Widgets/LabelButton.vala:119
 msgid "Edit labels"
-msgstr ""
+msgstr "Editar etiquetas"
 
 #: src/Widgets/Toast.vala:88
 msgid "Undo"
-msgstr ""
+msgstr "Dezfazer"
 
 #: src/Widgets/AreaRow.vala:81 src/Widgets/AreaRow.vala:345
 msgid "Display Projects"
-msgstr ""
+msgstr "Mostrar Projetos"
 
 #: src/Widgets/AreaRow.vala:125 src/Widgets/AreaRow.vala:350
 msgid "Hiding Projects"
-msgstr ""
+msgstr "Ocultar Projetos"
 
 #: src/Widgets/AreaRow.vala:496
 #, fuzzy
 msgid "Add project"
-msgstr "Adicionar seções"
+msgstr "Adicionar projeto"
 
 #: src/Widgets/AreaRow.vala:525
 msgid "Delete area"
-msgstr ""
+msgstr "Apagar Área"
 
 #: src/Widgets/AreaRow.vala:533
 msgid "Delete projects"
-msgstr ""
+msgstr "Apagar projetos"
 
 #: src/Widgets/NewCheck.vala:74
 msgid "Subtask name"
-msgstr ""
+msgstr "Nome da sub-tarefa"
 
 #: src/Widgets/UpcomingRow.vala:67
 msgid "Add task"
-msgstr ""
+msgstr "Adicionar tarefa"
 
 #: src/Widgets/QuickFind.vala:48 src/Dialogs/ProjectSettings.vala:253
 #: src/Dialogs/Preferences/Preferences.vala:78
 msgid "Close"
-msgstr ""
+msgstr "Fechar"
 
 #: src/Widgets/ReminderButton.vala:42
 msgid "Reminders"
-msgstr ""
+msgstr "Lembretes"
 
 #: src/Widgets/ReminderButton.vala:164
 msgid "Add reminder"
-msgstr ""
+msgstr "Adicionar lembrete"
 
 #: src/Widgets/ReminderButton.vala:199
 msgid "Time:"
-msgstr ""
+msgstr "Tempo"
 
 #: src/Widgets/NewLabel.vala:42
 msgid "Add Label"
-msgstr ""
+msgstr "Adicionar Etiqueta"
 
 #: src/Widgets/Calendar/CalendarHeader.vala:34
 msgid "%OB, %Y"
-msgstr ""
+msgstr "%OB, %Y"
 
 #: src/Widgets/Calendar/CalendarHeader.vala:42
 msgid "%OB %Y"
-msgstr ""
+msgstr "%OB %Y"
 
 #: src/Widgets/Calendar/CalendarWeek.vala:26
 msgid "Mon"
-msgstr ""
+msgstr "Seg"
 
 #: src/Widgets/Calendar/CalendarWeek.vala:29
 msgid "Tue"
-msgstr ""
+msgstr "Ter"
 
 #: src/Widgets/Calendar/CalendarWeek.vala:32
 msgid "Wed"
-msgstr ""
+msgstr "Qua"
 
 #: src/Widgets/Calendar/CalendarWeek.vala:35
 msgid "Thu"
-msgstr ""
+msgstr "Qui"
 
 #: src/Widgets/Calendar/CalendarWeek.vala:38
 msgid "Fri"
-msgstr ""
+msgstr "Sex"
 
 #: src/Widgets/Calendar/CalendarWeek.vala:41
 msgid "Sat"
-msgstr ""
+msgstr "Sáb"
 
 #: src/Widgets/Calendar/CalendarWeek.vala:44
 msgid "Sun"
-msgstr ""
+msgstr "Dom"
 
 #: src/Views/Welcome.vala:26
 msgid "Never worry about forgetting things again"
-msgstr ""
+msgstr "Não se preocupe em esquecer coisas outra vez"
 
 #: src/Views/Welcome.vala:29
 msgid "Startup"
-msgstr ""
+msgstr "Comece"
 
 #: src/Views/Welcome.vala:29
 msgid "Start working locally."
-msgstr ""
+msgstr "Começar a trabalhar localmente."
 
 #: src/Views/Welcome.vala:30 src/Dialogs/Preferences/Preferences.vala:902
 msgid "Todoist"
-msgstr ""
+msgstr "Todoist"
 
 #: src/Views/Welcome.vala:30
 msgid "Synchronize with your Todoist account and start working."
-msgstr ""
+msgstr "Sincronize com a sua conta Todoist e comece a trabalhar."
 
 #: src/Views/Inbox.vala:82 src/Views/Project.vala:113
 #, fuzzy
 msgid "Add Section"
-msgstr "Adicionar seções"
+msgstr "Adicionar secções"
 
 #: src/Views/Inbox.vala:91
 msgid "Inbox comments"
-msgstr ""
+msgstr "Comentários da Caixa de Entrada"
 
 #: src/Views/Inbox.vala:99 src/Views/Project.vala:138
 msgid "Search task"
-msgstr ""
+msgstr "Pesquisar tarefas"
 
 #: src/Views/Inbox.vala:106
 msgid "Inbox Menu"
-msgstr ""
+msgstr "Menu da Caixa de Entrada"
 
 #: src/Views/Inbox.vala:149
 msgid "All clear"
-msgstr ""
+msgstr "Tudo limpo"
 
 #: src/Views/Inbox.vala:150
 msgid "Looks like everything's organized in the right place."
-msgstr ""
+msgstr "Parece que está tudo organizado no sítio correto."
 
 #: src/Views/Inbox.vala:718 src/Views/Project.vala:842
 msgid "Show Completed"
-msgstr ""
+msgstr "Mostrar Completado"
 
 #: src/Views/Inbox.vala:881 src/Views/Project.vala:995
 msgid "Task completed"
-msgstr ""
+msgstr "Tarefa completada"
 
 #: src/Views/Today.vala:85
 msgid "What tasks are on your mind?"
-msgstr ""
+msgstr "Que tarefas tem em mente?"
 
 #: src/Views/Today.vala:86
 msgid "Tap + to add a task for today."
-msgstr ""
+msgstr "Toque + para adicionar tarefa para hoje."
 
 #: src/Views/Project.vala:121
 msgid "Invite person"
-msgstr ""
+msgstr "Convidar pessoa"
 
 #: src/Views/Project.vala:130
 msgid "Project comments"
-msgstr ""
+msgstr "Comentários do projeto"
 
 #: src/Views/Project.vala:186
 msgid "Add a note"
-msgstr ""
+msgstr "Adicionar uma nota"
 
 #: src/Views/Project.vala:195
 msgid "Add note"
-msgstr ""
+msgstr "Adicionar nota"
 
 #: src/Views/Project.vala:311
 msgid "What will you accomplish?"
-msgstr ""
+msgstr "O que vai conseguir fazer?"
 
 #: src/Views/Project.vala:312
 msgid "Tap + to add a task to this project."
-msgstr ""
+msgstr "Toque + para adicionar uma tarefa neste projeto."
 
 #: src/Dialogs/TodoistOAuth.vala:43 src/Dialogs/TodoistOAuth.vala:121
 msgid "Loading…"
-msgstr ""
+msgstr "A carregar…"
 
 #. Alert
 #: src/Dialogs/TodoistOAuth.vala:67 src/Dialogs/TodoistOAuth.vala:135
 msgid "Network Is Not Available"
-msgstr ""
+msgstr "Rede não está disponível"
 
 #: src/Dialogs/TodoistOAuth.vala:68
 msgid "Connect to the Internet to connect with Todoist"
-msgstr ""
+msgstr "Ligue-se à Internet para conetar-se com o Todoist"
 
 #: src/Dialogs/TodoistOAuth.vala:101
 msgid "Synchronizing… Wait a moment please."
-msgstr ""
+msgstr "Sincronizando… Por favor espere um momento."
 
 #: src/Dialogs/TodoistOAuth.vala:113
 msgid "Please enter your credentials…"
-msgstr ""
+msgstr "Por favor insira as suas credenciais…"
 
 #: src/Dialogs/ProjectSettings.vala:51
 msgid "Due:"
-msgstr ""
+msgstr "Data de Vencimento:"
 
 #: src/Dialogs/ProjectSettings.vala:226
 msgid "Uploading changes…"
-msgstr ""
+msgstr "Atualizando aterações…"
 
 #. General
 #: src/Dialogs/Preferences/Preferences.vala:87
 #: src/Dialogs/Preferences/Preferences.vala:94
 #: src/Dialogs/Preferences/Preferences.vala:580
 msgid "General"
-msgstr ""
+msgstr "Geral"
 
 #: src/Dialogs/Preferences/Preferences.vala:90
 #: src/Dialogs/Preferences/Preferences.vala:209
 #: src/Dialogs/Preferences/Preferences.vala:1230
 msgid "Homepage"
-msgstr ""
+msgstr "Página Inicial"
 
 #: src/Dialogs/Preferences/Preferences.vala:91
 #: src/Dialogs/Preferences/Preferences.vala:314
 msgid "Badge Count"
-msgstr ""
+msgstr "Contador do Ícone"
 
 #: src/Dialogs/Preferences/Preferences.vala:92
 #: src/Dialogs/Preferences/Preferences.vala:387
 msgid "Theme"
-msgstr ""
+msgstr "Tema"
 
 #: src/Dialogs/Preferences/Preferences.vala:93
 #: src/Dialogs/Preferences/Preferences.vala:436
 msgid "Quick Add"
-msgstr ""
+msgstr "Adicionar rápido"
 
 #. Addons
 #: src/Dialogs/Preferences/Preferences.vala:109
 msgid "Add-ons"
-msgstr ""
+msgstr "Complementos"
 
 #: src/Dialogs/Preferences/Preferences.vala:113
 #: src/Dialogs/Preferences/Preferences.vala:1042
 msgid "Calendar Events"
-msgstr ""
+msgstr "Eventos do calendário"
 
 #: src/Dialogs/Preferences/Preferences.vala:115
 #: src/Dialogs/Preferences/Preferences.vala:449
 #: src/Dialogs/Preferences/Preferences.vala:847
 msgid "Keyboard Shortcuts"
-msgstr ""
+msgstr "Atalhos do teclado"
 
 #. Others
 #: src/Dialogs/Preferences/Preferences.vala:130
 #: src/Dialogs/Preferences/Preferences.vala:1216
 msgid "About"
-msgstr ""
+msgstr "Sobre"
 
 #: src/Dialogs/Preferences/Preferences.vala:131
 #: src/Dialogs/Preferences/Preferences.vala:1121
 msgid "Support & Credits"
-msgstr ""
+msgstr "Suporte e Creditos"
 
 #: src/Dialogs/Preferences/Preferences.vala:212
 msgid ""
@@ -910,37 +959,43 @@ msgid ""
 "important. The default homepage is your <b>Inbox</b> view, but you can "
 "change it to whatever you'd like."
 msgstr ""
+"Quando abrir o Planner, verifique as suas tarefas mais importantes. "
+"A página principal é a vista da sua <b>Caixa de Entrada</b>, mas pode "
+"altera-la para o que quiser."
 
 #: src/Dialogs/Preferences/Preferences.vala:244
 msgid "Projects"
-msgstr ""
+msgstr "Projetos"
 
 #: src/Dialogs/Preferences/Preferences.vala:317
 msgid ""
 "Choose which items should be counted for the badge on the application icon."
 msgstr ""
+"Escolha quais os items a incluir no contador do ícone da aplicação."
 
 #: src/Dialogs/Preferences/Preferences.vala:327
 msgid "None"
-msgstr ""
+msgstr "Nenhum"
 
 #: src/Dialogs/Preferences/Preferences.vala:337
 msgid "Today + Inbox"
-msgstr ""
+msgstr "Hoje + Caixa de Entrada"
 
 #: src/Dialogs/Preferences/Preferences.vala:390
 msgid ""
 "Personalize the look and feel of your Planner by choosing the theme that "
 "best suits you."
 msgstr ""
+"Personalize a aparência do seu Planner escolhendo o tema mais que mais o"
+"agrada."
 
 #: src/Dialogs/Preferences/Preferences.vala:400
 msgid "Light"
-msgstr ""
+msgstr "Claro"
 
 #: src/Dialogs/Preferences/Preferences.vala:404
 msgid "Night"
-msgstr ""
+msgstr "Escuro"
 
 #: src/Dialogs/Preferences/Preferences.vala:439
 msgid ""
@@ -948,28 +1003,31 @@ msgid ""
 "open the Quick Add window, where you can enter a pending task and quickly "
 "return to work."
 msgstr ""
+"Não se preocupe com a aplicação que está a usar. Você pode usar o atalho do "
+"seu teclado para abrir a janela do Adicionar Rápido, onde é possível inserir "
+"uma tarefa pendente e retomar rapidamente ao trabalho."
 
 #: src/Dialogs/Preferences/Preferences.vala:461
 #: src/Dialogs/Preferences/Preferences.vala:530
 #, fuzzy
 msgid "Change"
-msgstr "Laranja"
+msgstr "Mudar"
 
 #: src/Dialogs/Preferences/Preferences.vala:489
 msgid "Save Last Selected Project"
-msgstr ""
+msgstr "Gravar o último projeto selecionado"
 
 #: src/Dialogs/Preferences/Preferences.vala:528
 msgid "Press keys…"
-msgstr ""
+msgstr "Pressione as teclas…"
 
 #: src/Dialogs/Preferences/Preferences.vala:583
 msgid "DE Integration"
-msgstr ""
+msgstr "Integração DE"
 
 #: src/Dialogs/Preferences/Preferences.vala:587
 msgid "Run in background"
-msgstr ""
+msgstr "Executar em segundo plano"
 
 #: src/Dialogs/Preferences/Preferences.vala:591
 msgid ""
@@ -977,97 +1035,107 @@ msgid ""
 "closes. This will allow Planner to continue updating and sending reminder "
 "notifications."
 msgstr ""
+"Ative esta definição para manter o Planner em execução em segundo plano "
+"quando o fechar. Isto vai permitir ao Planner continuar a actualizar "
+"e a enviar notificações de lembretes."
 
 #: src/Dialogs/Preferences/Preferences.vala:599
 msgid "Run on startup"
-msgstr ""
+msgstr "Executar ao iniciar"
 
 #: src/Dialogs/Preferences/Preferences.vala:603
 msgid "Enable this setting to make Planner startup with the system."
-msgstr ""
+msgstr "Ative esta definição para iniciar o Planner ao iníciar o sistema."
 
 #: src/Dialogs/Preferences/Preferences.vala:620
 msgid "Button layout"
-msgstr ""
+msgstr "Layout de botões"
 
 #: src/Dialogs/Preferences/Preferences.vala:627
 msgid "Help"
-msgstr ""
+msgstr "Ajuda"
 
 #: src/Dialogs/Preferences/Preferences.vala:631
 msgid "Create tutorial project"
-msgstr ""
+msgstr "Criar projeto tutorial"
 
 #: src/Dialogs/Preferences/Preferences.vala:631
 msgid "Create"
-msgstr ""
+msgstr "Criar"
 
 #: src/Dialogs/Preferences/Preferences.vala:633
 msgid "Danger zone"
-msgstr ""
+msgstr "Zona de perigo"
 
 #: src/Dialogs/Preferences/Preferences.vala:637
 #: src/Dialogs/Preferences/Preferences.vala:703
 msgid "Reset all"
-msgstr ""
+msgstr "Restaurar tudo"
 
 #: src/Dialogs/Preferences/Preferences.vala:637
 msgid "Reset"
-msgstr ""
+msgstr "Restaurar"
 
 #: src/Dialogs/Preferences/Preferences.vala:688
 msgid "Your tutorial project was created"
-msgstr ""
+msgstr "O seu projeto tutorial foi criado"
 
 #: src/Dialogs/Preferences/Preferences.vala:698
 msgid "Are you sure you want to reset all?"
-msgstr ""
+msgstr "Tem a certeza que quer restaurar tudo?" 
 
 #: src/Dialogs/Preferences/Preferences.vala:699
 msgid ""
 "It process removes all stored information without the possibility of undoing "
 "it."
 msgstr ""
+"O processor remove toda a informação guardada sem possibilidade de a restaurar."
 
 #: src/Dialogs/Preferences/Preferences.vala:724
 msgid ""
 "Save time by batching similar tasks together using labels. You’ll be able to "
 "pull up a list of all tasks with any given label in a matter of seconds."
 msgstr ""
+"Poupe tempo agrupando tarefas semelhantes usando etiquetas. Voçê poderá ver "
+"uma lista de todas as tarefas com uma etiqueta específica em segundos."
 
 #: src/Dialogs/Preferences/Preferences.vala:850
 msgid ""
 "All the shortcuts to save you time! Some can be used anywhere in the app, "
 "while others only work when adding or editing tasks."
 msgstr ""
+"Todos os atalhos poupam o seu tempo! Alguns podem ser usados em qualquer parte "
+"na aplicação enquanto que outros só funcionam ao adicionar ou ao editar tarefas."
 
 #: src/Dialogs/Preferences/Preferences.vala:926
 #, c-format
 msgid "Last successful sync: %s"
-msgstr ""
+msgstr "Última sincronização bem sucedida: %s"
 
 #: src/Dialogs/Preferences/Preferences.vala:935
 msgid "Sync server"
-msgstr ""
+msgstr "Servidor de sincronização"
 
 #: src/Dialogs/Preferences/Preferences.vala:940
 msgid ""
 "Activate this setting so that Planner automatically synchronizes with your "
 "Todoist account every 15 minutes."
 msgstr ""
+"Ative esta definição para que o Planner sincronize automáticamente com a sua "
+"conta Todoist a cada 15 minutos."
 
 #: src/Dialogs/Preferences/Preferences.vala:952
 #: src/Dialogs/Preferences/Preferences.vala:1007
 msgid "Log out"
-msgstr ""
+msgstr "Sair"
 
 #: src/Dialogs/Preferences/Preferences.vala:1002
 msgid "Are you sure you want to log out?"
-msgstr ""
+msgstr "Tem a certeza que quer sair?"
 
 #: src/Dialogs/Preferences/Preferences.vala:1003
 msgid "This process will close your Todoist session on this device."
-msgstr ""
+msgstr "Este processo vai fechar a sua sessão Todoist neste dispositivo."
 
 #: src/Dialogs/Preferences/Preferences.vala:1045
 msgid ""
@@ -1076,10 +1144,14 @@ msgid ""
 "shared calendars in <b>Today</b> and <b>Upcoming</b>. This is useful when "
 "you’re managing your day, and as you plan the week ahead."
 msgstr ""
+"Voçê pode conectar a sua aplicação <b>calendário</b> ao Planner para ver "
+"os seus eventos e tarefas num único síto. Vai poder ver o calendário de "
+"eventos pessoais e partilhados em <b>Hoje</b> e <b>Próximos</b>. Isto é "
+"útil enquanto organiza o seu dia e planeia a semana seguinte."
 
 #: src/Dialogs/Preferences/Preferences.vala:1056
 msgid "Enabled"
-msgstr ""
+msgstr "Ligado"
 
 #: src/Dialogs/Preferences/Preferences.vala:1124
 msgid ""
@@ -1087,16 +1159,21 @@ msgid ""
 "you like Planner and want to support its development, consider donating to "
 "via:"
 msgstr ""
+"O Planner está a ser desenvolvido com ❤️ e paixão para a comunidade código aberto. "
+"Contudo, se gosta do Planner e gostaria de contribuir para o seu desenvolvimento, "
+"considere uma doação via:"
 
 #: src/Dialogs/Preferences/Preferences.vala:1150
 msgid ""
 "Thanks to them who made a donation via Patreon or PayPal. (If you want to "
 "appear here visit our Patreon account 😉️)"
 msgstr ""
+"Obrigado a todos que fizeram uma doação via Patreon ou PayPal. (Se gostaria "
+"de aparecer aqui visite a nossa conta Patreon 😉️)"
 
 #: src/Dialogs/Preferences/Preferences.vala:1231
 msgid "Report a Problem"
-msgstr ""
+msgstr "Reportar um problema"
 
 #: src/Dialogs/Preferences/Preferences.vala:1232
 msgid "Suggest Translations"
@@ -1104,23 +1181,23 @@ msgstr "Sugerir traduções"
 
 #: src/Dialogs/Preferences/Preferences.vala:1334
 msgid "Disabled"
-msgstr ""
+msgstr "Desativado"
 
 #: src/Dialogs/Preferences/TopBox.vala:43
 msgid "Back"
-msgstr ""
+msgstr "Voltar"
 
 #: src/Objects/Project.vala:118
 msgid "The Project was copied to the Clipboard."
-msgstr ""
+msgstr "O Projeto foi copiado para a área de transferência."
 
 #: src/Objects/Item.vala:197 src/Objects/Item.vala:212
 msgid "The Task was copied to the Clipboard."
-msgstr ""
+msgstr "A Tarefa foi copiada para a área de transferência."
 
 #: src/Objects/Section.vala:117
 msgid "The Section was copied to the Clipboard."
-msgstr ""
+msgstr "A secção foi copiada para a área de transferência."
 
 #~ msgid "Fund"
 #~ msgstr "Fundo"
@@ -1133,7 +1210,7 @@ msgstr ""
 #~ msgstr "⏲️ Notificações de lembretes"
 
 #~ msgid "🔍️ Quick Find"
-#~ msgstr "🔍️ Busca rápida"
+#~ msgstr "🔍️ Procura rápida"
 
 #~ msgid "🌙️ Night mode"
 #~ msgstr "🌙️ Modo noturno"
@@ -1158,7 +1235,7 @@ msgstr ""
 
 #~ msgid "Planner will notify you if any new issue was posted"
 #~ msgstr ""
-#~ "O Planejador notificará você se houver algum novo problema publicado"
+#~ "O Planner irá notificá-lo se houver algum novo problema publicado"
 
 #~ msgid "Bugs and Improvements:"
 #~ msgstr "Problemas e melhorias"


### PR DESCRIPTION
Renamed pt.po to pt_PT.po.

In this way we have Portuguese (Portugal) and the existing Portuguese (Brazil) translations.