### PR TITLE
Add option to use system title bar

### DIFF
--- a/data/com.github.alainm23.planner.gschema.xml
+++ b/data/com.github.alainm23.planner.gschema.xml
@@ -80,6 +80,12 @@
             <description>Order the buttons on the title bar</description>
         </key>
 
+        <key name="use-system-decoration" type="b">
+            <default>false</default>
+            <summary>Whether application windows should not use custom title bar</summary>
+            <description>Whether application windows should not use custom title bar</description>
+        </key>
+
         <key name="default-priority" enum="com.github.alainm23.planner.default-priority">
             <default>"None"</default>
             <summary>Order the buttons on the title bar</summary>

--- a/src/Dialogs/Preferences/ItemSelect.vala
+++ b/src/Dialogs/Preferences/ItemSelect.vala
@@ -20,14 +20,17 @@
 */
 
 public class Dialogs.Preferences.ItemSelect : Gtk.EventBox {
+    private Gtk.ComboBoxText combobox;
+
     public signal void activated (int active);
 
     public ItemSelect (string title, int active, List<string> items, bool visible_separator=true) {
         var title_label = new Gtk.Label (title);
         title_label.get_style_context ().add_class ("font-weight-600");
 
-        var combobox = new Gtk.ComboBoxText ();
+        combobox = new Gtk.ComboBoxText ();
         combobox.can_focus = false;
+        combobox.sensitive = false;
         combobox.valign = Gtk.Align.CENTER;
 
         foreach (var item in items) {
@@ -60,5 +63,9 @@ public class Dialogs.Preferences.ItemSelect : Gtk.EventBox {
         });
 
         add (main_box);
+    }
+
+    public void set_combobox_sensitive (bool sensitive) {
+        combobox.set_sensitive (sensitive);
     }
 }

--- a/src/Dialogs/Preferences/Preferences.vala
+++ b/src/Dialogs/Preferences/Preferences.vala
@@ -597,12 +597,23 @@ public class Dialogs.Preferences.Preferences : Gtk.Dialog {
         list.append ("Close Only Left");
         list.append ("Close Only Right");
 
+        var use_system_decoration_val = Planner.settings.get_boolean ("use-system-decoration");
         var button_layout = new Dialogs.Preferences.ItemSelect (
             _("Button layout"),
             Planner.settings.get_enum ("button-layout"),
             list
         );
+        button_layout.set_combobox_sensitive (!use_system_decoration_val);
         button_layout.margin_top = 12;
+
+        var use_system_decoration = new Dialogs.Preferences.ItemSwitch (
+            // The reason we need a restart is because GTK has to tell the
+            // window manager whether to add any window decorations *before*
+            // the window is realized.
+            _("Use system window decoration (needs restart)"),
+            use_system_decoration_val
+        );
+        use_system_decoration.margin_top = 12;
        
         var main_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 0);
         main_box.valign = Gtk.Align.START;
@@ -626,6 +637,8 @@ public class Dialogs.Preferences.Preferences : Gtk.Dialog {
         main_box.pack_start (font_size_grid);
         main_box.pack_start (new Gtk.Separator (Gtk.Orientation.HORIZONTAL), false, true, 0);
         main_box.pack_start (button_layout);
+        main_box.pack_start (new Gtk.Separator (Gtk.Orientation.HORIZONTAL), false, true, 0);
+        main_box.pack_start (use_system_decoration);
 
         if (Planner.settings.get_enum ("appearance") == 0) {
             light_radio.active = true;
@@ -663,6 +676,11 @@ public class Dialogs.Preferences.Preferences : Gtk.Dialog {
 
         button_layout.activated.connect ((index) => {
             Planner.settings.set_enum ("button-layout", index);
+        });
+
+        use_system_decoration.activated.connect ((value) => {
+            Planner.settings.set_boolean ("use-system-decoration", value);
+            button_layout.set_combobox_sensitive (!value);
         });
 
         return main_box;

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -150,8 +150,10 @@ public class MainWindow : Gtk.Window {
         paned.wide_handle = true;
         paned.pack1 (pane, false, false);
         paned.pack2 (projectview_overlay, true, false);
-        
-        set_titlebar (header_paned);
+
+        if (!Planner.settings.get_boolean ("use-system-decoration")) {
+            set_titlebar (header_paned);
+        }
         add (paned);
 
         // This must come after setting header_paned as the titlebar


### PR DESCRIPTION
This PR adds the setting 'use-system-decoration', which will
disable the custom title bar that is used by default.

To enable/disable the `window-buttons` field in the preferences dialog, I had to add a method `set_combobox_sensitive`, which is used to mark the combobox as sensitive (i.e. enable/disable editing).

I could not find how to run the linter. I did my best to follow the style that was used; pardon me if there I missed something.

Fixes #406