### PR TITLE
Disable keyboard shortcuts when Entry regains focus after closing a dialog

### DIFF
--- a/core/Widgets/Markdown/MarkdownEditView.vala
+++ b/core/Widgets/Markdown/MarkdownEditView.vala
@@ -183,6 +183,7 @@
         markdown_view.add_controller (gesture);
         gesture.enter.connect (handle_focus_in);
         gesture.leave.connect (update_on_leave);
+		markdown_view.buffer.changed.connect (handle_focus_in);
 
         child = markdown_view;
 
@@ -199,6 +200,7 @@
     }
 
 	private void handle_focus_in () {
+		print ("Se desactiva todoooooo\n");
         Services.EventBus.get_default ().disconnect_typing_accel ();
         enter ();
     }

--- a/src/Widgets/EditableTextView.vala
+++ b/src/Widgets/EditableTextView.vala
@@ -1,134 +1,145 @@
 /*
-* Copyright © 2023 Alain M. (https://github.com/alainm23/planify)
-*
-* This program is free software; you can redistribute it and/or
-* modify it under the terms of the GNU General Public
-* License as published by the Free Software Foundation; either
-* version 3 of the License, or (at your option) any later version.
-*
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-* General Public License for more details.
-*
-* You should have received a copy of the GNU General Public
-* License along with this program; if not, write to the
-* Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
-* Boston, MA 02110-1301 USA
-*
-* Authored by: Alain M. <alainmh23@gmail.com>
-*/
+ * Copyright © 2023 Alain M. (https://github.com/alainm23/planify)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA
+ *
+ * Authored by: Alain M. <alainmh23@gmail.com>
+ */
 
 public class Widgets.EditableTextView : Adw.Bin {
-	public string placeholder_text { get; construct; }
+    public string placeholder_text { get; construct; }
 
-	public signal void focus_changed (bool active);
-	public signal void changed ();
-
-	private Gtk.Label label;
+    private Gtk.Label label;
     private Widgets.TextView textview;
-	private Gtk.Stack stack;
+    private Gtk.Stack stack;
 
-	public string text { get; set; }
+    public signal void focus_changed (bool active);
+    public signal void changed ();
 
-	public bool is_editing {
-		get {
-			return stack.visible_child == textview;
-		}
-	}
+    public string text { get; set; }
 
-	public void editing (bool value) {
-		focus_changed (value);
+    public bool is_editing {
+        get {
+            return stack.visible_child == textview;
+        }
+    }
 
-		if (value) {
-			textview.buffer.text = text;
-			stack.set_visible_child (textview);
-			textview.grab_focus ();
-		} else {
-			if (text != textview.buffer.text) {
-				text = textview.buffer.text;
-				changed ();
-			}
+    public void editing (bool value) {
+        focus_changed (value);
 
-			stack.set_visible_child (label);
-		}
-	}
+        if (value) {
+            textview.buffer.text = text;
+            stack.set_visible_child (textview);
+            textview.grab_focus ();
+        } else {
+            if (text != textview.buffer.text) {
+                text = textview.buffer.text;
+                changed ();
+            }
 
-	public bool editable {
-		set {
-			textview.editable = value;
-		}
-	}
+            stack.set_visible_child (label);
+        }
+    }
 
-	private Gee.HashMap<ulong, GLib.Object> signal_map = new Gee.HashMap<ulong, GLib.Object> ();
+    public bool editable {
+        set {
+            textview.editable = value;
+        }
+    }
 
-	public EditableTextView (string placeholder_text = "") {
-		Object (
-			placeholder_text: placeholder_text
-		);
-	}
+    private Gee.HashMap<ulong, GLib.Object> signal_map = new Gee.HashMap<ulong, GLib.Object> ();
 
-	~EditableTextView () {
+    public EditableTextView (string placeholder_text = "") {
+        Object (
+            placeholder_text: placeholder_text
+        );
+    }
+
+    ~EditableTextView () {
         print ("Destroying Widgets.EditableTextView\n");
     }
 
-	construct {
-		label = new Gtk.Label (null) {
+    construct {
+        label = new Gtk.Label (null) {
             wrap = true,
             wrap_mode = Pango.WrapMode.WORD_CHAR,
             xalign = 0,
             yalign = 0
-		};
+        };
 
         textview = new Widgets.TextView () {
             wrap_mode = Gtk.WrapMode.WORD_CHAR,
             css_classes = {}
         };
 
-		stack = new Gtk.Stack () {
-			transition_type = Gtk.StackTransitionType.CROSSFADE,
-			hexpand = true,
+        stack = new Gtk.Stack () {
+            transition_type = Gtk.StackTransitionType.CROSSFADE,
+            hexpand = true,
             hhomogeneous = false,
             vhomogeneous = false
-		};
-        
-		stack.add_child (label);
-		stack.add_child (textview);
+        };
 
-		child = stack;
-		signal_map[notify["text"].connect (() => {
-			label.label = text;
-			label.opacity = 1;
+        stack.add_child (label);
+        stack.add_child (textview);
 
-			if (label.label.length <= 0) {
-				label.label = placeholder_text;
-				label.opacity = 0.7;
-			}
-		})] = this;
+        child = stack;
 
-		var gesture_click = new Gtk.GestureClick ();
-		add_controller (gesture_click);
-		signal_map[gesture_click.pressed.connect (() => {
-			editing (true);
-		})] = gesture_click;
+        signal_map[notify["text"].connect (() => {
+            label.label = text;
+            label.opacity = 1;
 
-		var gesture_focus = new Gtk.EventControllerFocus ();
-		textview.add_controller (gesture_focus);
-		signal_map[gesture_focus.leave.connect (() => {
-			if (stack.visible_child == textview) {
-				editing (false);
-			}
-		})] = gesture_focus;
+            if (label.label.length <= 0) {
+                label.label = placeholder_text;
+                label.opacity = 0.7;
+            }
+        })] = this;
 
-		destroy.connect (() => {
-			print ("Widgets.EditableTextView Destroyed\n");
+        var gesture_click = new Gtk.GestureClick ();
+        add_controller (gesture_click);
+        signal_map[gesture_click.pressed.connect (() => {
+            editing (true);
+        })] = gesture_click;
 
+        var gesture_focus = new Gtk.EventControllerFocus ();
+        textview.add_controller (gesture_focus);
+        signal_map[gesture_focus.leave.connect (() => {
+            if (stack.visible_child == textview) {
+                editing (false);
+            }
+        })] = gesture_focus;
+
+        signal_map[textview.buffer.changed.connect (() => {
+            Services.EventBus.get_default ().disconnect_typing_accel ();
+        })] = textview.buffer;
+
+        signal_map[gesture_focus.enter.connect (() => {
+            Services.EventBus.get_default ().disconnect_typing_accel ();
+        })] = gesture_focus;
+
+        signal_map[gesture_focus.leave.connect (() => {
+            Services.EventBus.get_default ().connect_typing_accel ();
+        })] = gesture_focus;
+
+        destroy.connect (() => {
             // Clear Signals
             foreach (var entry in signal_map.entries) {
                 entry.value.disconnect (entry.key);
             }
-            
+
             signal_map.clear ();
         });
-	}
+    }
 }


### PR DESCRIPTION
Use `notify::has-focus` to ensure keyboard shortcuts are properly disabled when the `Entry` automatically regains focus after a dialog is closed.

Fixes: #1543
Fixes: #1539
