### PR TITLE
Fix view option menu indicator covering the button

### DIFF
--- a/core/Widgets/ReminderPicker/ReminderButton.vala
+++ b/core/Widgets/ReminderPicker/ReminderButton.vala
@@ -101,6 +101,7 @@ public class Widgets.ReminderPicker.ReminderButton : Adw.Bin {
                 child = indicator_grid,
                 halign = END,
                 valign = START,
+                sensitive = false,
             };
 
             var button = new Gtk.MenuButton () {

--- a/src/Views/Project/Project.vala
+++ b/src/Views/Project/Project.vala
@@ -62,6 +62,7 @@ public class Views.Project : Adw.Bin {
             child = indicator_grid,
 			halign = END,
 			valign = START,
+			sensitive = false,
         };
 
 		var view_setting_button = new Gtk.MenuButton () {

--- a/src/Views/Scheduled/Scheduled.vala
+++ b/src/Views/Scheduled/Scheduled.vala
@@ -43,6 +43,7 @@ public class Views.Scheduled.Scheduled : Adw.Bin {
             child = indicator_grid,
 			halign = END,
 			valign = START,
+			sensitive = false,
         };
 
 		var view_setting_button = new Gtk.MenuButton () {

--- a/src/Views/Today.vala
+++ b/src/Views/Today.vala
@@ -69,6 +69,7 @@ public class Views.Today : Adw.Bin {
             child = indicator_grid,
 			halign = END,
 			valign = START,
+			sensitive = false,
         };
 
         var view_setting_button = new Gtk.MenuButton () {


### PR DESCRIPTION
Previously clicking above the indicator would do nothing. Now clicking above it is the same as clicking the button.

The indicator doesn't seem to be used in ReminderButton and the Scheduled view, but I updated it regardless. Also the indicator is misaligned in the Today view, but that's unrelated.