### PR TITLE
Hide all details (collapse all)

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -246,9 +246,9 @@ public class Planner : Gtk.Application {
         //  }
 
         //  if (version) {
-		//  	print ("Test 0.1\n");
-		//  	return 0;
-		//  }
+        //      print ("Test 0.1\n");
+        //      return 0;
+        //  }
 
         return app.run (args);
     }

--- a/src/Views/Completed.vala
+++ b/src/Views/Completed.vala
@@ -36,6 +36,13 @@ public class Views.Completed : Gtk.EventBox {
         title_label.get_style_context ().add_class ("title-label");
         title_label.use_markup = true;
 
+        var hidden_button = new Gtk.Button.from_icon_name ("view-restore-symbolic", Gtk.IconSize.MENU);
+        hidden_button.can_focus = false;
+        hidden_button.margin_top = 1;
+        hidden_button.margin_end = 3;
+        hidden_button.tooltip_text = _("Hide Details");
+        hidden_button.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
+
         var top_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 6);
         top_box.hexpand = true;
         top_box.valign = Gtk.Align.START;
@@ -46,6 +53,7 @@ public class Views.Completed : Gtk.EventBox {
 
         top_box.pack_start (icon_image, false, false, 0);
         top_box.pack_start (title_label, false, false, 0);
+        top_box.pack_start (hidden_button, false, false, 0);
 
         listbox = new Gtk.ListBox ();
         listbox.margin_bottom = 32;
@@ -87,6 +95,13 @@ public class Views.Completed : Gtk.EventBox {
 
         add (main_box);
         show_all ();
+
+        hidden_button.clicked.connect (() => {
+            listbox.foreach ((widget) => {
+                var listBoxRow = (Widgets.ItemRow)widget;
+                if (listBoxRow.reveal_child) listBoxRow.hide_item();
+            });
+        });
     }
 
     public void add_all_items () {

--- a/src/Views/Completed.vala
+++ b/src/Views/Completed.vala
@@ -98,8 +98,8 @@ public class Views.Completed : Gtk.EventBox {
 
         hidden_button.clicked.connect (() => {
             listbox.foreach ((widget) => {
-                var listBoxRow = (Widgets.ItemRow)widget;
-                if (listBoxRow.reveal_child) listBoxRow.hide_item();
+                var list_box_row = (Widgets.ItemRow)widget;
+                if (list_box_row.reveal_child) list_box_row.hide_item ();
             });
         });
     }

--- a/src/Views/Inbox.vala
+++ b/src/Views/Inbox.vala
@@ -129,6 +129,13 @@ public class Views.Inbox : Gtk.EventBox {
         settings_button.image = settings_image;
         settings_button.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
 
+        var hidden_button = new Gtk.Button.from_icon_name ("view-restore-symbolic", Gtk.IconSize.MENU);
+        hidden_button.can_focus = false;
+        hidden_button.margin_top = 1;
+        hidden_button.margin_end = 3;
+        hidden_button.tooltip_text = _("Hide Details");
+        hidden_button.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
+
         top_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 6);
         top_box.hexpand = true;
         top_box.valign = Gtk.Align.START;
@@ -138,6 +145,7 @@ public class Views.Inbox : Gtk.EventBox {
 
         top_box.pack_start (icon_image, false, false, 0);
         top_box.pack_start (title_label, false, false, 0);
+        top_box.pack_start (hidden_button, false, false, 0);
         top_box.pack_end (settings_button, false, false, 0);
         // top_box.pack_end (search_button, false, false, 0);
         if (project.is_todoist == 1) {
@@ -608,6 +616,13 @@ public class Views.Inbox : Gtk.EventBox {
             if (row.item.project_id == project.id && section_id == 0) {
                 item_row_removed (row);
             }
+        });
+
+        hidden_button.clicked.connect (() => {
+            listbox.foreach ((widget) => {
+                var listBoxRow = (Widgets.ItemRow)widget;
+                if (listBoxRow.reveal_child) listBoxRow.hide_item();
+            });
         });
     }
 

--- a/src/Views/Inbox.vala
+++ b/src/Views/Inbox.vala
@@ -620,8 +620,8 @@ public class Views.Inbox : Gtk.EventBox {
 
         hidden_button.clicked.connect (() => {
             listbox.foreach ((widget) => {
-                var listBoxRow = (Widgets.ItemRow)widget;
-                if (listBoxRow.reveal_child) listBoxRow.hide_item();
+                var list_box_row = (Widgets.ItemRow)widget;
+                if (list_box_row.reveal_child) list_box_row.hide_item ();
             });
         });
     }

--- a/src/Views/Label.vala
+++ b/src/Views/Label.vala
@@ -37,6 +37,13 @@ public class Views.Label : Gtk.EventBox {
         title_label.get_style_context ().add_class ("title-label");
         title_label.use_markup = true;
 
+        var hidden_button = new Gtk.Button.from_icon_name ("view-restore-symbolic", Gtk.IconSize.MENU);
+        hidden_button.can_focus = false;
+        hidden_button.margin_top = 1;
+        hidden_button.margin_end = 3;
+        hidden_button.tooltip_text = _("Hide Details");
+        hidden_button.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
+
         var top_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 6);
         top_box.hexpand = true;
         top_box.valign = Gtk.Align.START;
@@ -47,6 +54,7 @@ public class Views.Label : Gtk.EventBox {
 
         top_box.pack_start (icon_image, false, false, 0);
         top_box.pack_start (title_label, false, false, 0);
+        top_box.pack_start (hidden_button, false, false, 0);
 
         listbox = new Gtk.ListBox ();
         listbox.expand = true;
@@ -136,6 +144,13 @@ public class Views.Label : Gtk.EventBox {
                     view_stack.visible_child_name = "placeholder";
                 }
             }
+        });
+
+        hidden_button.clicked.connect (() => {
+            listbox.foreach ((widget) => {
+                var listBoxRow = (Widgets.ItemRow)widget;
+                if (listBoxRow.reveal_child) listBoxRow.hide_item();
+            });
         });
     }
 }

