### PR TITLE
fix gxml wrap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,6 @@ build-aux/flatpak_build
 build-aux/.flatpak-builder
 build-aux/io.github.alainm23.planify.Devel.flatpak
 .flatpak-builder/
-subprojects/gxml
+subprojects/gxml**/
 *.snap
 planify*txt

--- a/subprojects/gxml-0.20.wrap
+++ b/subprojects/gxml-0.20.wrap
@@ -1,0 +1,7 @@
+[wrap-git]
+directory=gxml-0.20
+url=https://gitlab.gnome.org/GNOME/gxml.git
+revision=gxml-0.20
+
+[provide]
+gxml-0.20 = libgxml_dep

--- a/subprojects/gxml.wrap
+++ b/subprojects/gxml.wrap
@@ -1,4 +1,0 @@
-[wrap-git]
-directory=gxml
-url=https://gitlab.gnome.org/GNOME/gxml.git
-revision=master


### PR DESCRIPTION
When trying to compile i was stuck at 
```
meson.build:29:14: ERROR: Dependency "gxml-0.20" not found, tried pkgconfig and cmake
```
This is the same error as described in https://github.com/alainm23/planify/issues/1264

I noticed you already added a gxml.wrap file in the subprojects directory, however for me meson did not pick it up (meson version 1.5.1, ubuntu 24.04) because the dependency searched for gxml-0.20

I made the following changes to the wrap file:

- renamed wrap to to gxml-0.20.wrap such that meson can find it with dependency('gxml-0.20')
- set revision to gxml-0.20 to make sure that this specific branch is checked out from the git repository
- add [provide] tag to export libxml_dep as dependency (otherwise there is a 'no gxml-0.20' dependency provided error)

On my computer it now successfully picks up the gxml-0.20 wrap in case libgxml-0.20 is not available on the machine