### PR TITLE
Fix CalDAV sync by generating missing calendar_home_url

### DIFF
--- a/core/Objects/Source.vala
+++ b/core/Objects/Source.vala
@@ -325,7 +325,7 @@ public class Objects.SourceCalDAVData : Objects.SourceData {
         }
 
         get {
-            if (_calendar_home_url == null) {
+            if (_calendar_home_url == null || _calendar_home_url == "") {
                 _calendar_home_url = Path.build_filename (server_url, "calendars", username);
                 if (!_calendar_home_url.has_suffix ("/")) {
                     _calendar_home_url += "/";

--- a/core/Objects/Source.vala
+++ b/core/Objects/Source.vala
@@ -299,12 +299,43 @@ public class Objects.SourceTodoistData : Objects.SourceData {
 }
 
 public class Objects.SourceCalDAVData : Objects.SourceData {
-    public string server_url { get; set; default = ""; }
+    string _server_url;
+    public string server_url {
+        set {
+            _server_url = value;
+        }
+
+        get {
+            if (!_server_url.has_suffix ("/")) {
+                _server_url += "/";
+            }
+
+            return _server_url;
+        }
+    }
     public string username { get; set; default = ""; }
     public string password { get; set; default = ""; }
     public string user_displayname { get; set; default = ""; }
     public string user_email { get; set; default = ""; }
-    public string calendar_home_url { get; set; default = ""; }
+
+    string _calendar_home_url;
+    public string calendar_home_url {
+        set {
+            _calendar_home_url = value;
+        }
+
+        get {
+            if (_calendar_home_url == null) {
+                _calendar_home_url = Path.build_filename (server_url, "calendars", username);
+                if (!_calendar_home_url.has_suffix ("/")) {
+                    _calendar_home_url += "/";
+                }
+            }
+
+            return _calendar_home_url;
+        }
+    }
+    
     public CalDAVType caldav_type { get; set; default = CalDAVType.GENERIC; }
     public bool ignore_ssl { get; set; default = false; }
 

--- a/core/Services/CalDAV/CalDAVClient.vala
+++ b/core/Services/CalDAV/CalDAVClient.vala
@@ -175,23 +175,26 @@ public class Services.CalDAV.CalDAVClient : Services.CalDAV.WebDAVClient {
                     </d:propfind>
         """;
 
+        print ("calendar_home_url: %s\n", source.caldav_data.calendar_home_url);
         var multi_status = yield propfind (source.caldav_data.calendar_home_url, xml, "1", cancellable);
 
 
         // Delete CalDAV Generic
-        //  var server_urls = new Gee.HashSet<string> ();
-        //  foreach (var response in multi_status.responses ()) {
-        //      if (response.href != null) {
-        //          server_urls.add (get_absolute_url (response.href));
-        //      }
-        //  }
+        var server_urls = new Gee.HashSet<string> ();
+        foreach (var response in multi_status.responses ()) {
+            if (response.href != null) {
+                print ("href: %s\n", get_absolute_url (response.href));
+                server_urls.add (get_absolute_url (response.href));
+            }
+        }
 
-        //  var local_projects = Services.Store.instance ().get_projects_by_source (source.id);
-        //  foreach (var local_project in local_projects) {
-        //      if (!server_urls.contains (local_project.calendar_url)) {
-        //          Services.Store.instance ().delete_project (local_project);
-        //      }
-        //  }
+        var local_projects = Services.Store.instance ().get_projects_by_source (source.id);
+        foreach (Objects.Project local_project in local_projects) {
+            if (!server_urls.contains (local_project.calendar_url)) {
+                // Services.Store.instance ().delete_project (local_project);
+                print ("delete: %s\n", local_project.calendar_url);
+            }
+        }
 
         foreach (var response in multi_status.responses ()) {
             string? href = response.href;

--- a/core/Services/CalDAV/CalDAVClient.vala
+++ b/core/Services/CalDAV/CalDAVClient.vala
@@ -191,7 +191,7 @@ public class Services.CalDAV.CalDAVClient : Services.CalDAV.WebDAVClient {
         var local_projects = Services.Store.instance ().get_projects_by_source (source.id);
         foreach (Objects.Project local_project in local_projects) {
             if (!server_urls.contains (local_project.calendar_url)) {
-                // Services.Store.instance ().delete_project (local_project);
+                Services.Store.instance ().delete_project (local_project);
                 print ("delete: %s\n", local_project.calendar_url);
             }
         }
@@ -207,14 +207,14 @@ public class Services.CalDAV.CalDAVClient : Services.CalDAV.WebDAVClient {
                 var resourcetype = propstat.get_first_prop_with_tagname ("resourcetype");
                 var supported_calendar = propstat.get_first_prop_with_tagname ("supported-calendar-component-set");
 
-                //  if (is_deleted_calendar (resourcetype)) {
-                //      Objects.Project ? project = Services.Store.instance ().get_project_via_url (get_absolute_url (href));
-                //      if (project != null) {
-                //          Services.Store.instance ().delete_project (project);
-                //      }
+                if (is_deleted_calendar (resourcetype)) {
+                    Objects.Project ? project = Services.Store.instance ().get_project_via_url (get_absolute_url (href));
+                    if (project != null) {
+                        Services.Store.instance ().delete_project (project);
+                    }
 
-                //      continue;
-                //  }
+                    continue;
+                }
 
                 if (is_vtodo_calendar (resourcetype, supported_calendar)) {
                     var name = propstat.get_first_prop_with_tagname ("displayname");

--- a/core/Services/CalDAV/CalDAVClient.vala
+++ b/core/Services/CalDAV/CalDAVClient.vala
@@ -179,19 +179,19 @@ public class Services.CalDAV.CalDAVClient : Services.CalDAV.WebDAVClient {
 
 
         // Delete CalDAV Generic
-        var server_urls = new Gee.HashSet<string> ();
-        foreach (var response in multi_status.responses ()) {
-            if (response.href != null) {
-                server_urls.add (get_absolute_url (response.href));
-            }
-        }
+        //  var server_urls = new Gee.HashSet<string> ();
+        //  foreach (var response in multi_status.responses ()) {
+        //      if (response.href != null) {
+        //          server_urls.add (get_absolute_url (response.href));
+        //      }
+        //  }
 
-        var local_projects = Services.Store.instance ().get_projects_by_source (source.id);
-        foreach (var local_project in local_projects) {
-            if (!server_urls.contains (local_project.calendar_url)) {
-                Services.Store.instance ().delete_project (local_project);
-            }
-        }
+        //  var local_projects = Services.Store.instance ().get_projects_by_source (source.id);
+        //  foreach (var local_project in local_projects) {
+        //      if (!server_urls.contains (local_project.calendar_url)) {
+        //          Services.Store.instance ().delete_project (local_project);
+        //      }
+        //  }
 
         foreach (var response in multi_status.responses ()) {
             string? href = response.href;
@@ -204,14 +204,14 @@ public class Services.CalDAV.CalDAVClient : Services.CalDAV.WebDAVClient {
                 var resourcetype = propstat.get_first_prop_with_tagname ("resourcetype");
                 var supported_calendar = propstat.get_first_prop_with_tagname ("supported-calendar-component-set");
 
-                if (is_deleted_calendar (resourcetype)) {
-                    Objects.Project ? project = Services.Store.instance ().get_project_via_url (get_absolute_url (href));
-                    if (project != null) {
-                        Services.Store.instance ().delete_project (project);
-                    }
+                //  if (is_deleted_calendar (resourcetype)) {
+                //      Objects.Project ? project = Services.Store.instance ().get_project_via_url (get_absolute_url (href));
+                //      if (project != null) {
+                //          Services.Store.instance ().delete_project (project);
+                //      }
 
-                    continue;
-                }
+                //      continue;
+                //  }
 
                 if (is_vtodo_calendar (resourcetype, supported_calendar)) {
                     var name = propstat.get_first_prop_with_tagname ("displayname");

--- a/core/Services/CalDAV/CalDAVClient.vala
+++ b/core/Services/CalDAV/CalDAVClient.vala
@@ -175,7 +175,6 @@ public class Services.CalDAV.CalDAVClient : Services.CalDAV.WebDAVClient {
                     </d:propfind>
         """;
 
-        print ("calendar_home_url: %s\n", source.caldav_data.calendar_home_url);
         var multi_status = yield propfind (source.caldav_data.calendar_home_url, xml, "1", cancellable);
 
 
@@ -183,7 +182,6 @@ public class Services.CalDAV.CalDAVClient : Services.CalDAV.WebDAVClient {
         var server_urls = new Gee.HashSet<string> ();
         foreach (var response in multi_status.responses ()) {
             if (response.href != null) {
-                print ("href: %s\n", get_absolute_url (response.href));
                 server_urls.add (get_absolute_url (response.href));
             }
         }
@@ -192,7 +190,6 @@ public class Services.CalDAV.CalDAVClient : Services.CalDAV.WebDAVClient {
         foreach (Objects.Project local_project in local_projects) {
             if (!server_urls.contains (local_project.calendar_url)) {
                 Services.Store.instance ().delete_project (local_project);
-                print ("delete: %s\n", local_project.calendar_url);
             }
         }
 

--- a/core/Services/Database.vala
+++ b/core/Services/Database.vala
@@ -2253,10 +2253,12 @@ public class Services.Database : GLib.Object {
                 project.source.caldav_data.server_url,
                 "calendars", 
                 project.source.caldav_data.username,
-                project.id,
-                ""
+                project.id
             );
 
+            if (!url.has_suffix ("/")) {
+                url += "/";
+            }
 
             print ("Migration: Adding calendar_url for Project (%s) (%s)\n", project.name, url);
 

--- a/core/Services/Database.vala
+++ b/core/Services/Database.vala
@@ -2260,7 +2260,7 @@ public class Services.Database : GLib.Object {
                 url += "/";
             }
 
-            print ("Migration: Adding calendar_url for Project (%s) (%s)\n", project.name, url);
+            debug ("Migration: Adding calendar_url for Project (%s) (%s)\n", project.name, url);
 
             Sqlite.Statement stmt;
 

--- a/core/Services/Database.vala
+++ b/core/Services/Database.vala
@@ -2249,11 +2249,14 @@ public class Services.Database : GLib.Object {
                 continue;
             }
 
-            var url = "%s/calendars/%s/%s/".printf (
+            var url = Path.build_filename (
                 project.source.caldav_data.server_url,
+                "calendars", 
                 project.source.caldav_data.username,
-                project.id
+                project.id,
+                ""
             );
+
 
             print ("Migration: Adding calendar_url for Project (%s) (%s)\n", project.name, url);
 

--- a/core/Services/Database.vala
+++ b/core/Services/Database.vala
@@ -2255,7 +2255,7 @@ public class Services.Database : GLib.Object {
                 project.id
             );
 
-            print ("Migration: Adding calendar_url for Project (%s)\n", project.name);
+            print ("Migration: Adding calendar_url for Project (%s) (%s)\n", project.name, url);
 
             Sqlite.Statement stmt;
 


### PR DESCRIPTION
Fixes CalDAV task list synchronization by ensuring `calendar_home_url` is properly generated during migration. Previously, missing `calendar_home_url` prevented CalDAV projects from syncing correctly.

Changes
- Auto-generate `calendar_home_url` when missing in CalDAV data
- Use `Path.build_filename` to prevent double slashes in URLs
- Ensure proper URL formatting with trailing slashes