### PR TITLE
build: Use gtk4-update-icon-cache

### DIFF
--- a/build-aux/meson/post_install.py
+++ b/build-aux/meson/post_install.py
@@ -9,5 +9,5 @@ datadir = os.path.join(prefix, 'share')
 # Packaging tools define DESTDIR and this isn't needed for them
 if 'DESTDIR' not in os.environ:
     print('Updating package icon cache...')
-    subprocess.call(['gtk-update-icon-cache', '-qtf',
+    subprocess.call(['gtk4-update-icon-cache', '-qtf',
                      os.path.join(datadir, 'gnome-builder', 'icons', 'hicolor')])


### PR DESCRIPTION
Otherwise the post install script fails if gtk3 is not installed, which can happen in builder sandbox.