### PR TITLE
Add "Today" section to the Scheduled view

### DIFF
--- a/src/Views/Scheduled/Scheduled.vala
+++ b/src/Views/Scheduled/Scheduled.vala
@@ -165,7 +165,7 @@ public class Views.Scheduled.Scheduled : Adw.Bin {
         });
 
         scrolled_window.vadjustment.value_changed.connect (() => {
-            headerbar.revealer_title_box (scrolled_window.vadjustment.value >= Constants.HEADERBAR_TITLE_SCROLL_THRESHOLD);            
+            headerbar.revealer_title_box (scrolled_window.vadjustment.value >= Constants.HEADERBAR_TITLE_SCROLL_THRESHOLD);
         });
     }
 
@@ -179,10 +179,12 @@ public class Views.Scheduled.Scheduled : Adw.Bin {
             days_to_iterate += remaining_days;
         }
 
+        var row = new Views.Scheduled.ScheduledDay (date);
+        listbox.append (row);
+
         for (int i = 0; i < days_to_iterate; i++) {
             date = date.add_days (1);
-
-            var row = new Views.Scheduled.ScheduledDay (date);
+            row = new Views.Scheduled.ScheduledDay (date);
             listbox.append (row);
         }
 
@@ -190,14 +192,12 @@ public class Views.Scheduled.Scheduled : Adw.Bin {
         remaining_days = month_days - date.get_day_of_month ();
 
         if (remaining_days > 3) {
-            var row = new Views.Scheduled.ScheduledRange (date.add_days (1), date.add_days (remaining_days));
-            listbox.append (row);
+            listbox.append (new Views.Scheduled.ScheduledRange (date.add_days (1), date.add_days (remaining_days)));
         }
 
         for (int i = 0; i < 4; i++) {
             date = date.add_months (1);
-            var row = new Views.Scheduled.ScheduledMonth (date);
-            listbox.append (row);
+            listbox.append (new Views.Scheduled.ScheduledMonth (date));
         }
     }
 


### PR DESCRIPTION
This PR adds a Today section inside the Scheduled view.

The change was made in response to user feedback requesting the ability to see both today’s and upcoming scheduled tasks in one place, without switching between two separate views.

This improves planning for the whole week at a glance and aligns with how some users prefer to manage their schedules.

Fixes: #1550