### PR TITLE
Improve appearance when built like explained in README.md

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -128,8 +128,12 @@ public class Planner : Gtk.Application {
         utils.apply_theme_changed ();
 
         // Set Theme and Icon
-        Gtk.Settings.get_default ().set_property ("gtk-icon-theme-name", "elementary");
-        Gtk.Settings.get_default ().set_property ("gtk-theme-name", "elementary");
+        if (GLib.FileUtils.test("/usr/share/themes/elementary", GLib.FileTest.IS_DIR) || GLib.FileUtils.test("~/.themes/elementary", GLib.FileTest.IS_DIR)) {
+            Gtk.Settings.get_default ().set_property ("gtk-theme-name", "elementary");
+        }
+        if (GLib.FileUtils.test("/usr/share/icons/elementary", GLib.FileTest.IS_DIR) || GLib.FileUtils.test("~/.icons/elementary", GLib.FileTest.IS_DIR)) {
+            Gtk.Settings.get_default ().set_property ("gtk-icon-theme-name", "elementary");
+        }
 
         // Path Theme
         var command = new Granite.Services.SimpleCommand (".", "echo $DESKTOP_SESSION");


### PR DESCRIPTION
I added a condition to the point where the theme elementary is set. It only sets the theme when it can be found on the system. This way Planner takes on the local gtk theme as a fallback. That makes Planner look more adapted to the local environment and does not show a broken UI when the theme elementary can't be loaded.

On my machine this results in this:
![grafik](https://user-images.githubusercontent.com/1838576/79698967-9da3a000-828c-11ea-8343-158abab3e43c.png)

Instead of this:
![grafik](https://user-images.githubusercontent.com/1838576/79698993-ca57b780-828c-11ea-9f34-8babff7fb321.png)

I tested the flatpak build. It is not affected by this change.