### PR TITLE
Add "Fun Time" theme

### DIFF
--- a/data/com.github.alainm23.planner.gschema.xml
+++ b/data/com.github.alainm23.planner.gschema.xml
@@ -23,6 +23,7 @@
         <value nick="Black" value="1" />
         <value nick="Dark Blue" value="2" />
         <value nick="Arc Dark" value="3" />
+        <value nick="Fun Time" value="4" />
     </enum>
 
     <enum id="com.github.alainm23.planner.default-priority">

--- a/src/Dialogs/Preferences/Preferences.vala
+++ b/src/Dialogs/Preferences/Preferences.vala
@@ -548,6 +548,9 @@ public class Dialogs.Preferences.Preferences : Gtk.Dialog {
         var arc_dark_radio = new Gtk.RadioButton.with_label_from_widget (light_radio, _("Arc Dark"));
         arc_dark_radio.get_style_context ().add_class ("preference-item-radio");
 
+        var fun_time_radio = new Gtk.RadioButton.with_label_from_widget (light_radio, _("Fun Time"));
+        fun_time_radio.get_style_context ().add_class ("preference-item-radio");
+
         var font_size_scale = new Gtk.Scale.with_range (Gtk.Orientation.HORIZONTAL, 0.5, 2, 0.1);
         font_size_scale.hexpand = true;
         font_size_scale.set_value (Planner.settings.get_double ("font-scale"));
@@ -605,6 +608,7 @@ public class Dialogs.Preferences.Preferences : Gtk.Dialog {
         main_box.pack_start (night_radio, false, false, 0);
         main_box.pack_start (dark_blue_radio, false, false, 0);
         main_box.pack_start (arc_dark_radio, false, false, 0);
+        main_box.pack_start (fun_time_radio, false, false, 0);
         main_box.pack_start (new Gtk.Separator (Gtk.Orientation.HORIZONTAL), false, true, 0);
         main_box.pack_start (new Granite.HeaderLabel (_("Font Size")) {
             margin_start = 12,
@@ -623,7 +627,9 @@ public class Dialogs.Preferences.Preferences : Gtk.Dialog {
             dark_blue_radio.active = true;
         } else if (Planner.settings.get_enum ("appearance") == 3) {
             arc_dark_radio.active = true;
-        }   
+        } else if (Planner.settings.get_enum ("appearance") == 4) {
+            fun_time_radio.active = true;
+        }
 
         info_box.back_activated.connect (() => {
             stack.visible_child_name = "home";
@@ -643,6 +649,10 @@ public class Dialogs.Preferences.Preferences : Gtk.Dialog {
 
         arc_dark_radio.toggled.connect (() => {
             Planner.settings.set_enum ("appearance", 3);
+        });
+
+        fun_time_radio.toggled.connect (() => {
+            Planner.settings.set_enum ("appearance", 4);
         });
 
         font_size_scale.value_changed.connect (() => {

--- a/src/QuickAdd/Application.vala
+++ b/src/QuickAdd/Application.vala
@@ -225,6 +225,9 @@ public class PlannerQuickAdd : Gtk.Application {
         } else if (appearance_mode == 3) {
             base_color = "#353945";
             Gtk.Settings.get_default ().gtk_application_prefer_dark_theme = true;
+        } else if (appearance_mode == 4) {
+            base_color = "#fff9e0";
+            Gtk.Settings.get_default ().gtk_application_prefer_dark_theme = false;
         }
 
         // CSS provider

--- a/src/Utils.vala
+++ b/src/Utils.vala
@@ -802,7 +802,7 @@ public class Utils : GLib.Object {
                 check_border_color = "@border_color";
                 projectview_color = "#ffebfe";
                 pane_color = "#fbfcb6";
-                pane_selected_color = "shade (@bg_color, 0.95)";
+                pane_selected_color = "shade (@bg_color, 0.92)";
                 pane_text_color = "#222222";
                 popover_background = "#defaf2";
                 row_selected_color = "shade (@check_border_color, 0.75)";

--- a/src/Utils.vala
+++ b/src/Utils.vala
@@ -797,6 +797,18 @@ public class Utils : GLib.Object {
                 upcoming_color = "#a970ff";
 
                 Gtk.Settings.get_default ().gtk_application_prefer_dark_theme = true;
+            } else if (appearance_mode == 4) {
+                base_color = "#fff9e0";
+                check_border_color = "@border_color";
+                projectview_color = "#ffebfe";
+                pane_color = "#fbfcb6";
+                pane_selected_color = "shade (@bg_color, 0.95)";
+                pane_text_color = "#222222";
+                popover_background = "#defaf2";
+                row_selected_color = "shade (@check_border_color, 0.75)";
+                upcoming_color = "#692fc2";
+
+                Gtk.Settings.get_default ().gtk_application_prefer_dark_theme = false;
             }
 
             var css = _css.printf (


### PR DESCRIPTION
A colorful and fun theme to enhance user options.
There is a bug that should be reviewed: icons are white and not visible.
I didn't found where to configure this (to use the same icons as light theme),
although set _gtk_application_prefer_dark_theme_ to _false_.