### PR TITLE
Resolved Vala lint errors

### DIFF
--- a/core/Util/Util.vala
+++ b/core/Util/Util.vala
@@ -1071,13 +1071,13 @@ We hope you’ll enjoy using Planify!""");
         var text = escape_text (_text);
 
         try {
-            Regex mailto_regex = /(?P<mailto>[a-zA-Z0-9\._\%\+\-]+@[a-zA-Z0-9\-\.]+\.[a-zA-Z]+(\S*))/;
-            Regex url_regex = /(?P<url>(http|https)\:\/\/[a-zA-Z0-9\-\.]+\.[a-zA-Z]+(\/\S*))/;
+            Regex mailto_regex = /(?P<mailto>[a-zA-Z0-9\._\%\+\-]+@[a-zA-Z0-9\-\.]+\.[a-zA-Z]+(\S*))/; // vala-lint=space-before-paren
+            Regex url_regex = /(?P<url>(http|https)\:\/\/[a-zA-Z0-9\-\.]+\.[a-zA-Z]+(\/\S*))/; // vala-lint=space-before-paren
             Regex url_markdown = new Regex ("\\[([^\\]]+)\\]\\(([^\\)]+)\\)");
                     
-            Regex italic_bold_regex = /\*\*\*(.*?)\*\*\*/;
-            Regex bold_regex = /\*\*(.*?)\*\*/;
-            Regex italic_regex = /\*(.*?)\*/;
+            Regex italic_bold_regex = /\*\*\*(.*?)\*\*\*/; // vala-lint=space-before-paren
+            Regex bold_regex = /\*\*(.*?)\*\*/; // vala-lint=space-before-paren
+            Regex italic_regex = /\*(.*?)\*/; // vala-lint=space-before-paren
 
             MatchInfo info;
 

--- a/core/Widgets/Markdown/Color.vala
+++ b/core/Widgets/Markdown/Color.vala
@@ -41,7 +41,7 @@ namespace Color {
 		Gtk.rgb_to_hsv (rgb.r, rgb.g, rgb.b, out hsl.h, out s, out v);
 		hsl.l = v - v * s / 2;
 		float m = float.min (hsl.l, 1 - hsl.l);
-		hsl.s = (m != 0) ? (v-hsl.l) / m : 0;
+		hsl.s = (m != 0) ? (v - hsl.l) / m : 0;
 		return hsl;
 	}
 

--- a/core/Widgets/Markdown/MarkdownEditView.vala
+++ b/core/Widgets/Markdown/MarkdownEditView.vala
@@ -206,8 +206,7 @@
 		buffer.begin_user_action ();
 
 		if ( !markdown_view.remove_formatting (markdown_view, affix) &&
-			 !markdown_view.remove_formatting (markdown_view, second_affix))
-			{
+			 !markdown_view.remove_formatting (markdown_view, second_affix)) {
 			Gtk.TextIter selection_start, selection_end, cursor;
 			Gtk.TextMark cursor_mark, selection_start_mark, selection_end_mark;
 			buffer.get_selection_bounds (out selection_start, out selection_end);
@@ -372,18 +371,18 @@
 	private void find_word_selection (ref Gtk.TextIter selection_start, ref Gtk.TextIter selection_end) {
 		var current_char = selection_start.get_char ();
 		// If we're at the end of line, move back one.
-		if( current_char == '\n') {
+		if ( current_char == '\n') {
 			selection_start.backward_char ();
 			current_char = selection_start.get_char ();
 		}
 		// If the cursor is in a blank spot (1 or more spaces/tabs) then go backwards until
 		// we find a word/start of line/start of buffer.
-		while ((current_char == ' ' || current_char == '\t') && current_char != '\n' && !selection_start.is_start()) {
+		while ( (current_char == ' ' || current_char == '\t') && current_char != '\n' && !selection_start.is_start ()) {
 			selection_start.backward_char ();
 			current_char = selection_start.get_char ();
 		}
 		// Now continue going backwards until we find the start of the word of end condition.
-		while (current_char != '\n' && current_char != ' ' && current_char != '\t' && !selection_start.is_start()){
+		while (current_char != '\n' && current_char != ' ' && current_char != '\t' && !selection_start.is_start ()) {
 			selection_start.backward_char ();
 			current_char = selection_start.get_char ();
 		}
@@ -394,7 +393,7 @@
 		}
 		current_char = selection_end.get_char ();
 		// If we're at the end of line, we're done.
-		if( current_char != '\n') {
+		if ( current_char != '\n') {
 			while (current_char != '\n' && current_char != ' ' && current_char != '\t' && !selection_end.is_end ()) {
 				selection_end.forward_char ();
 				current_char = selection_end.get_char ();
@@ -430,4 +429,4 @@
 	public void view_focus () {
 		markdown_view.grab_focus ();
 	}
- }
+}

--- a/core/Widgets/Markdown/MarkdownView.vala
+++ b/core/Widgets/Markdown/MarkdownView.vala
@@ -144,7 +144,7 @@ public class Widgets.Markdown.View : GtkSource.View {
 	public bool check_if_bare_link (string text) {
 		MatchInfo matches;
 		try {
-			if( is_bare_link.match_full (text, text.length, 0, 0, out matches)) {
+			if ( is_bare_link.match_full (text, text.length, 0, 0, out matches)) {
 				return true;
 			}
 		} catch (Error e) {}
@@ -1043,7 +1043,7 @@ public class Widgets.Markdown.View : GtkSource.View {
 		if (is_blockquote.match_full (buffer_text, buffer_text.length, 0, 0, out matches)) {
 			do {
 				int start_marker_pos, end_marker_pos;
-				int start_full_pos,   end_full_pos;
+				int start_full_pos, end_full_pos;
 				bool have_marker = matches.fetch_pos (1, out start_marker_pos, out end_marker_pos);
 				bool have_full = matches.fetch_pos (0, out start_full_pos, out end_full_pos);
 
@@ -1138,8 +1138,8 @@ public class Widgets.Markdown.View : GtkSource.View {
 		if (is_code_block.match_full (buffer_text, buffer_text.length, 0, 0, out matches)) {
 			do {
 				int start_before_pos, end_before_pos;
-				int start_code_pos,   end_code_pos;
-				int start_after_pos,  end_after_pos;
+				int start_code_pos, end_code_pos;
+				int start_after_pos, end_after_pos;
 				bool have_code_start = matches.fetch_pos (1, out start_before_pos, out end_before_pos);
 				bool have_code = matches.fetch_pos (2, out start_code_pos, out end_code_pos);
 				bool have_code_close = matches.fetch_pos (3, out start_after_pos, out end_after_pos);
@@ -1154,8 +1154,8 @@ public class Widgets.Markdown.View : GtkSource.View {
 
 					// Convert the character offsets to TextIter's
 					Gtk.TextIter start_before_iter, end_before_iter;
-					Gtk.TextIter start_code_iter,   end_code_iter;
-					Gtk.TextIter start_after_iter,  end_after_iter;
+					Gtk.TextIter start_code_iter, end_code_iter;
+					Gtk.TextIter start_after_iter, end_after_iter;
 					buffer.get_iter_at_offset (out start_before_iter, start_before_pos);
 					buffer.get_iter_at_offset (out end_before_iter, end_before_pos);
 					buffer.get_iter_at_offset (out start_code_iter, start_code_pos);
@@ -1259,11 +1259,7 @@ public class Widgets.Markdown.View : GtkSource.View {
 					buffer.get_iter_at_offset (out end_after_iter, end_after_pos);
 
 					// Check to see if the tag has already been applied, if so, skip it.
-					if (start_code_iter.has_tag (text_tag) && 
-					    end_code_iter.has_tag (text_tag) && 
-						start_before_iter.has_tag (text_tag_around) && 
-						start_after_iter.has_tag (text_tag_around)
-					) {
+					if (start_code_iter.has_tag (text_tag) && end_code_iter.has_tag (text_tag) && start_before_iter.has_tag (text_tag_around) && start_after_iter.has_tag (text_tag_around)) {
 						continue;
 					}
 


### PR DESCRIPTION
Fixed errors in the code formatting picked up by the linter.

In `Util.vala` I ignored some issues raised with the regex as there is a [known issue](https://github.com/vala-lang/vala-lint/issues/141) and the workaround being ignoring it with `// vala-lint=space-before-paren`.

All other errors were resolved according to the error message.