--- a/src/Views/Label.vala
+++ b/src/Views/Label.vala
@@ -148,8 +148,8 @@ public class Views.Label : Gtk.EventBox {
 
         hidden_button.clicked.connect (() => {
             listbox.foreach ((widget) => {
-                var listBoxRow = (Widgets.ItemRow)widget;
-                if (listBoxRow.reveal_child) listBoxRow.hide_item();
+                var list_box_row = (Widgets.ItemRow)widget;
+                if (list_box_row.reveal_child) list_box_row.hide_item ();
             });
         });
     }

--- a/src/Views/Priority.vala
+++ b/src/Views/Priority.vala
@@ -35,6 +35,13 @@ public class Views.Priority : Gtk.EventBox {
         title_label.get_style_context ().add_class ("title-label");
         title_label.use_markup = true;
 
+        var hidden_button = new Gtk.Button.from_icon_name ("view-restore-symbolic", Gtk.IconSize.MENU);
+        hidden_button.can_focus = false;
+        hidden_button.margin_top = 1;
+        hidden_button.margin_end = 3;
+        hidden_button.tooltip_text = _("Hide Details");
+        hidden_button.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
+
         var top_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 6);
         top_box.hexpand = true;
         top_box.valign = Gtk.Align.START;
@@ -45,6 +52,7 @@ public class Views.Priority : Gtk.EventBox {
 
         top_box.pack_start (icon_image, false, false, 0);
         top_box.pack_start (title_label, false, false, 0);
+        top_box.pack_start (hidden_button, false, false, 0);
 
         listbox = new Gtk.ListBox ();
         listbox.expand = true;
@@ -153,6 +161,13 @@ public class Views.Priority : Gtk.EventBox {
                 }
 
                 return false;
+            });
+        });
+
+        hidden_button.clicked.connect (() => {
+            listbox.foreach ((widget) => {
+                var listBoxRow = (Widgets.ItemRow)widget;
+                if (listBoxRow.reveal_child) listBoxRow.hide_item();
             });
         });
     }

--- a/src/Views/Priority.vala
+++ b/src/Views/Priority.vala
@@ -166,8 +166,8 @@ public class Views.Priority : Gtk.EventBox {
 
         hidden_button.clicked.connect (() => {
             listbox.foreach ((widget) => {
-                var listBoxRow = (Widgets.ItemRow)widget;
-                if (listBoxRow.reveal_child) listBoxRow.hide_item();
+                var list_box_row = (Widgets.ItemRow)widget;
+                if (list_box_row.reveal_child) list_box_row.hide_item ();
             });
         });
     }

