### PR TITLE
Add "reminder" and "reminders" search terms to desktop file

### DIFF
--- a/data/io.github.alainm23.planify.desktop.in.in
+++ b/data/io.github.alainm23.planify.desktop.in.in
@@ -11,6 +11,6 @@ StartupNotify=true
 X-GNOME-Gettext-Domain=planify
 X-GNOME-UsesNotifications=true
 # Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
-Keywords=development;task;tasks;project;todo;event;events;calendar;todoist;
+Keywords=development;task;tasks;project;todo;reminder;reminders;event;events;calendar;todoist;
 # Translators: Do NOT translate or transliterate this text (these are enum types)!
 X-Purism-FormFactor=Workstation;Mobile;


### PR DESCRIPTION
I recently wanted to open Planify but I somehow couldn't remember the app's name, so I searched for "reminder" and was surprised to not see Planify in the results. I believe that searching for these terms should show the app.
This PR simply adds the words "reminder" and "reminders" to the desktop file of Planify.