### PR TITLE
Fixed spelling error in PriorityButton

### DIFF
--- a/po/com.github.alainm23.planner.pot
+++ b/po/com.github.alainm23.planner.pot
@@ -461,7 +461,7 @@ msgid ""
 msgstr ""
 
 #: src/Widgets/PriorityButton.vala:46
-msgid "Priority 1: hight"
+msgid "Priority 1: high"
 msgstr ""
 
 #: src/Widgets/PriorityButton.vala:47

--- a/po/es.po
+++ b/po/es.po
@@ -461,7 +461,7 @@ msgid ""
 msgstr ""
 
 #: src/Widgets/PriorityButton.vala:46
-msgid "Priority 1: hight"
+msgid "Priority 1: high"
 msgstr ""
 
 #: src/Widgets/PriorityButton.vala:47


### PR DESCRIPTION
When choosing priority for a task, the Priority 1 option read "hight" instead of "high". This commit fixes that.

Thank you for this incredible project, I use it daily!