### PR TITLE
Fix priority icon colors

### DIFF
--- a/core/Util/Util.vala
+++ b/core/Util/Util.vala
@@ -912,12 +912,12 @@ public class Util : GLib.Object {
             };
         } else if (priority == Constants.PRIORITY_2) {
             return new Gtk.Image.from_icon_name ("flag-outline-thick-symbolic") {
-                css_classes = { "priority-1-icon" },
+                css_classes = { "priority-2-icon" },
                 pixel_size = 16
             };
         } else if (priority == Constants.PRIORITY_3) {
             return new Gtk.Image.from_icon_name ("flag-outline-thick-symbolic") {
-                css_classes = { "priority-1-icon" },
+                css_classes = { "priority-3-icon" },
                 pixel_size = 16
             };
         } else if (priority == Constants.PRIORITY_4) {


### PR DESCRIPTION
Priority icons 2 and 3 used colors from icon 1.

Before
![Screenshot from 2024-05-01 11-31-00](https://github.com/alainm23/planify/assets/37774658/75343701-a477-4c52-a638-dc1d81867730)
After
![Screenshot from 2024-05-01 11-59-05](https://github.com/alainm23/planify/assets/37774658/f224b584-3a88-45a8-9e3c-eb5daf840305)