### PR TITLE
Avoid resetting TextView content when clicking while editing

### DIFF
--- a/src/Widgets/EditableTextView.vala
+++ b/src/Widgets/EditableTextView.vala
@@ -111,8 +111,8 @@ public class Widgets.EditableTextView : Adw.Bin {
         add_controller (gesture_click);
         signal_map[gesture_click.pressed.connect (() => {
             if (!is_editing) {
-        editing (true);
-    }
+                editing (true);
+            }
         })] = gesture_click;
 
         var gesture_focus = new Gtk.EventControllerFocus ();

--- a/src/Widgets/EditableTextView.vala
+++ b/src/Widgets/EditableTextView.vala
@@ -110,7 +110,9 @@ public class Widgets.EditableTextView : Adw.Bin {
         var gesture_click = new Gtk.GestureClick ();
         add_controller (gesture_click);
         signal_map[gesture_click.pressed.connect (() => {
-            editing (true);
+            if (!is_editing) {
+        editing (true);
+    }
         })] = gesture_click;
 
         var gesture_focus = new Gtk.EventControllerFocus ();


### PR DESCRIPTION
Prevented `editing(true)` from being called if the widget is already in editing mode, which was causing the text to be reset when clicking to reposition the cursor.

Fixes: #1541