### PR TITLE
Removed GenericName key from desktop entry

### DIFF
--- a/data/io.github.alainm23.planify.desktop.in.in
+++ b/data/io.github.alainm23.planify.desktop.in.in
@@ -1,8 +1,6 @@
 [Desktop Entry]
 # Translators: Keep this string as `Planify`
 Name=Planify
-# Translators: Keep this string as `Planify`
-GenericName=Planify
 Comment=Never worry about forgetting things again
 Categories=Utility;Office;ProjectManagement;Calendar;
 Exec=@exec@


### PR DESCRIPTION
# Why?

This violates the Desktop Entry Specification and causes the comment to not be shown when pinning Planify to the app launcher in KDE Plasma.

## Before:
<img src="https://github.com/user-attachments/assets/6bdb84f6-8e45-496f-a667-edfdd9dcce31" alt="" width="50%" align="center">
   
## After:
<img src="https://github.com/user-attachments/assets/fb4ace83-55f3-4d4e-8dae-def155323912" alt="" width="50%" align="center">
   
---
   
See here:
https://wiki.archlinux.org/title/Desktop_entries#Key_definition
https://specifications.freedesktop.org/desktop-entry-spec/latest/recognized-keys.html