### PR TITLE
Add mobile metadata to .desktop file

### DIFF
--- a/data/io.github.alainm23.planify.desktop.in.in
+++ b/data/io.github.alainm23.planify.desktop.in.in
@@ -14,3 +14,5 @@ X-GNOME-Gettext-Domain=planify
 X-GNOME-UsesNotifications=true
 # Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 Keywords=development;task;tasks;project;todo;event;events;calendar;todoist;
+# Translators: Do NOT translate or transliterate this text (these are enum types)!
+X-Purism-FormFactor=Workstation;Mobile;


### PR DESCRIPTION
This will enable the app to appear on the Phosh home screen without needing to toggle the All Apps view. This primarily affects devices running a mobile Linux distribution such as, but not limited to, PureOS (Librem 5) or Mobian.

Planify was featured in This Week in GNOME (TWIG) # 148 as having a responsive UI: https://thisweek.gnome.org/posts/2024/05/twig-148/

> **Support for Libadwaita 1.5 and Adaptive Dialogs**: All dialogs in Planify are now fully responsive, improving usability on various devices.

Examples of other apps with this metadata:

- Flatseal: https://github.com/tchx84/Flatseal/blob/master/data/com.github.tchx84.Flatseal.desktop.in#L12-L13
- Frog: https://github.com/TenderOwl/Frog/blob/master/data/com.github.tenderowl.frog.desktop.in#L13-L14

GitHub-Issue: #345