### PR TITLE
Show completed tasks below pending tasks with pagination

### DIFF
--- a/core/Constants.vala
+++ b/core/Constants.vala
@@ -45,4 +45,5 @@ namespace Constants {
     public const string MASTODON_URL = "https://mastodon.social/@planifyapp";
     public const bool SHOW_WHATSNEW = false;
     public const bool BLOCK_PAST_DAYS = false;
+    public const int COMPLETED_PAGE_SIZE = 15;
 }

--- a/core/Objects/Project.vala
+++ b/core/Objects/Project.vala
@@ -37,7 +37,18 @@ public class Objects.Project : Objects.BaseObject {
     public bool inbox_section_hidded { get; set; default = false; }
     public string sync_id { get; set; default = ""; }
     public string source_id { get; set; default = SourceType.LOCAL.to_string (); }
-    public bool show_completed { get; set; default = false; }
+
+    bool _show_completed = false;
+    public bool show_completed {
+        get {
+            return _show_completed;
+        }
+
+        set {
+            _show_completed = value;
+            show_completed_changed ();
+        }
+    }
 
     ProjectViewStyle _view_style = ProjectViewStyle.LIST;
     public ProjectViewStyle view_style {
@@ -196,6 +207,7 @@ public class Objects.Project : Objects.BaseObject {
     public signal void subproject_added (Objects.Project project);
     public signal void item_added (Objects.Item item);
     public signal void item_deleted (Objects.Item item);
+    public signal void show_completed_changed ();
     public signal void sort_order_changed ();
     public signal void section_sort_order_changed ();
     public signal void view_style_changed ();

--- a/core/Objects/Section.vala
+++ b/core/Objects/Section.vala
@@ -368,12 +368,12 @@ public class Objects.Section : Objects.BaseObject {
 
     public void delete_section (Gtk.Window window) {
         var dialog = new Adw.AlertDialog (
-            _("Delete Section %s".printf (name)),
-            _("This can not be undone")
+            _ ("Delete Section %s".printf (name)),
+            _ ("This can not be undone")
         );
 
-        dialog.add_response ("cancel", _("Cancel"));
-        dialog.add_response ("delete", _("Delete"));
+        dialog.add_response ("cancel", _ ("Cancel"));
+        dialog.add_response ("delete", _ ("Delete"));
         dialog.set_response_appearance ("delete", Adw.ResponseAppearance.DESTRUCTIVE);
         dialog.present (window);
 
@@ -394,12 +394,12 @@ public class Objects.Section : Objects.BaseObject {
 
     public void archive_section (Gtk.Window window) {
         var dialog = new Adw.AlertDialog (
-            _("Archive?"),
-            _("This will archive %s and all its tasks.".printf (name))
+            _ ("Archive?"),
+            _ ("This will archive %s and all its tasks.".printf (name))
         );
 
-        dialog.add_response ("cancel", _("Cancel"));
-        dialog.add_response ("archive", _("Archive"));
+        dialog.add_response ("cancel", _ ("Cancel"));
+        dialog.add_response ("archive", _ ("Archive"));
         dialog.close_response = "cancel";
         dialog.set_response_appearance ("archive", Adw.ResponseAppearance.DESTRUCTIVE);
         dialog.present (window);

--- a/core/Widgets/ContextMenu/MenuCheckPicker.vala
+++ b/core/Widgets/ContextMenu/MenuCheckPicker.vala
@@ -44,7 +44,6 @@ public class Widgets.ContextMenu.MenuCheckPicker : Adw.Bin {
         filters_map = new Gee.HashMap<string, Widgets.ContextMenu.MenuItemCheckPicker> ();
 
         menu_icon = new Gtk.Image () {
-            css_classes = { "dim-label" },
             valign = Gtk.Align.CENTER
         };
 

--- a/core/Widgets/ContextMenu/MenuSwitch.vala
+++ b/core/Widgets/ContextMenu/MenuSwitch.vala
@@ -89,8 +89,9 @@ public class Widgets.ContextMenu.MenuSwitch : Gtk.Button {
             hexpand = true,
             halign = END
         };
+        switch_widget.add_css_class ("switch-min");
 
-        var content_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 6) {
+        var content_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 12) {
             hexpand = true
         };
 

--- a/data/resources/stylesheet/stylesheet.css
+++ b/data/resources/stylesheet/stylesheet.css
@@ -69,7 +69,7 @@ entry.flat:focus-within {
 .color-radio radio:checked {
     background: transparent;
     color: #fff;
-    -gtk-icon-source: -gtk-icontheme("emblem-ok-symbolic");
+    -gtk-icon-source: -gtk-icontheme("checkmark-small-symbolic");
     -gtk-icon-shadow: 0 1px 1px shade(#fff, 0.85);
 }
 

--- a/src/Dialogs/CompletedTasks.vala
+++ b/src/Dialogs/CompletedTasks.vala
@@ -26,6 +26,8 @@ public class Dialogs.CompletedTasks : Adw.Dialog {
     private Gtk.ListBox listbox;
     private Gtk.SearchEntry search_entry;
     private Widgets.FilterFlowBox filters_flowbox;
+    private Gtk.Button remove_all;
+
     private string ? filter_section_id = null;
 
     public Gee.HashMap<string, Widgets.CompletedTaskRow> items_checked = new Gee.HashMap<string, Widgets.CompletedTaskRow> ();
@@ -34,7 +36,7 @@ public class Dialogs.CompletedTasks : Adw.Dialog {
     public CompletedTasks (Objects.Project project) {
         Object (
             project: project,
-            title: _("Completed Tasks"),
+            title: _ ("Completed Tasks"),
             content_width: 450,
             content_height: 500
         );
@@ -54,18 +56,19 @@ public class Dialogs.CompletedTasks : Adw.Dialog {
             popover = build_view_setting_popover (),
             icon_name = "funnel-outline-symbolic",
             css_classes = { "flat" },
-            tooltip_text = _("View Filter Menu")
+            tooltip_text = _ ("View Filter Menu")
         };
 
         search_entry = new Gtk.SearchEntry () {
-            placeholder_text = _("Search"),
+            placeholder_text = _ ("Search"),
             hexpand = true,
             css_classes = { "border-radius-9" }
         };
 
         var search_entry_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 6) {
-            margin_start = 16,
-            margin_end = 16
+            margin_start = 12,
+            margin_end = 12,
+            margin_bottom = 12
         };
         search_entry_box.append (search_entry);
         search_entry_box.append (filter_button);
@@ -73,26 +76,23 @@ public class Dialogs.CompletedTasks : Adw.Dialog {
         filters_flowbox = new Widgets.FilterFlowBox () {
             valign = Gtk.Align.START,
             vexpand = false,
-            vexpand_set = true
+            vexpand_set = true,
         };
-
         filters_flowbox.flowbox.margin_start = 12;
-        filters_flowbox.flowbox.margin_top = 24;
-        filters_flowbox.flowbox.margin_end = 12;
+        filters_flowbox.flowbox.margin_bottom = 12;
 
         listbox = new Gtk.ListBox () {
             hexpand = true,
             valign = START,
             css_classes = { "listbox-background", "listbox-separator-6" },
             margin_start = 12,
-            margin_end = 12,
-            margin_top = 12
+            margin_end = 12
         };
 
         listbox.set_sort_func (sort_completed_function);
         listbox.set_header_func (header_completed_function);
         listbox.set_filter_func (filter_function);
-        listbox.set_placeholder (new Gtk.Label (_("No completed tasks yet.")) {
+        listbox.set_placeholder (new Gtk.Label (_ ("No completed tasks yet.")) {
             css_classes = { "dim-label" },
             margin_top = 48,
             margin_start = 24,
@@ -119,7 +119,7 @@ public class Dialogs.CompletedTasks : Adw.Dialog {
             child = content_box
         };
 
-        var remove_all = new Gtk.Button.with_label (_("Delete All Completed Tasks")) {
+        remove_all = new Gtk.Button.with_label (_ ("Delete All Completed Tasks")) {
             css_classes = { "flat" },
             margin_start = 12,
             margin_end = 12,
@@ -131,7 +131,7 @@ public class Dialogs.CompletedTasks : Adw.Dialog {
         toolbar_view.add_bottom_bar (remove_all);
         toolbar_view.content = content_clamp;
 
-        var main_page = new Adw.NavigationPage (toolbar_view, _("Completed Tasks"));
+        var main_page = new Adw.NavigationPage (toolbar_view, _ ("Completed Tasks"));
 
         navigation_view = new Adw.NavigationView ();
         navigation_view.add (main_page);
@@ -160,13 +160,13 @@ public class Dialogs.CompletedTasks : Adw.Dialog {
             var items = Services.Store.instance ().get_items_checked_by_project (project);
 
             var dialog = new Adw.AlertDialog (
-                _("Delete All Completed Tasks"),
-                _("This will delete %d completed tasks and their subtasks from project %s".printf (items.size, project.name))
+                _ ("Delete All Completed Tasks"),
+                _ ("This will delete %d completed tasks and their subtasks from project %s".printf (items.size, project.name))
             );
 
             dialog.body_use_markup = true;
-            dialog.add_response ("cancel", _("Cancel"));
-            dialog.add_response ("delete", _("Delete"));
+            dialog.add_response ("cancel", _ ("Cancel"));
+            dialog.add_response ("delete", _ ("Delete"));
             dialog.set_response_appearance ("delete", Adw.ResponseAppearance.DESTRUCTIVE);
             dialog.present (Planify._instance.main_window);
 
@@ -232,7 +232,7 @@ public class Dialogs.CompletedTasks : Adw.Dialog {
         toolbar_view.add_top_bar (headerbar);
         toolbar_view.content = item_detail;
 
-        var item_page = new Adw.NavigationPage (toolbar_view, _("Task Detail"));
+        var item_page = new Adw.NavigationPage (toolbar_view, _ ("Task Detail"));
         navigation_view.push (item_page);
     }
 
@@ -247,6 +247,8 @@ public class Dialogs.CompletedTasks : Adw.Dialog {
                 listbox.append (items_checked[item.id]);
             }
         }
+
+        remove_all.sensitive = items_checked.size > 0;
     }
 
     private void header_completed_function (Gtk.ListBoxRow lbrow, Gtk.ListBoxRow ? lbbefore) {
@@ -295,13 +297,12 @@ public class Dialogs.CompletedTasks : Adw.Dialog {
 
     private Gtk.Widget get_header_box (string title) {
         var header_label = new Gtk.Label (title) {
-            css_classes = { "heading" },
+            css_classes = { "caption", "font-bold" },
             halign = START
         };
 
         var header_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 6) {
-            margin_start = 6,
-            margin_top = 12,
+            margin_start = 3,
             margin_bottom = 6
         };
 
@@ -324,12 +325,12 @@ public class Dialogs.CompletedTasks : Adw.Dialog {
             section_model.add (section.name);
         }
 
-        var section_item = new Widgets.ContextMenu.MenuPicker (_("Section"), "arrow3-right-symbolic", section_model);
+        var section_item = new Widgets.ContextMenu.MenuPicker (_ ("Section"), "arrow3-right-symbolic", section_model);
 
         var menu_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 0);
         menu_box.margin_top = menu_box.margin_bottom = 3;
-        menu_box.append (new Gtk.Label (_("Filter By")) {
-            css_classes = { "heading", "h4" },
+        menu_box.append (new Gtk.Label (_ ("Filter By")) {
+            css_classes = { "caption", "font-bold" },
             margin_start = 6,
             margin_top = 6,
             margin_bottom = 6,

--- a/src/Layouts/ItemBoard.vala
+++ b/src/Layouts/ItemBoard.vala
@@ -318,7 +318,7 @@ public class Layouts.ItemBoard : Layouts.ItemBase {
 
         update_request ();
 
-        if (!item.pinned) {
+        if (!item.pinned && !item.checked) {
             build_drag_and_drop ();
         }
 

--- a/src/Layouts/ItemSidebarView.vala
+++ b/src/Layouts/ItemSidebarView.vala
@@ -639,10 +639,10 @@ public class Layouts.ItemSidebarView : Adw.Bin {
             right_margin = 12,
             top_margin = 12,
             bottom_margin = 12,
-            margin_top = 3,
-            margin_bottom = 3,
-            margin_start = 3,
-            margin_end = 3
+            margin_top = 1,
+            margin_bottom = 1,
+            margin_start = 1,
+            margin_end = 1
         };
         markdown_edit_view.buffer = current_buffer;
 

--- a/src/Layouts/Sidebar.vala
+++ b/src/Layouts/Sidebar.vala
@@ -34,7 +34,7 @@ public class Layouts.Sidebar : Adw.Bin {
     private Layouts.HeaderItem favorites_header;
     public Gee.HashMap<string, Layouts.ProjectRow> favorites_hashmap = new Gee.HashMap<string, Layouts.ProjectRow> ();
     public Gee.HashMap<string, Layouts.SidebarSourceRow> sources_hashmap = new Gee.HashMap<string, Layouts.SidebarSourceRow> ();
-
+    
     construct {
         filters_flow = new Gtk.FlowBox () {
             homogeneous = true,

--- a/src/Views/Project/List.vala
+++ b/src/Views/Project/List.vala
@@ -55,7 +55,7 @@ public class Views.List : Adw.Bin {
     construct {
         sections_map = new Gee.HashMap<string, Layouts.SectionRow> ();
 
-        var description_widget = new Widgets.EditableTextView (_("Note")) {
+        var description_widget = new Widgets.EditableTextView (_ ("Note")) {
             text = project.description,
             margin_top = 6,
             margin_start = 27,
@@ -88,8 +88,8 @@ public class Views.List : Adw.Bin {
 
         var listbox_placeholder = new Adw.StatusPage () {
             icon_name = "check-round-outline-symbolic",
-            title = _("Add Some Tasks"),
-            description = _("Press 'a' to create a new task")
+            title = _ ("Add Some Tasks"),
+            description = _ ("Press 'a' to create a new task")
         };
 
         listbox_placeholder_stack = new Gtk.Stack () {
@@ -216,6 +216,10 @@ public class Views.List : Adw.Bin {
             }
         })] = Services.Store.instance ();
 
+        signals_map[project.show_completed_changed.connect (() => {
+            check_placeholder ();
+        })] = project;
+
         destroy.connect (() => {
             listbox.set_sort_func (null);
             listbox.set_filter_func (null);
@@ -232,11 +236,11 @@ public class Views.List : Adw.Bin {
     private void check_placeholder () {
         int count = project.project_count + sections_map.size;
 
-        if (count > 0) {
-            listbox_placeholder_stack.visible_child_name = "listbox";
-        } else {
-            listbox_placeholder_stack.visible_child_name = "placeholder";
+        if (project.show_completed) {
+            count = count + project.items_checked.size;
         }
+
+        listbox_placeholder_stack.visible_child_name = count > 0 ? "listbox" : "placeholder";
     }
 
     private void add_sections () {
@@ -314,7 +318,7 @@ public class Views.List : Adw.Bin {
     private Gtk.Revealer build_due_date_widget () {
         due_image = new Gtk.Image.from_icon_name ("month-symbolic");
 
-        due_label = new Gtk.Label (_("Schedule")) {
+        due_label = new Gtk.Label (_ ("Schedule")) {
             xalign = 0
         };
 
@@ -348,7 +352,7 @@ public class Views.List : Adw.Bin {
         var gesture = new Gtk.GestureClick ();
         due_box.add_controller (gesture);
         gesture.pressed.connect ((n_press, x, y) => {
-            var dialog = new Dialogs.DatePicker (_("When?"));
+            var dialog = new Dialogs.DatePicker (_ ("When?"));
 
             if (project.due_date != "") {
                 dialog.datetime = Utils.Datetime.get_date_from_string (project.due_date);

--- a/src/Views/Project/Project.vala
+++ b/src/Views/Project/Project.vala
@@ -60,7 +60,7 @@ public class Views.Project : Adw.Bin {
             popover = build_context_menu_popover (),
             icon_name = "view-more-symbolic",
             css_classes = { "flat" },
-            tooltip_text = _("Project Actions")
+            tooltip_text = _ ("Project Actions")
         };
 
         var indicator_grid = new Gtk.Grid () {
@@ -85,7 +85,7 @@ public class Views.Project : Adw.Bin {
             popover = build_view_setting_popover (),
             icon_name = "view-sort-descending-rtl-symbolic",
             css_classes = { "flat" },
-            tooltip_text = _("View Option Menu")
+            tooltip_text = _ ("View Option Menu")
         };
 
         var view_setting_overlay = new Gtk.Overlay ();
@@ -275,23 +275,23 @@ public class Views.Project : Adw.Bin {
     }
 
     private Gtk.Popover build_context_menu_popover () {
-        var edit_item = new Widgets.ContextMenu.MenuItem (_("Edit Project"), "edit-symbolic");
-        var duplicate_item = new Widgets.ContextMenu.MenuItem (_("Duplicate"), "tabs-stack-symbolic");
-        var schedule_item = new Widgets.ContextMenu.MenuItem (_("When?"), "month-symbolic");
-        var add_section_item = new Widgets.ContextMenu.MenuItem (_("Add Section"), "tab-new-symbolic");
+        var edit_item = new Widgets.ContextMenu.MenuItem (_ ("Edit Project"), "edit-symbolic");
+        var duplicate_item = new Widgets.ContextMenu.MenuItem (_ ("Duplicate"), "tabs-stack-symbolic");
+        var schedule_item = new Widgets.ContextMenu.MenuItem (_ ("When?"), "month-symbolic");
+        var add_section_item = new Widgets.ContextMenu.MenuItem (_ ("Add Section"), "tab-new-symbolic");
         add_section_item.secondary_text = "S";
-        var manage_sections = new Widgets.ContextMenu.MenuItem (_("Manage Sections"), "permissions-generic-symbolic");
+        var manage_sections = new Widgets.ContextMenu.MenuItem (_ ("Manage Sections"), "permissions-generic-symbolic");
 
-        var select_item = new Widgets.ContextMenu.MenuItem (_("Select"), "list-large-symbolic");
-        var paste_item = new Widgets.ContextMenu.MenuItem (_("Paste"), "tabs-stack-symbolic");
-        expand_all_item = new Widgets.ContextMenu.MenuItem (_("Expand All"), "size-vertically-symbolic") {
+        var select_item = new Widgets.ContextMenu.MenuItem (_ ("Select"), "list-large-symbolic");
+        var paste_item = new Widgets.ContextMenu.MenuItem (_ ("Paste"), "tabs-stack-symbolic");
+        expand_all_item = new Widgets.ContextMenu.MenuItem (_ ("Expand All"), "size-vertically-symbolic") {
             visible = view_style == ProjectViewStyle.LIST
         };
-        collapse_all_item = new Widgets.ContextMenu.MenuItem (_("Collapse All"), "size-vertically-symbolic") {
+        collapse_all_item = new Widgets.ContextMenu.MenuItem (_ ("Collapse All"), "size-vertically-symbolic") {
             visible = view_style == ProjectViewStyle.LIST
         };
-        var archive_item = new Widgets.ContextMenu.MenuItem (_("Archive"), "shoe-box-symbolic");
-        var delete_item = new Widgets.ContextMenu.MenuItem (_("Delete Project"), "user-trash-symbolic");
+        var archive_item = new Widgets.ContextMenu.MenuItem (_ ("Archive"), "shoe-box-symbolic");
+        var delete_item = new Widgets.ContextMenu.MenuItem (_ ("Delete Project"), "user-trash-symbolic");
         delete_item.add_css_class ("menu-item-danger");
 
         var menu_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 0);
@@ -337,7 +337,7 @@ public class Views.Project : Adw.Bin {
         });
 
         schedule_item.activate_item.connect (() => {
-            var dialog = new Dialogs.DatePicker (_("When?"));
+            var dialog = new Dialogs.DatePicker (_ ("When?"));
             dialog.clear = project.due_date != "";
             dialog.present (Planify._instance.main_window);
 
@@ -411,7 +411,7 @@ public class Views.Project : Adw.Bin {
         };
 
         list_box.append (new Gtk.Image.from_icon_name ("list-symbolic"));
-        list_box.append (new Gtk.Label (_("List")) {
+        list_box.append (new Gtk.Label (_ ("List")) {
             css_classes = { "caption" },
             valign = CENTER
         });
@@ -426,7 +426,7 @@ public class Views.Project : Adw.Bin {
         };
 
         board_box.append (new Gtk.Image.from_icon_name ("view-columns-symbolic"));
-        board_box.append (new Gtk.Label (_("Board")) {
+        board_box.append (new Gtk.Label (_ ("Board")) {
             css_classes = { "caption" },
             valign = CENTER
         });
@@ -450,62 +450,75 @@ public class Views.Project : Adw.Bin {
         view_box.append (board_button);
 
         var order_by_model = new Gee.ArrayList<string> ();
-        order_by_model.add (_("Custom sort order"));
-        order_by_model.add (_("Alphabetically"));
-        order_by_model.add (_("Due Date"));
-        order_by_model.add (_("Date Added"));
-        order_by_model.add (_("Priority"));
+        order_by_model.add (_ ("Custom sort order"));
+        order_by_model.add (_ ("Alphabetically"));
+        order_by_model.add (_ ("Due Date"));
+        order_by_model.add (_ ("Date Added"));
+        order_by_model.add (_ ("Priority"));
 
-        var order_by_item = new Widgets.ContextMenu.MenuPicker (_("Sorting"), "vertical-arrows-long-symbolic", order_by_model);
+        var order_by_item = new Widgets.ContextMenu.MenuPicker (_ ("Sorting"), "vertical-arrows-long-symbolic", order_by_model);
         order_by_item.selected = project.sort_order;
 
         // Filters
         var due_date_model = new Gee.ArrayList<string> ();
-        due_date_model.add (_("All (default)"));
-        due_date_model.add (_("Today"));
-        due_date_model.add (_("This Week"));
-        due_date_model.add (_("Next 7 Days"));
-        due_date_model.add (_("This Month"));
-        due_date_model.add (_("Next 30 Days"));
-        due_date_model.add (_("No Date"));
+        due_date_model.add (_ ("All (default)"));
+        due_date_model.add (_ ("Today"));
+        due_date_model.add (_ ("This Week"));
+        due_date_model.add (_ ("Next 7 Days"));
+        due_date_model.add (_ ("This Month"));
+        due_date_model.add (_ ("Next 30 Days"));
+        due_date_model.add (_ ("No Date"));
 
-        due_date_item = new Widgets.ContextMenu.MenuPicker (_("Duedate"), "month-symbolic", due_date_model);
+        due_date_item = new Widgets.ContextMenu.MenuPicker (_ ("Duedate"), "month-symbolic", due_date_model);
         due_date_item.selected = 0;
 
         var priority_items = new Gee.ArrayList<Objects.Filters.FilterItem> ();
 
         priority_items.add (new Objects.Filters.FilterItem () {
             filter_type = FilterItemType.PRIORITY,
-            name = _("P1"),
+            name = _ ("P1"),
             value = Constants.PRIORITY_1.to_string ()
         });
 
         priority_items.add (new Objects.Filters.FilterItem () {
             filter_type = FilterItemType.PRIORITY,
-            name = _("P2"),
+            name = _ ("P2"),
             value = Constants.PRIORITY_2.to_string ()
         });
 
         priority_items.add (new Objects.Filters.FilterItem () {
             filter_type = FilterItemType.PRIORITY,
-            name = _("P3"),
+            name = _ ("P3"),
             value = Constants.PRIORITY_3.to_string ()
         });
 
         priority_items.add (new Objects.Filters.FilterItem () {
             filter_type = FilterItemType.PRIORITY,
-            name = _("P4"),
+            name = _ ("P4"),
             value = Constants.PRIORITY_4.to_string ()
         });
 
-        priority_filter = new Widgets.ContextMenu.MenuCheckPicker (_("Priority"), "flag-outline-thick-symbolic");
+        priority_filter = new Widgets.ContextMenu.MenuCheckPicker (_ ("Priority"), "flag-outline-thick-symbolic");
         priority_filter.set_items (priority_items);
 
-        var labels_filter = new Widgets.ContextMenu.MenuItem (_("Filter by Labels"), "tag-outline-symbolic") {
+        var labels_filter = new Widgets.ContextMenu.MenuItem (_ ("Filter by Labels"), "tag-outline-symbolic") {
             arrow = true
         };
 
-        var show_completed_item = new Widgets.ContextMenu.MenuItem (_("Show Completed Tasks"), "check-round-outline-symbolic");
+        var show_completed_item = new Widgets.ContextMenu.MenuSwitch (_ ("Show Completed Tasks"), "check-round-outline-symbolic");
+        show_completed_item.active = project.show_completed;
+
+        var show_completed_item_button = new Gtk.Button.from_icon_name ("edit-find-symbolic") {
+            valign = CENTER,
+            tooltip_text = _("Search completed tasks")
+        };
+        show_completed_item_button.add_css_class ("flat");
+
+        var show_completed_box = new Gtk.Box (HORIZONTAL, 6) {
+            valign = CENTER
+        };
+        show_completed_box.append (show_completed_item);
+        show_completed_box.append (show_completed_item_button);
 
         var menu_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 0);
         menu_box.margin_top = menu_box.margin_bottom = 3;
@@ -515,7 +528,7 @@ public class Views.Project : Adw.Bin {
             menu_box.append (new Widgets.ContextMenu.MenuSeparator ());
         }
 
-        menu_box.append (new Gtk.Label (_("Sort By")) {
+        menu_box.append (new Gtk.Label (_ ("Sort By")) {
             css_classes = { "heading", "h4" },
             margin_start = 6,
             margin_top = 6,
@@ -524,7 +537,7 @@ public class Views.Project : Adw.Bin {
         });
         menu_box.append (order_by_item);
         menu_box.append (new Widgets.ContextMenu.MenuSeparator ());
-        menu_box.append (new Gtk.Label (_("Filter By")) {
+        menu_box.append (new Gtk.Label (_ ("Filter By")) {
             css_classes = { "heading", "h4" },
             margin_start = 6,
             margin_top = 6,
@@ -535,7 +548,7 @@ public class Views.Project : Adw.Bin {
         menu_box.append (priority_filter);
         menu_box.append (labels_filter);
         menu_box.append (new Widgets.ContextMenu.MenuSeparator ());
-        menu_box.append (show_completed_item);
+        menu_box.append (show_completed_box);
 
         var popover = new Gtk.Popover () {
             has_arrow = false,
@@ -551,6 +564,14 @@ public class Views.Project : Adw.Bin {
         });
 
         show_completed_item.activate_item.connect (() => {
+            project.show_completed = !project.show_completed;
+            project.update_local ();
+            check_default_filters ();
+        });
+
+        show_completed_item_button.clicked.connect (() => {
+            popover.popdown ();
+
             var dialog = new Dialogs.CompletedTasks (project);
             dialog.present (Planify._instance.main_window);
         });
@@ -587,17 +608,17 @@ public class Views.Project : Adw.Bin {
                 }
 
                 if (due_date_item.selected == 1) {
-                    filter.name = _("Today");
+                    filter.name = _ ("Today");
                 } else if (due_date_item.selected == 2) {
-                    filter.name = _("This Week");
+                    filter.name = _ ("This Week");
                 } else if (due_date_item.selected == 3) {
-                    filter.name = _("Next 7 Days");
+                    filter.name = _ ("Next 7 Days");
                 } else if (due_date_item.selected == 4) {
-                    filter.name = _("This Month");
+                    filter.name = _ ("This Month");
                 } else if (due_date_item.selected == 5) {
-                    filter.name = _("Next 30 Days");
+                    filter.name = _ ("Next 30 Days");
                 } else if (due_date_item.selected == 6) {
-                    filter.name = _("No Date");
+                    filter.name = _ ("No Date");
                 }
 
                 filter.value = due_date_item.selected.to_string ();

--- a/src/Widgets/CompletedTaskRow.vala
+++ b/src/Widgets/CompletedTaskRow.vala
@@ -120,7 +120,11 @@ public class Widgets.CompletedTaskRow : Gtk.ListBoxRow {
 
         var card = new Adw.Bin () {
             child = h_box,
-            css_classes = { "card", "activatable", "border-radius-9" }
+            css_classes = { "card", "activatable", "border-radius-9" },
+            margin_start = 1,
+            margin_end = 1,
+            margin_top = 1,
+            margin_bottom = 1
         };
 
         main_revealer = new Gtk.Revealer () {

--- a/src/Widgets/EditableTextView.vala
+++ b/src/Widgets/EditableTextView.vala
@@ -33,7 +33,7 @@ public class Widgets.EditableTextView : Adw.Bin {
 
     public bool is_editing {
         get {
-            return stack.visible_child == textview;
+            return stack.visible_child_name == "textview";
         }
     }
 
@@ -42,7 +42,7 @@ public class Widgets.EditableTextView : Adw.Bin {
 
         if (value) {
             textview.buffer.text = text;
-            stack.set_visible_child (textview);
+            stack.visible_child_name = "textview";
             textview.grab_focus ();
         } else {
             if (text != textview.buffer.text) {
@@ -50,7 +50,7 @@ public class Widgets.EditableTextView : Adw.Bin {
                 changed ();
             }
 
-            stack.set_visible_child (label);
+            stack.visible_child_name = "label";
         }
     }
 
@@ -93,8 +93,8 @@ public class Widgets.EditableTextView : Adw.Bin {
             vhomogeneous = false
         };
 
-        stack.add_child (label);
-        stack.add_child (textview.get_widget ());
+        stack.add_named (label, "label");
+        stack.add_named (textview.get_widget (), "textview");
 
         child = stack;
 
@@ -119,7 +119,7 @@ public class Widgets.EditableTextView : Adw.Bin {
         var gesture_focus = new Gtk.EventControllerFocus ();
         textview.add_controller (gesture_focus);
         signal_map[gesture_focus.leave.connect (() => {
-            if (stack.visible_child == textview) {
+            if (stack.visible_child_name == "textview") {
                 editing (false);
             }
         })] = gesture_focus;


### PR DESCRIPTION
This PR changes how completed tasks are displayed.
Instead of showing them in a separate dialog, they now appear directly below the pending tasks.
Pagination has been added to avoid loading too many completed tasks at once, improving performance and usability.

Fixes: #1614 #1565 #1415 #1417
