### PR TITLE
Fix scheduled range view

### DIFF
--- a/src/Views/Scheduled/ScheduledRange.vala
+++ b/src/Views/Scheduled/ScheduledRange.vala
@@ -122,7 +122,7 @@ public class Views.Scheduled.ScheduledRange : Gtk.ListBoxRow {
         });
         
         content.append (event_list_revealer);
-        content.append (listbox_grid);
+        content.append (listbox_revealer);
 
         child = content;
 


### PR DESCRIPTION
Fixes #1270

In other scheduled views, listbox_revealer is appended, but here listbox_grid is appended instead, which is already a child of the revealer. I'm assuming it fails because a widget can't have two parents.