### PR TITLE
fix: Today counter not updating when task is deleted

### DIFF
--- a/core/Services/Store.vala
+++ b/core/Services/Store.vala
@@ -557,8 +557,8 @@ public class Services.Store : GLib.Object {
 			}
 
 			item.deleted ();
-			item_deleted (item);
 			_items.remove (item);
+			item_deleted (item);
 
 			item.project.item_deleted (item);
 			if (item.has_section) {


### PR DESCRIPTION
The Today counter was not decreasing when tasks were deleted because the item_deleted signal was emitted before the item was removed from the Store's _items collection. This caused the counter recalculation to include the deleted item.

Fixed by moving the item_deleted signal emission to after the item removal from the collection.

🤖 Generated with [Claude Code](https://claude.ai/code)

Issue: https://github.com/alainm23/planify/issues/1604