### PR TITLE
Fix task duplication turning notes into tasks

### DIFF
--- a/core/Objects/Item.vala
+++ b/core/Objects/Item.vala
@@ -1309,6 +1309,7 @@ public class Objects.Item : Objects.BaseObject {
         new_item.pinned = pinned;
         new_item.priority = priority;
         new_item.labels = labels;
+        new_item.item_type = item_type;
         return new_item;
     }
 


### PR DESCRIPTION
Ensure the `item_type` is correctly preserved when duplicating an item, so notes remain notes and tasks remain tasks.

Fixes #1472