### PR TITLE
fix: display correct type of source in preference window

### DIFF
--- a/src/Dialogs/Preferences/PreferencesWindow.vala
+++ b/src/Dialogs/Preferences/PreferencesWindow.vala
@@ -961,7 +961,8 @@ public class Dialogs.Preferences.PreferencesWindow : Adw.PreferencesDialog {
 	}
 
 	private Adw.NavigationPage get_source_view (Objects.Source source) {
-		var settings_header = new Dialogs.Preferences.SettingsHeader (_("Todoist"));
+
+		var settings_header = new Dialogs.Preferences.SettingsHeader (source.subheader_text);
 
 		var avatar = new Adw.Avatar (84, source.user_displayname, true);
 


### PR DESCRIPTION
The preference window showed “Todoist” despite my source being a CalDAV/Nextcloud server. Fixed by using an already existing property of Source.

Before: (screenshot of my production environment)
![Screenshot from 2025-02-25 12-13-34-obfuscated](https://github.com/user-attachments/assets/643d5187-0969-418c-b11d-0f5e5c5087c2)

After: (screenshot of my dev environment, the icon on the right of Display Name is broken there)
![Screenshot from 2025-02-25 14-56-28-obfuscated](https://github.com/user-attachments/assets/44e0f98b-12ef-497f-831a-5d938b7a2a6f)


