### PR TITLE
Fix gtk criticals

### DIFF
--- a/src/Dialogs/Preferences/DatabaseSettings.vala
+++ b/src/Dialogs/Preferences/DatabaseSettings.vala
@@ -166,7 +166,7 @@ public class Dialogs.Preferences.DatabaseSettings : Gtk.EventBox {
                 }
 
                 Planner.database.set_database_path (filename);
-                current_location_content.label = "<small>%s<small>".printf (filename);
+                current_location_content.label = "<small>%s</small>".printf (filename);
                 location_grid.tooltip_text = _("Current location: %s".printf (filename));
 
                 break;

--- a/src/Widgets/ItemRow.vala
+++ b/src/Widgets/ItemRow.vala
@@ -1028,7 +1028,7 @@ public class Widgets.ItemRow : Gtk.ListBoxRow {
     }
 
     private void check_preview_box () {
-        if (bottom_revealer.reveal_child == false) {
+        if (null != bottom_revealer && bottom_revealer.reveal_child == false) {
             preview_revealer.reveal_child = duedate_preview_revealer.reveal_child ||
             note_preview_revealer.reveal_child ||
             checklist_preview_revealer.reveal_child ||

--- a/src/Widgets/New.vala
+++ b/src/Widgets/New.vala
@@ -523,7 +523,6 @@ public class Widgets.New : Gtk.Revealer {
         action_bar.pack_start (cancel_button);
 
         var box = new Gtk.Box (Gtk.Orientation.VERTICAL, 0);
-        box.add (project_button);
         box.pack_start (project_button, false, false, 0);
         box.pack_start (area_button, false, false, 0);
         box.pack_end (action_bar, false, false, 0);

--- a/src/Widgets/Pane.vala
+++ b/src/Widgets/Pane.vala
@@ -188,7 +188,7 @@ public class Widgets.Pane : Gtk.EventBox {
         listbox_grid.add (area_listbox);
 
         var listbox_scrolled = new Gtk.ScrolledWindow (null, null);
-        listbox_scrolled.width_request = 252;
+        listbox_scrolled.width_request = 238;
         listbox_scrolled.hexpand = true;
         listbox_scrolled.margin_bottom = 6;
         listbox_scrolled.add (listbox_grid);


### PR DESCRIPTION
I wanted to get rid of Gtk-Critical warnings in the log. This are three small changes that make the log in while development much more readable.