### PR TITLE
Fix some criticals, warnings and deprecations

### DIFF
--- a/build-aux/io.github.alainm23.planify.Devel.json
+++ b/build-aux/io.github.alainm23.planify.Devel.json
@@ -4,6 +4,9 @@
     "runtime-version": "44",
     "sdk" : "org.gnome.Sdk",
     "command" : "io.github.alainm23.planify",
+    "sdk-extensions" : [
+        "org.freedesktop.Sdk.Extension.vala"
+    ],
     "tags" : [
         "devel"
     ],
@@ -20,9 +23,11 @@
         "--own-name=io.github.alainm23.planify.quick-add",
         "--own-name=io.github.alainm23.planify"
     ],
-    "x-run-args" : [
-        "--debug"
-    ],
+    "build-options" : {
+        "prepend-path" : "/usr/lib/sdk/vala/bin/",
+        "prepend-ld-library-path" : "/usr/lib/sdk/vala/lib",
+        "env" : {        }
+    },
     "cleanup" : [
         "/include",
         "/lib/pkgconfig",

--- a/build-aux/io.github.alainm23.planify.json
+++ b/build-aux/io.github.alainm23.planify.json
@@ -4,6 +4,9 @@
     "runtime-version": "44",
     "sdk": "org.gnome.Sdk",
     "command": "io.github.alainm23.planify",
+    "sdk-extensions" : [
+        "org.freedesktop.Sdk.Extension.vala"
+    ],
     "finish-args": [
         "--device=dri",
         "--share=ipc",
@@ -13,6 +16,11 @@
         "--talk-name=org.gnome.evolution.dataserver.Calendar8",
         "--talk-name=org.gnome.evolution.dataserver.Sources5"
     ],
+    "build-options" : {
+        "prepend-path" : "/usr/lib/sdk/vala/bin/",
+        "prepend-ld-library-path" : "/usr/lib/sdk/vala/lib",
+        "env" : {        }
+    },
     "cleanup": [
         "/include",
         "/lib/pkgconfig",

--- a/data/resources/ui/shortcuts.ui
+++ b/data/resources/ui/shortcuts.ui
@@ -64,7 +64,7 @@
 
             <child>
               <object class="GtkShortcutsShortcut" id="open-preferences">
-                <property name="accelerator">&lt;ctrl&gt;.</property>
+                <property name="accelerator">&lt;ctrl&gt;comma</property>
                 <property name="title" translatable="yes" context="shortcut window">Open preferences</property>
               </object>
             </child>

--- a/src/Dialogs/ManageSectionOrder.vala
+++ b/src/Dialogs/ManageSectionOrder.vala
@@ -96,8 +96,8 @@ public class Dialogs.ManageSectionOrder : Adw.Window {
     
     private void set_sort_func () {
         listbox.set_sort_func ((row1, row2) => {
-            Objects.Section item1 = ((Layouts.SectionRow) row1).section;
-            Objects.Section item2 = ((Layouts.SectionRow) row2).section;
+            Objects.Section item1 = ((Dialogs.ProjectPicker.SectionPickerRow) row1).section;
+            Objects.Section item2 = ((Dialogs.ProjectPicker.SectionPickerRow) row2).section;
 
             return item1.section_order - item2.section_order;
         });

--- a/src/Dialogs/Preferences/PreferencesWindow.vala
+++ b/src/Dialogs/Preferences/PreferencesWindow.vala
@@ -582,11 +582,11 @@ public class Dialogs.Preferences.PreferencesWindow : Adw.PreferencesWindow {
 		todoist_setting_revealer.child = todoist_setting_button;
 
 		var todoist_row = new Adw.ActionRow ();
-		todoist_row.icon_name = "planner-todoist";
 		todoist_row.title = _("Todoist");
 		todoist_row.subtitle = _("Synchronize with your Todoist Account");
 		todoist_row.add_suffix (todoist_setting_revealer);
 		todoist_row.add_suffix (todoist_switch);
+        todoist_row.add_prefix (new Gtk.Image.from_icon_name ("planner-todoist"));
 
 		// Google Tasks
 		var google_tasks_switch = new Gtk.Switch () {
@@ -614,11 +614,11 @@ public class Dialogs.Preferences.PreferencesWindow : Adw.PreferencesWindow {
 		google_tasks_revealer.child = google_tasks_button;
 
 		var google_row = new Adw.ActionRow ();
-		google_row.icon_name = "google";
 		google_row.title = _("Google Tasks");
 		google_row.subtitle = _("Synchronize with your Google Account");
 		google_row.add_suffix (google_tasks_revealer);
 		google_row.add_suffix (google_tasks_switch);
+        google_row.add_prefix (new Gtk.Image.from_icon_name ("google"));
 
 		var accounts_group = new Adw.PreferencesGroup ();
 		accounts_group.title = _("Accounts");

--- a/src/Dialogs/RepeatConfig.vala
+++ b/src/Dialogs/RepeatConfig.vala
@@ -21,7 +21,7 @@
 
 public class Dialogs.RepeatConfig : Adw.Window {
     private Gtk.SpinButton recurrency_interval;
-    private Gtk.ComboBoxText recurrency_combobox;
+    private Gtk.DropDown recurrency_combobox;
     private Gtk.Label repeat_label;
 
     private Gtk.CheckButton mo_button;
@@ -37,9 +37,9 @@ public class Dialogs.RepeatConfig : Adw.Window {
             recurrency_interval.value = value.recurrency_interval;
 
             if (value.recurrency_type == RecurrencyType.NONE) {
-                recurrency_combobox.active = 0;
+                recurrency_combobox.selected = 0;
             } else {
-                recurrency_combobox.active = (int) value.recurrency_type;
+                recurrency_combobox.selected = (int) value.recurrency_type;
             }
 
             if (value.recurrency_type == RecurrencyType.EVERY_WEEK) {
@@ -98,18 +98,17 @@ public class Dialogs.RepeatConfig : Adw.Window {
         };
         recurrency_interval.add_css_class ("popover-spinbutton");
 
-        recurrency_combobox = new Gtk.ComboBoxText () {
+        string[] items = {
+            _("Days(s)"), _("Week(s)"), _("Month(s)"), _("Year(s)")
+        };
+
+        recurrency_combobox = new Gtk.DropDown.from_strings (items) {
             hexpand = true,
             margin_top = 6,
             margin_end = 6,
             margin_bottom = 6
         };
-        
-        recurrency_combobox.append_text (_("Day(s)"));
-        recurrency_combobox.append_text (_("Week(s)"));
-        recurrency_combobox.append_text (_("Month(s)"));
-        recurrency_combobox.append_text (_("Year(s)"));
-        recurrency_combobox.active = 0;
+        recurrency_combobox.selected = 0;
 
         var repeat_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 6) {
             hexpand = true,
@@ -181,8 +180,8 @@ public class Dialogs.RepeatConfig : Adw.Window {
             update_repeat_label ();
         });
 
-        recurrency_combobox.changed.connect (() => {
-            if ((RecurrencyType) this.recurrency_combobox.get_active() == RecurrencyType.EVERY_WEEK) {
+        recurrency_combobox.notify["selected-item"].connect (() => {
+            if ((RecurrencyType) this.recurrency_combobox.selected == RecurrencyType.EVERY_WEEK) {
                 weeks_revealer.reveal_child = true;
             } else {
                 weeks_revealer.reveal_child = false;
@@ -228,7 +227,7 @@ public class Dialogs.RepeatConfig : Adw.Window {
     private void set_repeat () {
         var duedate = new Objects.DueDate ();
         duedate.is_recurring = true;
-        duedate.recurrency_type = (RecurrencyType) this.recurrency_combobox.get_active();
+        duedate.recurrency_type = (RecurrencyType) this.recurrency_combobox.selected;
         duedate.recurrency_interval = (int) recurrency_interval.value;
 
         if (duedate.recurrency_type == RecurrencyType.EVERY_WEEK) {
@@ -285,7 +284,7 @@ public class Dialogs.RepeatConfig : Adw.Window {
     }
 
     private void update_repeat_label () {
-        RecurrencyType selected_option = (RecurrencyType) this.recurrency_combobox.get_active();
+        RecurrencyType selected_option = (RecurrencyType) this.recurrency_combobox.selected;
         string label = Util.get_default ().get_recurrency_weeks (selected_option, (int)  recurrency_interval.value, get_recurrency_weeks ());
         repeat_label.label = label;
     }

--- a/src/Dialogs/TodoistOAuth.vala
+++ b/src/Dialogs/TodoistOAuth.vala
@@ -123,7 +123,7 @@ public class Dialogs.TodoistOAuth : Adw.Window {
             if (("https://github.com/alainm23/planner?code=" in redirect_uri) &&
                 ("&state=%s".printf (STATE) in redirect_uri)) {
                 info_label.label = _("Synchronizing. Wait a moment please.");
-                get_todoist_token (redirect_uri);
+                get_todoist_token.begin (redirect_uri);
             }
 
             if ("https://github.com/alainm23/planner?error=access_denied" in redirect_uri) {

--- a/src/Dialogs/WhatsNew.vala
+++ b/src/Dialogs/WhatsNew.vala
@@ -102,7 +102,7 @@ public class Dialogs.WhatsNew : Adw.Window {
 
 	public void add_feature (string title, string description, string icon) {
 		var row = new Adw.ActionRow ();
-		row.icon_name = icon;
+        row.add_prefix (new Gtk.Image.from_icon_name (icon));
 		row.title = title;
 		row.subtitle = description;
 

--- a/src/Layouts/HeaderItem.vala
+++ b/src/Layouts/HeaderItem.vala
@@ -269,12 +269,12 @@ public class Layouts.HeaderItem : Gtk.Grid {
         content_revealer.reveal_child = size > 0;
     }
 
-    public void set_sort_func (Gtk.ListBoxSortFunc? sort_func) {
-        listbox.set_sort_func (sort_func);
+    public void set_sort_func (owned Gtk.ListBoxSortFunc? sort_func) {
+        listbox.set_sort_func ((owned) sort_func);
     }
 
-    public void set_filter_func (Gtk.ListBoxFilterFunc? filter_func) {
-        listbox.set_filter_func (filter_func);
+    public void set_filter_func (owned Gtk.ListBoxFilterFunc? filter_func) {
+        listbox.set_filter_func ((owned) filter_func);
     }
 
     public void invalidate_filter () {

--- a/src/Layouts/LabelRow.vala
+++ b/src/Layouts/LabelRow.vala
@@ -57,8 +57,8 @@ public class Layouts.LabelRow : Gtk.ListBoxRow {
             halign = Gtk.Align.END
         };
 
-        count_label.get_style_context ().add_class ("dim-label");
-        count_label.get_style_context ().add_class (Granite.STYLE_CLASS_SMALL_LABEL);
+        count_label.add_css_class ("dim-label");
+        count_label.add_css_class (Granite.STYLE_CLASS_SMALL_LABEL);
 
         count_revealer = new Gtk.Revealer () {
             reveal_child = int.parse (count_label.label) > 0

--- a/src/Layouts/ProjectRow.vala
+++ b/src/Layouts/ProjectRow.vala
@@ -124,7 +124,10 @@ public class Layouts.ProjectRow : Gtk.ListBoxRow {
         arrow_button.add_css_class ("transparent");
         arrow_button.add_css_class ("hidden-button");
         arrow_button.add_css_class ("no-padding");
-        arrow_button.add_css_class (project.collapsed ? "opened" : "");
+
+        if (project.collapsed) {
+            arrow_button.add_css_class ("opened");
+        }
 
         menu_stack = new Gtk.Stack () {
             transition_type = Gtk.StackTransitionType.CROSSFADE,

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -270,7 +270,7 @@ public class MainWindow : Adw.ApplicationWindow {
 		}
 
 		sidebar.init();
-		labels_header.init ();
+		// labels_header.init ();
 
 		Services.Notification.get_default ();
 		Services.TimeMonitor.get_default ();

--- a/src/Services/CalendarEvents/Util.vala
+++ b/src/Services/CalendarEvents/Util.vala
@@ -59,14 +59,19 @@
          * fails for some reason.
          */
         const string LIBICAL_TZ_PREFIX = "/freeassociation.sourceforge.net/";
-        if (tzid.has_prefix (LIBICAL_TZ_PREFIX)) {
-            // TZID has prefix "/freeassociation.sourceforge.net/",
-            // indicating a libical TZID.
-            return new GLib.TimeZone (tzid.offset (LIBICAL_TZ_PREFIX.length));
-        } else {
+        try {
+            if (tzid.has_prefix (LIBICAL_TZ_PREFIX)) {
+                // TZID has prefix "/freeassociation.sourceforge.net/",
+                // indicating a libical TZID.
+                return new GLib.TimeZone.identifier (tzid.offset (LIBICAL_TZ_PREFIX.length));
+            }
             // TZID does not have libical prefix, potentially indicating an Olson
             // standard city name.
-            return new GLib.TimeZone (tzid);
+            return new GLib.TimeZone.identifier (tzid);
+        }
+        catch (Error e) {
+            debug ("Failed to parse Timezone: %s. Using UTC", e.message);
+            return new GLib.TimeZone.utc ();
         }
     }
 

--- a/src/Views/Date.vala
+++ b/src/Views/Date.vala
@@ -45,15 +45,15 @@ public class Views.Date : Gtk.Grid {
             margin_start = 26,
             margin_bottom = 6
         };
-        overdue_label.get_style_context ().add_class ("font-bold");
+        overdue_label.add_css_class ("font-bold");
         
         var reschedule_button = new Gtk.Button.with_label (_("Reschedule")) {
             can_focus = false,
             hexpand = true,
             halign = Gtk.Align.END
         };
-        reschedule_button.get_style_context ().add_class (Granite.STYLE_CLASS_FLAT);
-        reschedule_button.get_style_context ().add_class ("primary-color");
+        reschedule_button.add_css_class (Granite.STYLE_CLASS_FLAT);
+        reschedule_button.add_css_class ("primary-color");
         reschedule_button.clicked.connect (open_datetime_picker);
 
         var overdue_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0);

--- a/src/Views/Project.vala
+++ b/src/Views/Project.vala
@@ -224,7 +224,7 @@ public class Views.Project : Gtk.Grid {
 
 			Views.Board? board_view;
 			board_view = (Views.Board) view_stack.get_child_by_name ("board");
-			if (list_view != null) {
+			if (board_view != null) {
 				view_stack.remove (board_view);
 			}
 		} else if (view_style == ProjectViewStyle.BOARD) {

--- a/src/Widgets/Calendar/CalendarWeek.vala
+++ b/src/Widgets/Calendar/CalendarWeek.vala
@@ -62,13 +62,12 @@ public class Widgets.Calendar.CalendarWeek : Gtk.Box {
     }
 
     public void update () {
-        remove (label_sunday);
-        remove (label_monday);
-        remove (label_tuesday);
-        remove (label_wednesday);
-        remove (label_thursday);
-        remove (label_friday);
-        remove (label_saturday);
+        for (Gtk.Widget? child = get_first_child (); child != null;) {
+            Gtk.Widget? next = child.get_next_sibling ();
+            remove (child);
+
+            child = next;
+        }
 
         var start_week = Services.Settings.get_default ().settings.get_enum ("start-week");
         

--- a/src/Widgets/ProjectViewHeaderBar.vala
+++ b/src/Widgets/ProjectViewHeaderBar.vala
@@ -9,9 +9,6 @@ public class Widgets.ProjectViewHeaderBar : Gtk.Grid {
     private Gtk.Label emoji_label;
     private Widgets.CircularProgressBar circular_progress_bar;
 
-    private ulong project_count_updated;
-    private ulong project_updated;
-
     public ProjectViewHeaderBar () {
         Object (
             valign: Gtk.Align.CENTER
@@ -69,9 +66,6 @@ public class Widgets.ProjectViewHeaderBar : Gtk.Grid {
 
     public void update_view (Objects.BaseObject view) {
         // content_revealer.reveal_child = false;
-
-        disconnect (project_count_updated);
-        disconnect (project_updated);
 
         if (view is Objects.Project) {
             var project = ((Objects.Project) view);

--- a/src/Widgets/ScheduleButton.vala
+++ b/src/Widgets/ScheduleButton.vala
@@ -91,7 +91,7 @@ public class Widgets.ScheduleButton : Gtk.Grid {
     public void update_from_item (Objects.Item item) {
         due_label.label = _("Schedule");
         tooltip_text = _("Schedule");
-        repeat_label.label = "";
+        // repeat_label.label = "";
 
         due_image.update_icon_name ("planner-calendar");
         datetime = null;

--- a/src/Widgets/SectionsOrderPopover.vala
+++ b/src/Widgets/SectionsOrderPopover.vala
@@ -40,8 +40,8 @@ public class Widgets.SectionsOrderPopover : Gtk.Popover {
 
     private void set_sort_func () {
         listbox.set_sort_func ((row1, row2) => {
-            Objects.Section item1 = ((Layouts.SectionRow) row1).section;
-            Objects.Section item2 = ((Layouts.SectionRow) row2).section;
+            Objects.Section item1 = ((Widgets.SectionsOrderItem) row1).section;
+            Objects.Section item2 = ((Widgets.SectionsOrderItem) row2).section;
     
             return item1.section_order - item2.section_order;
         });


### PR DESCRIPTION
Hello there! I've been using Planify for a couple of weeks and I've loved it. I made some small changes in the development version fixing some criticals that popped up as well as some warnings in compile time. These include:

* Remove deprecations in GTK 4.10 and Libadwaita 1.3 (latest in GNOME 44 runtime):
  * Use Gtk.DropDown instead of Gtk.ComboBoxText
  * Use a Gtk.Image prefix instead of Adw.ActionRow.icon_name
* Avoid illegal casts and calling methods from null instances
* Transfer ownership for delegate methods
* Fix an accelerator in the shortcut window
* Tweaks to the Flatpak Manifests

If there is any change I have to make to improve this PR I will make the necessary updates as soon as I can :smile: