### PR TITLE
Add Arc-Dark theme

### DIFF
--- a/data/com.github.alainm23.planner.gschema.xml
+++ b/data/com.github.alainm23.planner.gschema.xml
@@ -22,6 +22,7 @@
         <value nick="Light" value="0" />
         <value nick="Black" value="1" />
         <value nick="Dark Blue" value="2" />
+        <value nick="Arc Dark" value="3" />
     </enum>
 
     <schema path="/com/github/alainm23/planner/" id="com.github.alainm23.planner" gettext-domain="com.github.alainm23.planner">        

--- a/src/Dialogs/Preferences/Preferences.vala
+++ b/src/Dialogs/Preferences/Preferences.vala
@@ -405,6 +405,9 @@ public class Dialogs.Preferences.Preferences : Gtk.Dialog {
         var dark_blue_radio = new Gtk.RadioButton.with_label_from_widget (light_radio, _("Dark Blue"));
         dark_blue_radio.get_style_context ().add_class ("preference-item-radio");
 
+        var arc_dark_radio = new Gtk.RadioButton.with_label_from_widget (light_radio, _("Arc Dark"));
+        arc_dark_radio.get_style_context ().add_class ("preference-item-radio");
+
         var main_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 0);
         main_box.expand = true;
 
@@ -413,6 +416,7 @@ public class Dialogs.Preferences.Preferences : Gtk.Dialog {
         main_box.pack_start (light_radio, false, false, 0);
         main_box.pack_start (night_radio, false, false, 0);
         main_box.pack_start (dark_blue_radio, false, false, 0);
+        main_box.pack_start (arc_dark_radio, false, false, 0);
         main_box.pack_start (new Gtk.Separator (Gtk.Orientation.HORIZONTAL), false, true, 0);
 
         if (Planner.settings.get_enum ("appearance") == 0) {
@@ -421,6 +425,8 @@ public class Dialogs.Preferences.Preferences : Gtk.Dialog {
             night_radio.active = true;
         } else if (Planner.settings.get_enum ("appearance") == 2) {
             dark_blue_radio.active = true;
+        } else if (Planner.settings.get_enum ("appearance") == 3) {
+            arc_dark_radio.active = true;
         }   
 
         info_box.back_activated.connect (() => {
@@ -437,6 +443,10 @@ public class Dialogs.Preferences.Preferences : Gtk.Dialog {
 
         dark_blue_radio.toggled.connect (() => {
             Planner.settings.set_enum ("appearance", 2);
+        });
+
+        arc_dark_radio.toggled.connect (() => {
+            Planner.settings.set_enum ("appearance", 3);
         });
 
         return main_box;

--- a/src/Utils.vala
+++ b/src/Utils.vala
@@ -741,6 +741,17 @@ public class Utils : GLib.Object {
                 row_selected_color = "shade (#ffffff, 0.125)";
 
                 Gtk.Settings.get_default ().gtk_application_prefer_dark_theme = true;
+            } else if (appearance_mode == 3) {
+                base_color = "#353945";
+                check_border_color = "grey";
+                projectview_color = "#404552";
+                pane_color = "#353945";
+                pane_selected_color = "#2B303B";
+                pane_text_color = "#fefeff";
+                popover_background = "#353945";
+                row_selected_color = "shade (#fefeff, 0.25)";
+
+                Gtk.Settings.get_default ().gtk_application_prefer_dark_theme = true;
             }
 
             var css = _css.printf (

--- a/src/Utils.vala
+++ b/src/Utils.vala
@@ -749,7 +749,7 @@ public class Utils : GLib.Object {
                 pane_selected_color = "#2B303B";
                 pane_text_color = "#fefeff";
                 popover_background = "#353945";
-                row_selected_color = "shade (#fefeff, 0.25)";
+                row_selected_color = "shade (@projectview_color, 0.3)";
 
                 Gtk.Settings.get_default ().gtk_application_prefer_dark_theme = true;
             }

--- a/src/Utils.vala
+++ b/src/Utils.vala
@@ -757,6 +757,7 @@ public class Utils : GLib.Object {
                 pane_text_color = "#fefeff";
                 popover_background = "#353945";
                 row_selected_color = "shade (@projectview_color, 0.3)";
+                upcoming_color = "#a970ff";
 
                 Gtk.Settings.get_default ().gtk_application_prefer_dark_theme = true;
             }


### PR DESCRIPTION
This adds a theme option which is based on the Arc-Dark theme. It's a pretty popular theme, especially useful for people who don't want to use a light theme but find the other Dark theme options to be too dark.