### PR TITLE
Remove invalid css property

### DIFF
--- a/data/resources/stylesheet/stylesheet.css
+++ b/data/resources/stylesheet/stylesheet.css
@@ -691,7 +691,6 @@ checkbutton.theme-selector radio:checked {
     font-weight: bold;
     color: @colorAccent;
     transition: all 150ms ease-out;
-    pointer-events: none;
 }
 
 .priority-label-impact {


### PR DESCRIPTION
This property doesn't exist in GTK.

```
(io.github.alainm23.planify.Devel:2): Gtk-WARNING **: 23:00:00.494: Theme parser error: stylesheet.css:694:5-19: No property named "pointer-events"
```