### PR TITLE
fix: task schedule button issues

### DIFF
--- a/core/Widgets/DateTimePicker/ScheduleButton.vala
+++ b/core/Widgets/DateTimePicker/ScheduleButton.vala
@@ -26,7 +26,6 @@ public class Widgets.ScheduleButton : Gtk.Grid {
     private Gtk.Label due_label;
     private Gtk.Box schedule_box;
     private Gtk.Image due_image;
-    private Widgets.DateTimePicker.TimePicker time_picker;
     private Widgets.DateTimePicker.DateTimePicker datetime_picker;
     private Gtk.Revealer clear_revealer;
 
@@ -263,7 +262,6 @@ public class Widgets.ScheduleButton : Gtk.Grid {
         due_label.tooltip_text = label;
         tooltip_text = label;
         datetime_picker.reset ();
-        time_picker.has_time = false;
         duedate = new Objects.DueDate ();
         duedate.datetime = null;
         duedate_changed ();

--- a/core/Widgets/DateTimePicker/ScheduleButton.vala
+++ b/core/Widgets/DateTimePicker/ScheduleButton.vala
@@ -24,9 +24,9 @@ public class Widgets.ScheduleButton : Gtk.Grid {
     public string label { get; construct; }
 
     private Gtk.Label due_label;
-    
     private Gtk.Box schedule_box;
     private Gtk.Image due_image;
+    private Widgets.DateTimePicker.TimePicker time_picker;
     private Widgets.DateTimePicker.DateTimePicker datetime_picker;
     private Gtk.Revealer clear_revealer;
 
@@ -121,6 +121,7 @@ public class Widgets.ScheduleButton : Gtk.Grid {
         var clear_button = new Gtk.Button.from_icon_name ("window-close") {
             css_classes = { "flat" }
         };
+        clear_button.set_tooltip_text ("Clear Schedule");
 
         clear_revealer = new Gtk.Revealer () {
 			transition_type = Gtk.RevealerTransitionType.CROSSFADE,
@@ -213,6 +214,7 @@ public class Widgets.ScheduleButton : Gtk.Grid {
 
         due_label.label = Utils.Datetime.get_relative_date_from_date (item.due.datetime);
         due_label.tooltip_text = due_label.label;
+        due_image.tooltip_text = due_label.label;
     
         duedate = item.due;
         
@@ -255,10 +257,15 @@ public class Widgets.ScheduleButton : Gtk.Grid {
     }
 
     public void reset () {
-        due_label.label = label;
-        tooltip_text = label;
         due_image.icon_name = "month-symbolic";
-        duedate = new Objects.DueDate ();
+        due_image.tooltip_text = label;
+        due_label.label = label;
+        due_label.tooltip_text = label;
+        tooltip_text = label;
         datetime_picker.reset ();
+        time_picker.has_time = false;
+        duedate = new Objects.DueDate ();
+        duedate.datetime = null;
+        duedate_changed ();
     }
 }


### PR DESCRIPTION
Fixed issues of #1421 

The following changes I have made, tested, and built were successful. 

- The clear schedule button clears the task schedule tag on the left if not scheduled.
- The clear schedule button's tooltip shows "Schedule". Now shows "Clear Schedule".
- Two tooltips for the schedule button show the same.

Please review this PR. 

If you have any feedback about this PR, please let me know.
