### PR TITLE
Fix CalDAV project creation - save calendar URL to database

### DIFF
--- a/core/Services/CalDAV/CalDAVClient.vala
+++ b/core/Services/CalDAV/CalDAVClient.vala
@@ -459,13 +459,17 @@ public class Services.CalDAV.CalDAVClient : Services.CalDAV.WebDAVClient {
         </d:mkcol>
         """.printf (project.name, project.color_hex);
 
-        var url = "%s/%s".printf (project.source.caldav_data.calendar_home_url, project.id);
+        var calendar_url = GLib.Uri.resolve_relative (project.source.caldav_data.calendar_home_url, project.id, GLib.UriFlags.NONE);
+        if (!calendar_url.has_suffix ("/")) {
+            calendar_url += "/";
+        }
 
         HttpResponse response = new HttpResponse ();
 
         try {
-            yield send_request ("MKCOL", url, "application/xml", xml, null, null,
+            yield send_request ("MKCOL", calendar_url, "application/xml", xml, null, null,
                                 { Soup.Status.CREATED });
+            project.calendar_url = calendar_url;
             response.status = true;
         } catch (Error e) {
             response.error_code = e.code;

--- a/core/Services/CalDAV/CalDAVClient.vala
+++ b/core/Services/CalDAV/CalDAVClient.vala
@@ -440,7 +440,6 @@ public class Services.CalDAV.CalDAVClient : Services.CalDAV.WebDAVClient {
         try {
             yield send_request ("MKCOL", url, "application/xml", xml, null, null,
                                 { Soup.Status.CREATED });
-
             response.status = true;
         } catch (Error e) {
             response.error_code = e.code;

--- a/src/Dialogs/Project.vala
+++ b/src/Dialogs/Project.vala
@@ -436,7 +436,6 @@ public class Dialogs.Project : Adw.Dialog {
                 if (response.status) {
                     Services.Store.instance ().insert_project (project);
                     caldav_client.update_sync_token.begin (project, new GLib.Cancellable ());
-                    print ("%s\n".printf (project.to_string ()));
                     go_project (project.id);
                 } else {
                     Services.EventBus.get_default ().send_error_toast (response.error_code, response.error);

--- a/src/Dialogs/Project.vala
+++ b/src/Dialogs/Project.vala
@@ -436,6 +436,7 @@ public class Dialogs.Project : Adw.Dialog {
                 if (response.status) {
                     Services.Store.instance ().insert_project (project);
                     caldav_client.update_sync_token.begin (project, new GLib.Cancellable ());
+                    print ("%s\n".printf (project.to_string ()));
                     go_project (project.id);
                 } else {
                     Services.EventBus.get_default ().send_error_toast (response.error_code, response.error);


### PR DESCRIPTION
Fixes newly created CalDAV projects being unusable until next sync. The issue was that calendar_url wasn't being saved to the database after project creation on the server.

**Solution**

Ensure `calendar_url` is properly set and saved when creating CalDAV projects by updating the project in the database after successful server creation.