### PR TITLE
Fix Memory Leaks in ItemRow and SubItems Widgets

### DIFF
--- a/core/Widgets/ContextMenu/MenuItem.vala
+++ b/core/Widgets/ContextMenu/MenuItem.vala
@@ -125,10 +125,6 @@ public class Widgets.ContextMenu.MenuItem : Gtk.Button {
         );
     }
 
-    ~MenuItem () {
-        print ("Destroying - Widgets.ContextMenu.MenuItem\n");
-    }
-
     construct {
         add_css_class ("flat");
         add_css_class ("no-font-bold");

--- a/core/Widgets/ContextMenu/MenuSeparator.vala
+++ b/core/Widgets/ContextMenu/MenuSeparator.vala
@@ -19,11 +19,7 @@
  * Authored by: Alain M. <alainmh23@gmail.com>
  */
 
-public class Widgets.ContextMenu.MenuSeparator : Adw.Bin {
-    ~MenuSeparator () {
-        print ("Destroying - Widgets.ContextMenu.MenuSeparator\n");
-    }
-    
+public class Widgets.ContextMenu.MenuSeparator : Adw.Bin {    
     construct {
         child = new Gtk.Separator (Gtk.Orientation.HORIZONTAL) {
             margin_top = 6,

--- a/core/Widgets/ContextMenu/MenuSwitch.vala
+++ b/core/Widgets/ContextMenu/MenuSwitch.vala
@@ -63,11 +63,7 @@ public class Widgets.ContextMenu.MenuSwitch : Gtk.Button {
             hexpand: true
         );
     }
-
-    ~MenuSwitch () {
-        print ("Destroying - Widgets.ContextMenu.MenuSwitch\n");
-    }
-
+    
     construct {
         add_css_class ("flat");
         add_css_class ("no-font-bold");

--- a/core/Widgets/ItemLabels.vala
+++ b/core/Widgets/ItemLabels.vala
@@ -32,6 +32,7 @@ public class Widgets.ItemLabels : Adw.Bin {
     private Gtk.Revealer main_revealer;
 
     private Gee.HashMap<string, Widgets.ItemLabelChild> item_labels_map = new Gee.HashMap<string, Widgets.ItemLabelChild> ();
+    private Gee.HashMap<ulong, GLib.Object> signal_map = new Gee.HashMap<ulong, GLib.Object> ();
 
     public ItemLabels (Objects.Item item) {
         Object (
@@ -43,6 +44,10 @@ public class Widgets.ItemLabels : Adw.Bin {
         set {
             flowbox.margin_top = value;
         }
+    }
+
+    ~ItemLabels () {
+        print ("Destroying - Widgets.ItemLabels\n");
     }
 
     construct {
@@ -64,13 +69,13 @@ public class Widgets.ItemLabels : Adw.Bin {
         child = main_revealer;
         add_labels ();
 
-        item.item_label_deleted.connect ((label) => {
+        signal_map[item.item_label_deleted.connect ((label) => {
             remove_item_label (label);
-        });
+        })] = item;
 
-        item.item_label_added.connect ((label) => {
+        signal_map[item.item_label_added.connect ((label) => {
             add_item_label (label);
-        });
+        })] = item;
     }
 
     public void add_labels () {
@@ -110,5 +115,17 @@ public class Widgets.ItemLabels : Adw.Bin {
         }
 
         item_labels_map.clear ();
+    }
+
+    public void clean_up () {
+        foreach (var entry in signal_map.entries) {
+            entry.value.disconnect (entry.key);
+        }
+
+        signal_map.clear ();
+
+        foreach (Widgets.ItemLabelChild item_label_row in item_labels_map.values) {
+            item_label_row.clean_up ();
+        }
     }
 }

--- a/src/Layouts/ItemBase.vala
+++ b/src/Layouts/ItemBase.vala
@@ -24,9 +24,12 @@ public abstract class Layouts.ItemBase : Gtk.ListBoxRow {
 
     public string update_id { get; set; default = Util.get_default ().generate_id (); }
 
+    public Gee.HashMap<ulong, GLib.Object> signals_map = new Gee.HashMap<ulong, GLib.Object> ();
+
     public abstract void update_request ();
     public abstract void hide_destroy ();
     public abstract void delete_request (bool undo = true);
     public abstract void select_row (bool active);
     public abstract void checked_toggled (bool active, uint ? time = null);
+    public abstract void clean_up ();
 }

--- a/src/Layouts/ItemBoard.vala
+++ b/src/Layouts/ItemBoard.vala
@@ -96,7 +96,6 @@ public class Layouts.ItemBoard : Layouts.ItemBase {
 
 
     public bool on_drag = false;
-    private Gee.HashMap<ulong, GLib.Object> signals_map = new Gee.HashMap<ulong, GLib.Object> ();
 
     public ItemBoard (Objects.Item item) {
         Object (
@@ -450,9 +449,9 @@ public class Layouts.ItemBoard : Layouts.ItemBase {
             item.update_pin (false);
         })] = hide_loading_button;
 
-        activate.connect (() => {
+        signals_map[activate.connect (() => {
             open_detail ();
-        });
+        })] = this;
     }
 
     private void update_next_recurrency () {
@@ -1128,14 +1127,13 @@ public class Layouts.ItemBoard : Layouts.ItemBase {
         }
     }
 
-    public void clean_up () {
-        // Clear Signals
+    public override void clean_up () {
         foreach (var entry in signals_map.entries) {
             entry.value.disconnect (entry.key);
         }
 
         signals_map.clear ();
 
-        menu_handle_popover.unparent ();
+        labels_summary.clean_up ();
     }
 }

--- a/src/Layouts/ItemRow.vala
+++ b/src/Layouts/ItemRow.vala
@@ -95,7 +95,6 @@ public class Layouts.ItemRow : Layouts.ItemBase {
     
     private Gee.HashMap<ulong, weak GLib.Object> dnd_handlerses = new Gee.HashMap<ulong, weak GLib.Object> ();
     private ulong description_handler_change_id = 0;
-    private Gee.HashMap<ulong, weak GLib.Object> signals_map = new Gee.HashMap<ulong, weak GLib.Object> ();
 
     bool _edit = false;
     public bool edit {
@@ -1776,26 +1775,17 @@ public class Layouts.ItemRow : Layouts.ItemBase {
         });
     }
 
-    public void clean_up () {
-        if (menu_handle_popover != null) {
-            menu_handle_popover.unparent ();
-            menu_handle_popover = null;
-        }
-
+    public override void clean_up () {
         foreach (var entry in signals_map.entries) {
-            if (SignalHandler.is_connected (entry.value, entry.key)) {
-                entry.value.disconnect (entry.key);
-            }
+            entry.value.disconnect (entry.key);
         }
 
         signals_map.clear ();
 
         foreach (var entry in dnd_handlerses.entries) {
-            if (SignalHandler.is_connected (entry.value, entry.key)) {
-                entry.value.disconnect (entry.key);
-            }
+            entry.value.disconnect (entry.key);
         }
-        
+
         dnd_handlerses.clear ();
 
         if (description_handler_change_id != 0) {
@@ -1805,6 +1795,13 @@ public class Layouts.ItemRow : Layouts.ItemBase {
 
         subitems.clean_up ();
         attachments.clean_up ();
+        item_labels.clean_up ();
+        schedule_button.clean_up ();
+        // labels_summary.clean_up ();
+        priority_button.clean_up ();
+        label_button.clean_up ();
+        // pin_button.clean_up ();
+        reminder_button.clean_up ();
         
         current_buffer = null;
         markdown_edit_view = null;

--- a/src/Layouts/ItemRow.vala
+++ b/src/Layouts/ItemRow.vala
@@ -1797,10 +1797,8 @@ public class Layouts.ItemRow : Layouts.ItemBase {
         attachments.clean_up ();
         item_labels.clean_up ();
         schedule_button.clean_up ();
-        // labels_summary.clean_up ();
         priority_button.clean_up ();
         label_button.clean_up ();
-        // pin_button.clean_up ();
         reminder_button.clean_up ();
         
         current_buffer = null;

--- a/src/Layouts/SectionBoard.vala
+++ b/src/Layouts/SectionBoard.vala
@@ -85,7 +85,7 @@ public class Layouts.SectionBoard : Gtk.FlowBoxChild {
     }
 
     ~SectionBoard () {
-        print ("Destroying Layouts.SectionBoard\n");
+        print ("Destroying - Layouts.SectionBoard\n");
     }
 
     construct {

--- a/src/Layouts/SectionRow.vala
+++ b/src/Layouts/SectionRow.vala
@@ -96,7 +96,7 @@ public class Layouts.SectionRow : Gtk.ListBoxRow {
     }
 
     ~SectionRow () {
-        print ("Destroying Layouts.SectionRow\n");
+        print ("Destroying - Layouts.SectionRow\n");
     }
 
     construct {

--- a/src/Widgets/LabelsSummary.vala
+++ b/src/Widgets/LabelsSummary.vala
@@ -50,7 +50,7 @@ public class Widgets.LabelsSummary : Adw.Bin {
     }
 
     ~LabelsSummary () {
-        print ("Destroying - Widgets.LabelsSummary - %s\n".printf (item.content));
+        print ("Destroying - Widgets.LabelsSummary\n");
     }
 
     construct {
@@ -145,5 +145,9 @@ public class Widgets.LabelsSummary : Adw.Bin {
 
     public void check_revealer () {
         revealer.reveal_child = labels.size > 0;
+    }
+
+    public void clean_up () {
+
     }
 }

--- a/src/Widgets/SubItems.vala
+++ b/src/Widgets/SubItems.vala
@@ -34,7 +34,7 @@ public class Widgets.SubItems : Adw.Bin {
     private Gtk.Revealer main_revealer;
     public Widgets.LoadingButton add_button;
 
-    private Gee.HashMap<ulong, GLib.Object> signals_map = new Gee.HashMap<ulong, GLib.Object> ();
+    private Gee.HashMap<ulong, GLib.Object> signal_map = new Gee.HashMap<ulong, GLib.Object> ();
     public Gee.HashMap<string, Layouts.ItemBase> items_map = new Gee.HashMap<string, Layouts.ItemBase> ();
     public Gee.HashMap<string, Layouts.ItemBase> items_checked = new Gee.HashMap<string, Layouts.ItemBase> ();
 
@@ -85,7 +85,7 @@ public class Widgets.SubItems : Adw.Bin {
     }
 
     ~SubItems () {
-        print ("Destroying Widgets.SubItems\n");
+        print ("Destroying - Widgets.SubItems\n");
     }
 
     construct {
@@ -180,9 +180,9 @@ public class Widgets.SubItems : Adw.Bin {
         add_items ();
         checked_revealer.reveal_child = show_completed;
 
-        signals_map[item_parent.item_added.connect (add_item)] = item_parent;
+        signal_map[item_parent.item_added.connect (add_item)] = item_parent;
 
-        signals_map[Services.Store.instance ().item_updated.connect ((item, update_id) => {
+        signal_map[Services.Store.instance ().item_updated.connect ((item, update_id) => {
             if (items_map.has_key (item.id)) {
                 if (items_map[item.id].update_id != update_id) {
                     items_map[item.id].update_request ();
@@ -195,7 +195,7 @@ public class Widgets.SubItems : Adw.Bin {
             }
         })] = Services.Store.instance ();
 
-        signals_map[Services.Store.instance ().item_pin_change.connect ((item) => {
+        signal_map[Services.Store.instance ().item_pin_change.connect ((item) => {
             // vala-lint=no-space
             if (!item.pinned && item.parent_id == item_parent.id &&
                 !items_map.has_key (item.id)) {
@@ -208,7 +208,7 @@ public class Widgets.SubItems : Adw.Bin {
             }
         })] = Services.Store.instance ();
 
-        signals_map[Services.Store.instance ().item_deleted.connect ((item) => {
+        signal_map[Services.Store.instance ().item_deleted.connect ((item) => {
             if (items_map.has_key (item.id)) {
                 items_map[item.id].hide_destroy ();
                 items_map.unset (item.id);
@@ -222,7 +222,7 @@ public class Widgets.SubItems : Adw.Bin {
             children_changes ();
         })] = Services.Store.instance ();
 
-        signals_map[Services.EventBus.get_default ().item_moved.connect ((item, old_project_id, old_section_id, old_parent_id) => {
+        signal_map[Services.EventBus.get_default ().item_moved.connect ((item, old_project_id, old_section_id, old_parent_id) => {
             if (old_parent_id == item_parent.id) {
                 if (items_map.has_key (item.id)) {
                     items_map[item.id].hide_destroy ();
@@ -243,7 +243,7 @@ public class Widgets.SubItems : Adw.Bin {
             children_changes ();
         })] = Services.EventBus.get_default ();
 
-        signals_map[Services.EventBus.get_default ().checked_toggled.connect ((item, old_checked) => {
+        signal_map[Services.EventBus.get_default ().checked_toggled.connect ((item, old_checked) => {
             if (item.parent_id == item_parent.id) {
                 if (!old_checked) {
                     if (items_map.has_key (item.id)) {
@@ -282,7 +282,7 @@ public class Widgets.SubItems : Adw.Bin {
             }
         })] = Services.EventBus.get_default ();
 
-        signals_map[Services.EventBus.get_default ().update_inserted_item_map.connect ((_row, old_section_id, old_parent_id) => {
+        signal_map[Services.EventBus.get_default ().update_inserted_item_map.connect ((_row, old_section_id, old_parent_id) => {
             if (!is_board) {
                 var row = (Layouts.ItemRow) _row;
 
@@ -300,26 +300,26 @@ public class Widgets.SubItems : Adw.Bin {
             }
         })] = Services.EventBus.get_default ();
 
-        signals_map[add_button.clicked.connect (() => {
+        signal_map[add_button.clicked.connect (() => {
             prepare_new_item ();
         })] = add_button;
 
-        signals_map[item_parent.project.sort_order_changed.connect (() => {
+        signal_map[item_parent.project.sort_order_changed.connect (() => {
             update_sort ();
         })] = item_parent.project;
 
-        signals_map[item_parent.project.sorted_by_changed.connect (() => {
+        signal_map[item_parent.project.sorted_by_changed.connect (() => {
             update_sort ();
         })] = item_parent.project;
 
-        signals_map[Services.Settings.get_default ().settings.changed["always-show-completed-subtasks"].connect (() => {
+        signal_map[Services.Settings.get_default ().settings.changed["always-show-completed-subtasks"].connect (() => {
             checked_revealer.reveal_child = show_completed;
             if (show_completed) {
                 add_completed_items ();
             }
         })] = Services.Settings.get_default ().settings;
 
-        signals_map[Services.EventBus.get_default ().expand_all.connect ((project_id, value) => {
+        signal_map[Services.EventBus.get_default ().expand_all.connect ((project_id, value) => {
             if (item_parent.project_id == project_id) {
                 foreach (Layouts.ItemBase row_base in items_map.values) {
                     if (row_base is Layouts.ItemRow) {
@@ -329,7 +329,7 @@ public class Widgets.SubItems : Adw.Bin {
             }
         })] = Services.Settings.get_default ();
 
-        signals_map[item_parent.project.show_completed_changed.connect (() => {
+        signal_map[item_parent.project.show_completed_changed.connect (() => {
             if (!Services.Settings.get_default ().settings.get_boolean ("always-show-completed-subtasks")) {
                 checked_revealer.reveal_child = show_completed;
 
@@ -345,7 +345,7 @@ public class Widgets.SubItems : Adw.Bin {
             }
         })] = item_parent.project;
 
-        signals_map[load_more_button.clicked.connect (() => {
+        signal_map[load_more_button.clicked.connect (() => {
             load_next_completed_page ();
         })] = load_more_button;
     }
@@ -498,11 +498,19 @@ public class Widgets.SubItems : Adw.Bin {
     public void clean_up () {
         listbox.set_sort_func (null);
 
-        foreach (var entry in signals_map.entries) {
+        foreach (var row in Util.get_default ().get_children (listbox)) {
+            (row as Layouts.ItemBase).clean_up ();  
+        }
+
+        foreach (var row in Util.get_default ().get_children (checked_listbox)) {
+            (row as Layouts.ItemBase).clean_up ();  
+        }
+
+        foreach (var entry in signal_map.entries) {
             entry.value.disconnect (entry.key);
         }
 
-        signals_map.clear ();
+        signal_map.clear ();
     }
 
     public void disable_drag_and_drop () {


### PR DESCRIPTION
Fixes memory leaks in ItemRow and SubItems widgets by properly cleaning up event controllers, gesture handlers, and circular references that prevented proper object destruction.