### PR TITLE
Fix: Remove "Offline Mode" tooltip when network is available again

### DIFF
--- a/src/Widgets/SyncButton.vala
+++ b/src/Widgets/SyncButton.vala
@@ -74,6 +74,7 @@ public class Widgets.SyncButton : Adw.Bin {
     private void network_available () {
         if (Services.NetworkMonitor.instance ().network_available) {
             stack.visible_child_name = "sync";
+            tooltip_markup = "";
         } else {
             stack.visible_child_name = "error";
             tooltip_markup = "<b>%s</b>\n%s".printf (_("Offline Mode Is On"), _("Looks like you'are not connected to the\ninternet. Changes you make in offline\nmode will be synced when you reconnect")); // vala-lint=line-length


### PR DESCRIPTION
This PR fixes the following Bug:

**Bug Description**
When you disconnect your network and then reconnect again, it will show this tooltip.

![grafik](https://github.com/user-attachments/assets/50628909-a47a-41aa-802a-518e6a73f668)
