### PR TITLE
Improve drag-and-drop animations in Widgets.ReorderChild and fix last-item reorder bug

### DIFF
--- a/core/Widgets/SectionPicker/SectionPickerRow.vala
+++ b/core/Widgets/SectionPicker/SectionPickerRow.vala
@@ -70,7 +70,10 @@ public class Widgets.SectionPicker.SectionPickerRow : Gtk.ListBoxRow {
             active = section.id == "" ? !section.project.inbox_section_hidded : !section.hidded
         };
 
-        var order_icon = new Gtk.Image.from_icon_name ("list-drag-handle-symbolic");
+        var order_icon = new Gtk.Image.from_icon_name ("list-drag-handle-symbolic") {
+            css_classes = { "dimmed" },
+            pixel_size = 12
+        };
 
         var content_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 6) {
             margin_top = 6,

--- a/data/resources/stylesheet/stylesheet.css
+++ b/data/resources/stylesheet/stylesheet.css
@@ -556,8 +556,18 @@ checkbutton.theme-selector radio:checked {
 }
 
 .drop-area {
-    background-color: alpha(#1e63ec, 0.25);
+    background-color: alpha(#1e63ec, 0.35);
     border-radius: 6px;
+}
+
+.drop-area-active {
+    border-radius: 6px;
+    border: 1px solid #1e63ec;
+}
+
+.drop-area-outline-active {
+    border-radius: 6px;
+    outline: 1px solid #1e63ec;
 }
 
 .drop-target:drop(active) {
@@ -587,16 +597,6 @@ checkbutton.theme-selector radio:checked {
 .indicator {
     background: #1e63ec;
     border-radius: 50%;
-}
-
-.drop-area-active {
-    border-radius: 6px;
-    border: 1px solid #1e63ec;
-}
-
-.drop-area-outline-active {
-    border-radius: 6px;
-    outline: 1px solid #1e63ec;
 }
 
 .view-button {

--- a/src/Dialogs/ManageSectionOrder.vala
+++ b/src/Dialogs/ManageSectionOrder.vala
@@ -202,10 +202,10 @@ public class Dialogs.ManageSectionOrder : Adw.Dialog {
 
         add_section (new Dialogs.ProjectPicker.SectionPickerRow (inbox_section, "order"));
         foreach (Objects.Section section in project.sections) {
-            if (!section.was_archived ()) {
-                add_section (new Dialogs.ProjectPicker.SectionPickerRow (section, "order"));
-            } else {
+            if (section.was_archived ()) {
                 archived_listbox.append (new Dialogs.ProjectPicker.SectionPickerRow (section, "menu"));
+            } else {
+                add_section (new Dialogs.ProjectPicker.SectionPickerRow (section, "order"));
             }
         }
     }

--- a/src/Dialogs/Preferences/Pages/Sidebar.vala
+++ b/src/Dialogs/Preferences/Pages/Sidebar.vala
@@ -128,8 +128,7 @@ public class Widgets.SidebarRow : Gtk.ListBoxRow {
     public string icon { get; construct; }
     public string title { get; construct; }
 
-    private Gtk.Box handle_grid;
-    private Gtk.CheckButton check_button;
+    private Gtk.Switch check_button;
 
     public bool active {
         get {
@@ -153,7 +152,7 @@ public class Widgets.SidebarRow : Gtk.ListBoxRow {
         name_label.valign = Gtk.Align.CENTER;
         name_label.ellipsize = Pango.EllipsizeMode.END;
 
-        check_button = new Gtk.CheckButton () {
+        check_button = new Gtk.Switch () {
             valign = CENTER,
             halign = END,
             hexpand = true,
@@ -161,18 +160,21 @@ public class Widgets.SidebarRow : Gtk.ListBoxRow {
             active = check_active ()
         };
 
-        handle_grid = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 9) {
+        var content_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 9) {
             margin_top = 12,
-            margin_start = 12,
             margin_end = 12,
-            margin_bottom = 12
+            margin_bottom = 12,
+            margin_start = 12
+        };
+        content_box.append (new Gtk.Image.from_icon_name (icon));
+        content_box.append (name_label);
+        content_box.append (check_button);
+
+        var handle = new Adw.Bin () {
+            child = content_box
         };
 
-        handle_grid.append (new Gtk.Image.from_icon_name (icon));
-        handle_grid.append (name_label);
-        handle_grid.append (check_button);
-
-        var reorder = new Widgets.ReorderChild (handle_grid, this);
+        var reorder = new Widgets.ReorderChild (handle, this);
 
         var main_revealer = new Gtk.Revealer () {
             transition_type = Gtk.RevealerTransitionType.SLIDE_DOWN,
@@ -187,7 +189,7 @@ public class Widgets.SidebarRow : Gtk.ListBoxRow {
             return GLib.Source.REMOVE;
         });
 
-        check_button.toggled.connect (() => {
+        check_button.notify["active"].connect (() => {
             updateView (
                 get_views_array (),
                 filter_type.to_string (),
@@ -197,6 +199,10 @@ public class Widgets.SidebarRow : Gtk.ListBoxRow {
 
         reorder.on_drop_end.connect ((listbox) => {
             update_views_order (listbox);
+        });
+
+        main_revealer.notify["child-revealed"].connect (() => {
+            reorder.draw_motion_widgets ();
         });
     }
 

--- a/src/Dialogs/ProjectPicker/SectionPickerRow.vala
+++ b/src/Dialogs/ProjectPicker/SectionPickerRow.vala
@@ -27,6 +27,12 @@ public class Dialogs.ProjectPicker.SectionPickerRow : Gtk.ListBoxRow {
     private Gtk.Grid handle_grid;
     private Gtk.Revealer main_revealer;
 
+    public bool is_inbox_section {
+        get {
+            return section.id == "";
+        }
+    }
+
     public signal void update_section ();
 
     private Gee.HashMap<ulong, GLib.Object> signal_map = new Gee.HashMap<ulong, GLib.Object> ();
@@ -68,10 +74,15 @@ public class Dialogs.ProjectPicker.SectionPickerRow : Gtk.ListBoxRow {
 
         var hidded_switch = new Gtk.Switch () {
             css_classes = { "active-switch" },
-            active = section.id == "" ? !section.project.inbox_section_hidded : !section.hidded
+            active = is_inbox_section ? !section.project.inbox_section_hidded : !section.hidded,
+            halign = Gtk.Align.END,
+            hexpand = true
         };
 
-        var order_icon = new Gtk.Image.from_icon_name ("list-drag-handle-symbolic");
+        var order_icon = new Gtk.Image.from_icon_name ("list-drag-handle-symbolic") {
+            css_classes = { "dimmed" },
+            pixel_size = 12
+        };
 
         var menu_button = new Gtk.MenuButton () {
             hexpand = true,
@@ -88,17 +99,12 @@ public class Dialogs.ProjectPicker.SectionPickerRow : Gtk.ListBoxRow {
             margin_bottom = 9
         };
 
-        content_box.append (name_label);
-
         if (widget_type == "order") {
-            var box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 12) {
-                hexpand = true,
-                halign = Gtk.Align.END
-            };
-            box.append (hidded_switch);
-            box.append (order_icon);
-
-            content_box.append (box);
+            if (!is_inbox_section) {
+                content_box.append (order_icon);
+            }
+            content_box.append (name_label);
+            content_box.append (hidded_switch);
         }
 
         if (widget_type == "picker") {
@@ -143,7 +149,7 @@ public class Dialogs.ProjectPicker.SectionPickerRow : Gtk.ListBoxRow {
         }
 
         if (widget_type == "order") {
-            if (section.id != "") {
+            if (!is_inbox_section) {
                 reorder_child.build_drag_and_drop ();
             }
 
@@ -162,6 +168,10 @@ public class Dialogs.ProjectPicker.SectionPickerRow : Gtk.ListBoxRow {
             signal_map[reorder_child.on_drop_end.connect (() => {
                 update_section ();
             })] = reorder_child;
+
+            main_revealer.notify["child-revealed"].connect (() => {
+                reorder_child.draw_motion_widgets ();
+            });
         }
 
         if (widget_type == "menu") {

--- a/src/Widgets/SectionsOrderPopover.vala
+++ b/src/Widgets/SectionsOrderPopover.vala
@@ -87,7 +87,8 @@ public class Widgets.SectionsOrderItem : Gtk.ListBoxRow {
         add_css_class ("transition");
 
         var order_icon = new Gtk.Image.from_icon_name ("list-drag-handle-symbolic") {
-            css_classes = { "dimmed" }
+            css_classes = { "dimmed" },
+            pixel_size = 12
         };
 
         var widget_color = new Gtk.Grid () {

--- a/src/Widgets/SourceRow.vala
+++ b/src/Widgets/SourceRow.vala
@@ -75,6 +75,7 @@ public class Widgets.SourceRow : Gtk.ListBoxRow {
 
         content_box.append (new Gtk.Image.from_icon_name ("list-drag-handle-symbolic") {
             css_classes = { "dimmed" },
+            pixel_size = 12
         });
         content_box.append (title_box);
         content_box.append (end_box);
@@ -113,6 +114,10 @@ public class Widgets.SourceRow : Gtk.ListBoxRow {
 
         reorder.on_drop_end.connect ((listbox) => {
             update_views_order (listbox);
+        });
+
+        main_revealer.notify["child-revealed"].connect (() => {
+            reorder.draw_motion_widgets ();
         });
     }
 


### PR DESCRIPTION
This PR refines the drag-and-drop animations in `Widgets.ReorderChild` to make reordering feel smoother and more fluid.
It also fixes a bug that prevented items from being reordered to the last position in the list.


https://github.com/user-attachments/assets/7a8d2db1-b939-4702-9036-77bdee04ac38

