### PR TITLE
Added libhandy-1-0 to dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ You'll need the following dependencies:
 * libedataserver1.2-dev
 * libpeas-dev
 * libical-dev
+* libhandy-1-0
 * meson
 * valac >= 0.40.3
 


### PR DESCRIPTION
This pull request fixes the fact that the dependency `libhandy = dependency ('libhandy-1', version: '>=0.90.0')` is currently not reflected in the list of dependencies in the README.md. 