### PR TITLE
Default label prefill when creating a task inside a label window

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -498,9 +498,10 @@ public class MainWindow : Adw.ApplicationWindow {
                 scheduled_view.prepare_new_item (content);
             }
         } else if (views_stack.visible_child_name.has_prefix ("labels-view")) {
-            var dialog = new Dialogs.QuickAdd ();
-            dialog.update_content (content);
-            dialog.present (Planify._instance.main_window);
+            Views.Labels ? labels_view = (Views.Labels) views_stack.visible_child;
+            if (labels_view != null) {
+                labels_view.prepare_new_item (content);
+            }
         } else if (views_stack.visible_child_name.has_prefix ("label-view")) {
             Views.Label ? label_view = (Views.Label) views_stack.visible_child;
             if (label_view != null) {

--- a/src/Views/Label/Label.vala
+++ b/src/Views/Label/Label.vala
@@ -124,9 +124,19 @@ public class Views.Label : Adw.Bin {
             child = content_clamp
         };
 
+        var magic_button = new Widgets.MagicButton ();
+
+        var content_overlay = new Gtk.Overlay () {
+            hexpand = true,
+            vexpand = true,
+            child = scrolled_window
+        };
+
+        content_overlay.add_overlay (magic_button);
+
         var toolbar_view = new Adw.ToolbarView ();
         toolbar_view.add_top_bar (headerbar);
-        toolbar_view.content = scrolled_window;
+        toolbar_view.content = content_overlay;
 
         child = toolbar_view;
 
@@ -149,6 +159,10 @@ public class Views.Label : Adw.Bin {
         
         scrolled_window.vadjustment.value_changed.connect (() => {
             headerbar.revealer_title_box (scrolled_window.vadjustment.value >= Constants.HEADERBAR_TITLE_SCROLL_THRESHOLD);            
+        });
+
+        magic_button.clicked.connect (() => {
+            prepare_new_item ();
         });
     }
 
@@ -212,6 +226,11 @@ public class Views.Label : Adw.Bin {
     public void prepare_new_item (string content = "") {
         var dialog = new Dialogs.QuickAdd ();
         dialog.update_content (content);
+        
+        var labels_map = new Gee.HashMap<string, Objects.Label> ();
+        labels_map.set (label.id, label);
+        dialog.set_labels (labels_map);
+
         dialog.present (Planify._instance.main_window);
     }
 }

--- a/src/Views/Label/Labels.vala
+++ b/src/Views/Label/Labels.vala
@@ -86,9 +86,19 @@ public class Views.Labels : Adw.Bin {
             child = content_clamp
         };
 
+        var magic_button = new Widgets.MagicButton ();
+
+        var content_overlay = new Gtk.Overlay () {
+            hexpand = true,
+            vexpand = true,
+            child = scrolled_window
+        };
+
+        content_overlay.add_overlay (magic_button);
+
         var toolbar_view = new Adw.ToolbarView ();
         toolbar_view.add_top_bar (headerbar);
-        toolbar_view.content = scrolled_window;
+        toolbar_view.content = content_overlay;
 
         child = toolbar_view;
 
@@ -107,6 +117,10 @@ public class Views.Labels : Adw.Bin {
         scrolled_window.vadjustment.value_changed.connect (() => {
             headerbar.revealer_title_box (scrolled_window.vadjustment.value >= Constants.HEADERBAR_TITLE_SCROLL_THRESHOLD);            
         });
+
+        magic_button.clicked.connect (() => {
+            prepare_new_item ();
+        });
     }
 
     private void add_source_row (Objects.Source source) {
@@ -114,5 +128,11 @@ public class Views.Labels : Adw.Bin {
             sources_hashmap[source.id] = new Views.LabelSourceRow (source);
             sources_listbox.append (sources_hashmap[source.id]);
         }
+    }
+
+    public void prepare_new_item (string content = "") {
+        var dialog = new Dialogs.QuickAdd ();
+        dialog.update_content (content);
+        dialog.present (Planify._instance.main_window);
     }
 }


### PR DESCRIPTION
This PR implements the default tag filling for new tasks when created inside a tag window.
When a user is viewing a specific tag, any new task created will automatically include that tag. The tag can still be removed manually if not desired.

Fixes #1525