### PR TITLE
Get rid of deprecated compile warnings

### DIFF
--- a/src/Dialogs/Preferences/DatabaseSettings.vala
+++ b/src/Dialogs/Preferences/DatabaseSettings.vala
@@ -129,9 +129,9 @@ public class Dialogs.Preferences.DatabaseSettings : Gtk.EventBox {
                     _("database location"), 
                     this as Gtk.Window, 
                     Gtk.FileChooserAction.SAVE,
-                    Gtk.Stock.CANCEL,
+                    _("_Cancel"),
                     Gtk.ResponseType.CANCEL,
-                    Gtk.Stock.OPEN,
+                    _("_Open"),
                     Gtk.ResponseType.ACCEPT
                 );
 

--- a/src/Dialogs/Preferences/DatabaseSettings.vala
+++ b/src/Dialogs/Preferences/DatabaseSettings.vala
@@ -166,7 +166,7 @@ public class Dialogs.Preferences.DatabaseSettings : Gtk.EventBox {
                 }
 
                 Planner.database.set_database_path (filename);
-                current_location_content.label = "<small>%s<small>".printf (filename);
+                current_location_content.label = "<small>%s</small>".printf (filename);
                 location_grid.tooltip_text = _("Current location: %s".printf (filename));
 
                 break;


### PR DESCRIPTION
This may avoid future problems when gtk deletes this api. This stock constants are deprecated since they moved to freedesktop standards.