### PR TITLE
Fix spacing issue in Inbox Pinboard using Adw.WrapBox

### DIFF
--- a/core/Objects/Item.vala
+++ b/core/Objects/Item.vala
@@ -410,8 +410,6 @@ public class Objects.Item : Objects.BaseObject {
     }
 
     public void patch_from_vtodo (string data, string _ical_url, bool is_update = false) {
-        print ("\nICAL DATA:\n%s\n", data);
-
         ICal.Component ical = ICal.Parser.parse_string (data);
         ICal.Component ? ical_vtodo = ical.get_first_component (ICal.ComponentKind.VTODO_COMPONENT);
         ECal.Component ecal = new ECal.Component.from_icalcomponent (ical_vtodo);

--- a/core/Objects/Item.vala
+++ b/core/Objects/Item.vala
@@ -410,6 +410,8 @@ public class Objects.Item : Objects.BaseObject {
     }
 
     public void patch_from_vtodo (string data, string _ical_url, bool is_update = false) {
+        print ("\nICAL DATA:\n%s\n", data);
+
         ICal.Component ical = ICal.Parser.parse_string (data);
         ICal.Component ? ical_vtodo = ical.get_first_component (ICal.ComponentKind.VTODO_COMPONENT);
         ECal.Component ecal = new ECal.Component.from_icalcomponent (ical_vtodo);

--- a/src/Layouts/ItemBoard.vala
+++ b/src/Layouts/ItemBoard.vala
@@ -63,20 +63,37 @@ public class Layouts.ItemBoard : Layouts.ItemBase {
     public bool is_loading {
         set {
             _is_loading = value;
-
-            if (_is_loading) {
-                hide_loading_revealer.reveal_child = _is_loading;
-                hide_loading_button.is_loading = _is_loading;
-            } else {
-                hide_loading_button.is_loading = _is_loading;
-                hide_loading_revealer.reveal_child = false;
-            }
+            
+            hide_loading_button.is_loading = _is_loading;
+            set_loading_state (_is_loading);
         }
 
         get {
             return _is_loading;
         }
     }
+
+    private bool _pin_mode = false;
+    public bool pin_mode {
+        get {
+            return _pin_mode;
+        }
+        set {
+            _pin_mode = value;
+
+            if (_pin_mode) {
+                hide_loading_revealer.reveal_child = true;
+                card_widget.margin_end = 6;
+                card_widget.margin_top = 6;
+                handle_grid.width_request = 200;
+            } else {
+                card_widget.margin_end = 0;
+                card_widget.margin_top = 0;
+                handle_grid.width_request = -1;
+            }
+        }
+}
+
 
     public bool on_drag = false;
     private Gee.HashMap<ulong, GLib.Object> signals_map = new Gee.HashMap<ulong, GLib.Object> ();
@@ -129,8 +146,6 @@ public class Layouts.ItemBoard : Layouts.ItemBase {
         hide_loading_button = new Widgets.LoadingButton.with_icon ("window-close", 16) {
             valign = Gtk.Align.CENTER,
             halign = Gtk.Align.CENTER,
-            margin_top = 7,
-            margin_end = 7,
             tooltip_text = _ ("Unpin"),
             css_classes = { "min-height-0", "view-button" }
         };
@@ -1119,12 +1134,12 @@ public class Layouts.ItemBoard : Layouts.ItemBase {
         main_revealer.reveal_child = false;
     }
 
-    public void activate_pin_view () {
-        hide_loading_revealer.reveal_child = true;
-        handle_grid.margin_top = 3;
-        handle_grid.margin_start = 3;
-        handle_grid.margin_end = 6;
-        handle_grid.width_request = 200;
+    private void set_loading_state (bool loading) {
+        if (pin_mode) {
+            hide_loading_revealer.reveal_child = true;
+        } else {
+            hide_loading_revealer.reveal_child = loading;
+        }
     }
 
     public void clean_up () {

--- a/src/Widgets/PinnedItemsFlowBox.vala
+++ b/src/Widgets/PinnedItemsFlowBox.vala
@@ -22,7 +22,7 @@
 public class Widgets.PinnedItemsFlowBox : Adw.Bin {
     public Objects.Project project { get; construct; }
 
-    private Gtk.Box box_layout;
+    private Adw.WrapBox box_layout;
     private Gtk.Revealer main_revealer;
     public Gee.HashMap<string, Layouts.ItemBoard> items_map = new Gee.HashMap<string, Layouts.ItemBoard> ();
 
@@ -37,19 +37,13 @@ public class Widgets.PinnedItemsFlowBox : Adw.Bin {
     }
 
     construct {
-        box_layout = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 6) {
+        box_layout = new Adw.WrapBox () {
             margin_start = 20,
             margin_end = 24,
             margin_top = 12,
-            homogeneous = true,
-            halign = Gtk.Align.START
+            child_spacing = 12,
+            halign = START
         };
-
-        if (Services.EventBus.get_default ().mobile_mode) {
-            box_layout.orientation = Gtk.Orientation.VERTICAL;
-        } else {
-            box_layout.orientation = Gtk.Orientation.HORIZONTAL;
-        }
 
         main_revealer = new Gtk.Revealer () {
             transition_type = Gtk.RevealerTransitionType.SLIDE_DOWN,
@@ -59,11 +53,6 @@ public class Widgets.PinnedItemsFlowBox : Adw.Bin {
 
         child = main_revealer;
         add_items ();
-        update_box_layout ();
-
-        Services.EventBus.get_default ().mobile_mode_change.connect (() => {
-            update_box_layout ();
-        });
 
         project.item_added.connect ((item) => {
             add_item (item);
@@ -116,25 +105,12 @@ public class Widgets.PinnedItemsFlowBox : Adw.Bin {
         }
 
         items_map[item.id] = new Layouts.ItemBoard (item) {
-            hexpand = true
+            hexpand = true,
+            pin_mode = true
         };
-
-        items_map[item.id].activate_pin_view ();
 
         box_layout.append (items_map[item.id]);
         check_reveal_child ();
-    }
-
-    private void update_box_layout () {
-        if (Services.EventBus.get_default ().mobile_mode) {
-            box_layout.orientation = Gtk.Orientation.VERTICAL;
-            box_layout.homogeneous = false;
-            box_layout.halign = Gtk.Align.FILL;
-        } else {
-            box_layout.orientation = Gtk.Orientation.HORIZONTAL;
-            box_layout.homogeneous = true;
-            box_layout.halign = Gtk.Align.START;
-        }
     }
 
     private void update_pinboard (Objects.Item item) {


### PR DESCRIPTION
This PR fixes the issue where pinned tasks in the Inbox Pinboard were being cut off both vertically and horizontally when resizing or maximizing the window.

Changes

- Replaced the previous container with `Adw.WrapBox` to handle layout properly.
- Ensures long pinned tasks wrap correctly instead of being cut off.
- Improves responsiveness by dynamically adjusting pinned tasks when resizing the window.

Fixes: #1761