### PR TITLE
Use the user-specified CalDAV server URL pathname for the task move destination URL base

### DIFF
--- a/core/Services/CalDAV/Core.vala
+++ b/core/Services/CalDAV/Core.vala
@@ -687,7 +687,7 @@ public class Services.CalDAV.Core : GLib.Object {
 		string username = item.project.source.caldav_data.username;
 
 		var url = "%s/calendars/%s/%s/%s".printf (item.project.source.caldav_data.server_url, username, item.project.id, item.ics);
-		var destination = "/remote.php/dav/calendars/%s/%s/%s".printf (username, project_id, item.ics);
+		var destination = "%s/calendars/%s/%s/%s".printf (item.project.source.caldav_data.server_url, username, project_id, item.ics);
 
 		var message = new Soup.Message ("MOVE", url);
 		message.request_headers.append ("Authorization", "Basic %s".printf (item.project.source.caldav_data.credentials));


### PR DESCRIPTION
Title put simpler: instead of using `/remote.php/dav/calendars/` as a base for the destination upon task move between projects, the user-specified NextCloud servers URL pathname will be used, e.g. `/my_nextcloud_instance/remote.php/dav/calendars/`

Fixes #1368 