### PR TITLE
Add search entry to project selection when moving tasks

### DIFF
--- a/src/Dialogs/ProjectPicker/ProjectPickerSourceRow.vala
+++ b/src/Dialogs/ProjectPicker/ProjectPickerSourceRow.vala
@@ -43,7 +43,6 @@ public class Dialogs.ProjectPicker.ProjectPickerSourceRow : Gtk.ListBoxRow {
         };
 
         child = group;
-
         add_projects ();
     }
 
@@ -55,5 +54,21 @@ public class Dialogs.ProjectPicker.ProjectPickerSourceRow : Gtk.ListBoxRow {
 
             group.add_child (new Dialogs.ProjectPicker.ProjectPickerRow (project));
         }
+    }
+
+    public void filter (string search) {
+        int size = 0;
+        group.set_filter_func ((row) => {
+            var project = ((Dialogs.ProjectPicker.ProjectPickerRow) row).project;
+            var return_value = search.down () in project.name.down ();
+
+            if (return_value) {
+                size++;
+            }
+
+            return return_value;
+        });
+
+        group.reveal_child = size > 0;
     }
 }


### PR DESCRIPTION
This PR adds a search entry to the project selection dialog.
It allows users to quickly filter and find a project when moving a task, making the process faster and more convenient.

<img width="442" height="582" alt="image" src="https://github.com/user-attachments/assets/70bb89ec-d1c0-457a-bb03-ddb14ea5e3ad" />

FIxes: #1586