### PR TITLE
Fix build with vala 0.56

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -42,7 +42,7 @@ public class Planner : Gtk.Application {
     private static bool clear_database = false;
     private static string lang = "";
 
-    public const OptionEntry[] PLANNER_OPTIONS = {
+    private const OptionEntry[] PLANNER_OPTIONS = {
         { "version", 'v', 0, OptionArg.NONE, ref version,
         "Display version number", null },
         { "reset", 'r', 0, OptionArg.NONE, ref clear_database,


### PR DESCRIPTION
Otherwise build fails with

```
../src/Application.vala:45.50-55.5: error: value is less accessible than constant `Planner.PLANNER_OPTIONS'
   45 |     public const OptionEntry[] PLANNER_OPTIONS = {
      |                                                  ^
   46 |         { "version", 'v', 0, OptionArg.NONE, ref version,
      | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   47 |         "Display version number", null },
      | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   48 |         { "reset", 'r', 0, OptionArg.NONE, ref clear_database,
      | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   49 |         "Reset Planner", null },
      | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   50 |         { "silent", 's', 0, OptionArg.NONE, out silent,
      | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   51 |         "Run the Application in background", null },
      | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   52 |         { "lang", 'l', 0, OptionArg.STRING, ref lang,
      | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   53 |         "Open Planner in a specific language", "LANG" },
      | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   54 |         { null }
      | ~~~~~~~~~~~~~~~~
   55 |     };
      | ~~~~~ 
Compilation failed: 1 error(s), 1 warning(s)
ninja: build stopped: subcommand failed.
```

See also: https://github.com/elementary/mail/pull/765