### PR TITLE
docs: fix typos

### DIFF
--- a/quick-add/Services/Database.vala
+++ b/quick-add/Services/Database.vala
@@ -311,7 +311,7 @@ public class Services.Database : GLib.Object {
         stmt.reset ();
     }
 
-    // PARAMENTER REGION
+    // PARAMETER REGION
     private void set_parameter_int (Sqlite.Statement? stmt, string par, int val) {
         int par_position = stmt.bind_parameter_index (par);
         stmt.bind_int (par_position, val);

--- a/src/Enum.vala
+++ b/src/Enum.vala
@@ -144,7 +144,7 @@ public enum ObjectType {
                 return _("Projects");
 
             case SECTION:
-                return _("Setions");
+                return _("Sections");
 
             case ITEM:
                 return _("Tasks");

--- a/src/Services/Database.vala
+++ b/src/Services/Database.vala
@@ -1942,7 +1942,7 @@ public class Services.Database : GLib.Object {
         stmt.reset ();
     }
 
-    // PARAMENTER REGION
+    // PARAMETER REGION
     private void set_parameter_int (Sqlite.Statement? stmt, string par, int val) {
         int par_position = stmt.bind_parameter_index (par);
         stmt.bind_int (par_position, val);

--- a/src/Widgets/CircularProgressBar.vala
+++ b/src/Widgets/CircularProgressBar.vala
@@ -249,7 +249,7 @@ public class _CircularProgressBar : Gtk.DrawingArea {
         //  var context = get_style_context ();
         //  context.save ();
         //  // FIXME: Gtk4 has changes in the styles that need to be reviewed
-        //  // For now we get the text color from the defaut context.
+        //  // For now we get the text color from the default context.
         //  color = context.get_color ();
         //  Gdk.cairo_set_source_rgba (cr, color);
 


### PR DESCRIPTION
Found via `codespell -S po,data -L childs,bu`