### PR TITLE
fix: Whole day events displaying as 12:00 AM 

### DIFF
--- a/src/Services/CalendarEvents/Util.vala
+++ b/src/Services/CalendarEvents/Util.vala
@@ -91,10 +91,9 @@
      * Say if an event lasts all day.
      */
     public bool is_the_all_day (GLib.DateTime dtstart, GLib.DateTime dtend) {
-        var utc_start = dtstart.to_timezone (new TimeZone.utc ());
         var timespan = dtend.difference (dtstart);
 
-        if (timespan % GLib.TimeSpan.DAY == 0 && utc_start.get_hour () == 0) {
+        if (timespan % GLib.TimeSpan.DAY == 0 && dtstart.get_hour () == 0) {
             return true;
         } else {
             return false;


### PR DESCRIPTION
Fixes #1449

The all day method should check the local time instead of the UTC time, since it will never be true unless the user is in the UTC time. For example, if the user's local zone is three hours behind UTC, it will never consider the events as taking the whole day, since UTC will be 3 am when the user's local time is 12 am. 

Unfixed on the left and fixed on the right.
<img width="869" height="104" alt="whole_day_fix" src="https://github.com/user-attachments/assets/315b1212-dd5d-4efd-a8cc-41585976ec4f" />
