### PR TITLE
Fix drag and drop at the end of list by adding bottom drop area

### DIFF
--- a/core/Layouts/HeaderItem.vala
+++ b/core/Layouts/HeaderItem.vala
@@ -80,11 +80,13 @@ public class Layouts.HeaderItem : Adw.Bin {
     private Gtk.Label subheader_label;
     private Gtk.Revealer subheader_revealer;
     private Gtk.Label placeholder_label;
-    private Gtk.ListBox listbox;
-    private Adw.Bin content_grid;
+    public Gtk.ListBox listbox;
     private Gtk.Box action_box;
     private Gtk.Revealer content_revealer;
     private Gtk.Revealer separator_revealer;
+    public Gtk.Grid drop_target_end;
+    public Gtk.Revealer drop_target_end_revealer;
+
     public signal void add_activated ();
     public signal void row_activated (Gtk.Widget widget);
 
@@ -200,10 +202,6 @@ public class Layouts.HeaderItem : Adw.Bin {
         listbox.set_placeholder (get_placeholder ());
         listbox.add_css_class ("bg-transparent");
 
-        content_grid = new Adw.Bin () {
-            child = listbox
-        };
-
         action_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 6) {
             hexpand = true,
             halign = END
@@ -229,6 +227,18 @@ public class Layouts.HeaderItem : Adw.Bin {
             child = separator
         };
 
+        drop_target_end = new Gtk.Grid () {
+            height_request = 27,
+            css_classes = { "drop-target" },
+            margin_top = 3
+        };
+
+        drop_target_end_revealer = new Gtk.Revealer () {
+            transition_type = SLIDE_UP,
+            transition_duration = 150,
+            child = drop_target_end
+        };
+
         var content_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 0) {
             hexpand = true,
             margin_top = 3
@@ -236,7 +246,8 @@ public class Layouts.HeaderItem : Adw.Bin {
 
         content_box.append (header_box);
         content_box.append (separator_revealer);
-        content_box.append (content_grid);
+        content_box.append (listbox);
+        content_box.append (drop_target_end_revealer);
 
         content_revealer = new Gtk.Revealer () {
             transition_type = Gtk.RevealerTransitionType.SLIDE_DOWN,

--- a/core/Services/EventBus.vala
+++ b/core/Services/EventBus.vala
@@ -57,7 +57,8 @@ public class Services.EventBus : Object {
     public signal void section_sort_order_changed (string project_id);
     public signal void drag_n_drop_active (string project_id, bool active);
     public signal void expand_all (string project_id, bool active);
-    public signal void drag_projects_end (string source_id);
+    public signal void projects_drag_begin (string source_id);
+    public signal void projects_drag_end (string source_id);
     public signal void drag_items_end (string project_id);
     public signal void update_sources_position ();
 

--- a/data/resources/stylesheet/stylesheet.css
+++ b/data/resources/stylesheet/stylesheet.css
@@ -589,7 +589,7 @@ checkbutton.theme-selector radio:checked {
 
 .drop-begin {
     padding: 3px;
-    background: @popover_bg_color;
+    background: @selected_color;
     border-radius: 9px;
     border: 1px solid @item_border_color;
 }

--- a/data/resources/stylesheet/stylesheet.css
+++ b/data/resources/stylesheet/stylesheet.css
@@ -420,7 +420,7 @@ entry.flat:focus-within {
     border-radius: 6px;
     padding: 3px 6px;
     color: @upcoming_fg_color;
-    font-weight: bold;
+    font-weight: 500;
 }
 
 .icon-animation-dropshadow,

--- a/src/Layouts/ItemBoard.vala
+++ b/src/Layouts/ItemBoard.vala
@@ -774,7 +774,7 @@ public class Layouts.ItemBoard : Layouts.ItemBase {
         // Drop Magic Button
         build_drop_magic_button_target ();
 
-        //// Drop Order
+        // Drop Order
         build_drop_order_target ();
     }
 

--- a/src/Layouts/ItemRow.vala
+++ b/src/Layouts/ItemRow.vala
@@ -1485,24 +1485,29 @@ public class Layouts.ItemRow : Layouts.ItemBase {
         drop_motion_ctrl = new Gtk.DropControllerMotion ();
         add_controller (drop_motion_ctrl);
 
-        dnd_handlerses[drop_motion_ctrl.motion.connect ((x, y) => {
+        dnd_handlerses[drop_motion_ctrl.enter.connect ((x, y) => {
             var drop = drop_motion_ctrl.get_drop ();
             GLib.Value value = Value (typeof (Gtk.Widget));
 
             try {
                 drop.drag.content.get_value (ref value);
+
+                if (value.dup_object () is Layouts.ItemRow) {
+                    var picked_widget = (Layouts.ItemBoard) value;
+
+                    if (picked_widget.item.id == item.parent_id) {
+                        return;
+                    }
+
+                    motion_top_grid.height_request = picked_widget.handle_grid.get_height ();
+                    motion_top_revealer.reveal_child = drop_motion_ctrl.contains_pointer;
+                } else if (value.dup_object () is Widgets.MagicButton) {
+                    motion_top_grid.height_request = 32;
+                    motion_top_revealer.reveal_child = drop_motion_ctrl.contains_pointer;
+                }
             } catch (Error e) {
                 debug (e.message);
             }
-
-            if (value.dup_object () is Layouts.ItemBoard) {
-                var picked_widget = (Layouts.ItemBoard) value;
-                motion_top_grid.height_request = picked_widget.handle_grid.get_height ();
-            } else {
-                motion_top_grid.height_request = 32;
-            }
-
-            motion_top_revealer.reveal_child = drop_motion_ctrl.contains_pointer;
         })] = drop_motion_ctrl;
 
         dnd_handlerses[drop_motion_ctrl.leave.connect (() => {

--- a/src/Widgets/ReorderChild.vala
+++ b/src/Widgets/ReorderChild.vala
@@ -133,10 +133,6 @@ public class Widgets.ReorderChild : Adw.Bin {
         row.add_controller (drop_motion_ctrl);
 
         signal_map[drop_motion_ctrl.motion.connect ((x, y) => {
-            var listbox_parent = row.parent as Gtk.ListBox;
-            if (listbox_parent == null)
-                return;
-
             var row_height = row.get_height ();
             bool is_top_half = (y < row_height / 2);
 
@@ -150,7 +146,7 @@ public class Widgets.ReorderChild : Adw.Bin {
         })] = drop_motion_ctrl;
     }
 
-    private bool on_drop (GLib.Value value, double x, double y, bool last = false) {
+    private bool on_drop (GLib.Value value, double x, double y, bool bottom = false) {
         var picked_widget = (Widgets.ReorderChild) value;
         var target_widget = this;
 
@@ -167,7 +163,7 @@ public class Widgets.ReorderChild : Adw.Bin {
         var target_list = (Gtk.ListBox) target_widget.row.parent;
 
         source_list.remove (picked_widget.row);
-        target_list.insert (picked_widget.row, target_widget.row.get_index () + (last ? 1 : 0));
+        target_list.insert (picked_widget.row, target_widget.row.get_index () + (bottom ? 1 : 0));
 
         on_drop_end (target_list);
         return true;

--- a/src/Widgets/ReorderChild.vala
+++ b/src/Widgets/ReorderChild.vala
@@ -62,7 +62,7 @@ public class Widgets.ReorderChild : Adw.Bin {
         };
 
         motion_top_revealer = new Gtk.Revealer () {
-            transition_type = Gtk.RevealerTransitionType.SLIDE_UP,
+            transition_type = SLIDE_UP,
             transition_duration = 150,
             child = motion_top_grid
         };
@@ -72,7 +72,7 @@ public class Widgets.ReorderChild : Adw.Bin {
         };
 
         motion_bottom_revealer = new Gtk.Revealer () {
-            transition_type = Gtk.RevealerTransitionType.SLIDE_DOWN,
+            transition_type = SLIDE_DOWN,
             transition_duration = 150,
             child = motion_bottom_grid
         };
@@ -83,7 +83,7 @@ public class Widgets.ReorderChild : Adw.Bin {
         main_box.append (motion_bottom_revealer);
 
         main_revealer = new Gtk.Revealer () {
-            transition_type = Gtk.RevealerTransitionType.SLIDE_DOWN,
+            transition_type = SLIDE_DOWN,
             child = main_box,
             reveal_child = true
         };

--- a/src/Widgets/SyncButton.vala
+++ b/src/Widgets/SyncButton.vala
@@ -35,12 +35,12 @@ public class Widgets.SyncButton : Adw.Bin {
     construct {
         sync_button = new Gtk.Button.from_icon_name ("update-symbolic") {
             valign = Gtk.Align.CENTER,
-            css_classes = { "flat", "header-item-button", "dimmed" }
+            css_classes = { "flat", "header-item-button" }
         };
 
         var error_button = new Gtk.Button.from_icon_name ("dialog-warning-symbolic") {
             valign = Gtk.Align.CENTER,
-            css_classes = { "flat", "header-item-button", "dimmed" }
+            css_classes = { "flat", "header-item-button" }
         };
 
         stack = new Gtk.Stack () {


### PR DESCRIPTION
Previously, it was not possible to drop items at the end of the list when reordering.
This change introduces a new widget that acts as a drop target for the last position,
allowing users to reorder elements to the end more intuitively.

- Added dedicated widget for drop at the bottom.
- Improved motion handling logic to detect last row and decide between top/bottom revealers.
- Cleaned up the motion signal code for readability and consistency.

Fixes: #1522