### PR TITLE
Retain the last used project in Quick Add

### DIFF
--- a/core/QuickAdd.vala
+++ b/core/QuickAdd.vala
@@ -74,8 +74,7 @@ public class Layouts.QuickAdd : Adw.Bin {
             item.custom_order = true;
         }
 
-        if (is_window_quick_add &&
-            Services.Settings.get_default ().settings.get_boolean ("quick-add-save-last-project")) {
+        if (Services.Settings.get_default ().settings.get_boolean ("quick-add-save-last-project")) {
             var project = Services.Store.instance ().get_project (Services.Settings.get_default ().settings.get_string ("quick-add-project-selected"));
 
             if (project != null) {

--- a/src/Views/Scheduled/Scheduled.vala
+++ b/src/Views/Scheduled/Scheduled.vala
@@ -202,13 +202,8 @@ public class Views.Scheduled.Scheduled : Adw.Bin {
     }
 
     public void prepare_new_item (string content = "") {
-        var inbox_project = Services.Store.instance ().get_project (
-            Services.Settings.get_default ().settings.get_string ("local-inbox-project-id")
-        );
-
         var dialog = new Dialogs.QuickAdd ();
         dialog.update_content (content);
-        dialog.set_project (inbox_project);
         dialog.set_due (Utils.Datetime.get_date_only (new GLib.DateTime.now_local ().add_days (1)));
         dialog.present (Planify._instance.main_window);
     }

--- a/src/Views/Today.vala
+++ b/src/Views/Today.vala
@@ -578,13 +578,8 @@ public class Views.Today : Adw.Bin {
     }
 
     public void prepare_new_item (string content = "") {
-        var inbox_project = Services.Store.instance ().get_project (
-            Services.Settings.get_default ().settings.get_string ("local-inbox-project-id")
-        );
-
         var dialog = new Dialogs.QuickAdd ();
         dialog.update_content (content);
-        dialog.set_project (inbox_project);
         dialog.set_due (Utils.Datetime.get_date_only (date));
         dialog.present (Planify._instance.main_window);
     }


### PR DESCRIPTION
As the title suggests.

Such mechanism already exists for _Quick Add_ but not for the same dialog within the app. I have found that feature to be especially convenient.