--- a/src/Views/Project.vala
+++ b/src/Views/Project.vala
@@ -89,13 +89,14 @@ public class Views.Project : Gtk.EventBox {
 
         name_label = new Gtk.Label (project.name);
         name_label.halign = Gtk.Align.START;
+        name_label.hexpand = false;
         name_label.get_style_context ().add_class ("title-label");
         name_label.get_style_context ().add_class ("font-bold");
 
         var name_eventbox = new Gtk.EventBox ();
         name_eventbox.valign = Gtk.Align.START;
         name_eventbox.add_events (Gdk.EventMask.ENTER_NOTIFY_MASK | Gdk.EventMask.LEAVE_NOTIFY_MASK);
-        name_eventbox.hexpand = true;
+        name_eventbox.hexpand = false;
         name_eventbox.add (name_label);
 
         name_entry = new Widgets.Entry ();
@@ -104,13 +105,20 @@ public class Views.Project : Gtk.EventBox {
         name_entry.get_style_context ().add_class ("flat");
         name_entry.get_style_context ().add_class ("title-label");
         name_entry.get_style_context ().add_class ("project-name-entry");
-        name_entry.hexpand = true;
+        name_entry.hexpand = false;
 
         name_stack = new Gtk.Stack ();
         name_stack.transition_type = Gtk.StackTransitionType.CROSSFADE;
 
         name_stack.add_named (name_eventbox, "name_label");
         name_stack.add_named (name_entry, "name_entry");
+
+        var hidden_button = new Gtk.Button.from_icon_name ("view-restore-symbolic", Gtk.IconSize.MENU);
+        hidden_button.can_focus = false;
+        hidden_button.margin_top = 1;
+        hidden_button.margin_end = 3;
+        hidden_button.tooltip_text = _("Hide Details");
+        hidden_button.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
 
         var project_progress = new Widgets.ProjectProgress (9);
         project_progress.margin = 2;
@@ -235,6 +243,7 @@ public class Views.Project : Gtk.EventBox {
         action_revealer.add (action_grid);
 
         top_box.pack_start (name_stack, false, true, 0);
+        top_box.pack_start (hidden_button, false, false, 0);
         top_box.pack_end (settings_button, false, false, 0);
         // top_box.pack_end (search_button, false, false, 0);
         if (project.is_todoist == 1) {
@@ -888,6 +897,13 @@ public class Views.Project : Gtk.EventBox {
                     completed_revealer.reveal_child = false;
                 }
             }
+        });
+
+        hidden_button.clicked.connect (() => {
+            listbox.foreach ((widget) => {
+                var listBoxRow = (Widgets.ItemRow)widget;
+                if (listBoxRow.reveal_child) listBoxRow.hide_item();
+            });
         });
     }
 

--- a/src/Views/Project.vala
+++ b/src/Views/Project.vala
@@ -901,8 +901,8 @@ public class Views.Project : Gtk.EventBox {
 
         hidden_button.clicked.connect (() => {
             listbox.foreach ((widget) => {
-                var listBoxRow = (Widgets.ItemRow)widget;
-                if (listBoxRow.reveal_child) listBoxRow.hide_item();
+                var list_box_row = (Widgets.ItemRow)widget;
+                if (list_box_row.reveal_child) list_box_row.hide_item ();
             });
         });
     }

--- a/src/Views/Today.vala
+++ b/src/Views/Today.vala
@@ -75,6 +75,13 @@ public class Views.Today : Gtk.EventBox {
         date_label.use_markup = true;
         update_today_label ();
 
+        var hidden_button = new Gtk.Button.from_icon_name ("view-restore-symbolic", Gtk.IconSize.MENU);
+        hidden_button.can_focus = false;
+        hidden_button.margin_top = 1;
+        hidden_button.margin_end = 3;
+        hidden_button.tooltip_text = _("Hide Details");
+        hidden_button.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
+
         var settings_image = new Gtk.Image ();
         settings_image.gicon = new ThemedIcon ("view-more-symbolic");
         settings_image.pixel_size = 14;
@@ -97,6 +104,7 @@ public class Views.Today : Gtk.EventBox {
         top_box.pack_start (icon_image, false, false, 0);
         top_box.pack_start (title_label, false, false, 0);
         top_box.pack_start (date_label, false, false, 0);
+        top_box.pack_start (hidden_button, false, false, 0);
         top_box.pack_end (settings_button, false, false, 0);
 
         listbox = new Gtk.ListBox ();
@@ -443,6 +451,13 @@ public class Views.Today : Gtk.EventBox {
 
                 popover.show_all ();
             }
+        });
+
+        hidden_button.clicked.connect (() => {
+            listbox.foreach ((widget) => {
+                var listBoxRow = (Widgets.ItemRow)widget;
+                if (listBoxRow.reveal_child) listBoxRow.hide_item();
+            });
         });
     }
 

