### PR TITLE
Fix changing label for database path

### DIFF
--- a/src/Dialogs/Preferences/DatabaseSettings.vala
+++ b/src/Dialogs/Preferences/DatabaseSettings.vala
@@ -166,7 +166,7 @@ public class Dialogs.Preferences.DatabaseSettings : Gtk.EventBox {
                 }
 
                 Planner.database.set_database_path (filename);
-                current_location_content.label = "<small>%s<small>".printf (filename);
+                current_location_content.label = "<small>%s</small>".printf (filename);
                 location_grid.tooltip_text = _("Current location: %s".printf (filename));
 
                 break;


### PR DESCRIPTION
The label was not updated anymore due to a formatting problem. The tag <small> was not closed.