--- a/src/Views/Today.vala
+++ b/src/Views/Today.vala
@@ -455,8 +455,8 @@ public class Views.Today : Gtk.EventBox {
 
         hidden_button.clicked.connect (() => {
             listbox.foreach ((widget) => {
-                var listBoxRow = (Widgets.ItemRow)widget;
-                if (listBoxRow.reveal_child) listBoxRow.hide_item();
+                var list_box_row = (Widgets.ItemRow)widget;
+                if (list_box_row.reveal_child) list_box_row.hide_item ();
             });
         });
     }

--- a/src/Views/Upcoming.vala
+++ b/src/Views/Upcoming.vala
@@ -127,10 +127,10 @@ public class Views.Upcoming : Gtk.EventBox {
 
         hidden_button.clicked.connect (() => {
             listbox.foreach ((widget) => {
-                var listBoxRow = (Widgets.UpcomingRow)widget;
+                //var list_box_row = (Widgets.UpcomingRow)widget;
                 //listBoxRow.hide_item();
                 //if (listBoxRow.reveal_child) listBoxRow.hide_item();
-                ((Widgets.UpcomingRow)widget).hide_items();
+                ((Widgets.UpcomingRow)widget).hide_items ();
             });
         });
     }

--- a/src/Views/Upcoming.vala
+++ b/src/Views/Upcoming.vala
@@ -37,6 +37,13 @@ public class Views.Upcoming : Gtk.EventBox {
         title_label.get_style_context ().add_class ("title-label");
         title_label.use_markup = true;
 
+        var hidden_button = new Gtk.Button.from_icon_name ("view-restore-symbolic", Gtk.IconSize.MENU);
+        hidden_button.can_focus = false;
+        hidden_button.margin_top = 1;
+        hidden_button.margin_end = 3;
+        hidden_button.tooltip_text = _("Hide Details");
+        hidden_button.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
+
         var top_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 6);
         top_box.hexpand = true;
         top_box.valign = Gtk.Align.START;
@@ -47,6 +54,7 @@ public class Views.Upcoming : Gtk.EventBox {
 
         top_box.pack_start (icon_image, false, false, 0);
         top_box.pack_start (title_label, false, false, 0);
+        top_box.pack_start (hidden_button, false, false, 0);
 
         listbox = new Gtk.ListBox ();
         listbox.get_style_context ().add_class ("listbox");
@@ -115,6 +123,15 @@ public class Views.Upcoming : Gtk.EventBox {
             date = new GLib.DateTime.now_local ();
 
             add_upcomings ();
+        });
+
+        hidden_button.clicked.connect (() => {
+            listbox.foreach ((widget) => {
+                var listBoxRow = (Widgets.UpcomingRow)widget;
+                //listBoxRow.hide_item();
+                //if (listBoxRow.reveal_child) listBoxRow.hide_item();
+                ((Widgets.UpcomingRow)widget).hide_items();
+            });
         });
     }
 

--- a/src/Widgets/UpcomingRow.vala
+++ b/src/Widgets/UpcomingRow.vala
@@ -497,4 +497,11 @@ public class Widgets.UpcomingRow : Gtk.ListBoxRow {
             listbox.show_all ();
         }
     }
+
+    public void hide_items () {
+        listbox.foreach ((widget) => {
+            var listBoxRow = (Widgets.ItemRow)widget;
+            if (listBoxRow.reveal_child) listBoxRow.hide_item();
+        });
+    }
 }

--- a/src/Widgets/UpcomingRow.vala
+++ b/src/Widgets/UpcomingRow.vala
@@ -500,8 +500,8 @@ public class Widgets.UpcomingRow : Gtk.ListBoxRow {
 
     public void hide_items () {
         listbox.foreach ((widget) => {
-            var listBoxRow = (Widgets.ItemRow)widget;
-            if (listBoxRow.reveal_child) listBoxRow.hide_item();
+            var list_box_row = (Widgets.ItemRow)widget;
+            if (list_box_row.reveal_child) list_box_row.hide_item ();
         });
     }
 }


### PR DESCRIPTION
This pull request corresponds to my feature request #532. I implemented a button that collapses all the tasks in a view. I placed it after the name and other parameters at the left of the header.

![image](https://user-images.githubusercontent.com/54047840/94376708-e6596200-0124-11eb-8bac-f26543e20a53.png)

I will be implementing  shortcut key too, just needed this for every day, so I was in a hurry.

Button placed on each view that collapses all tasks

Signed-off-by: Alexios Tsiaparas <alexios@watergate.gr>

Hope you accept it