### PR TITLE
Remove orphaned labels when deleting a Source

### DIFF
--- a/core/Services/Store.vala
+++ b/core/Services/Store.vala
@@ -186,6 +186,10 @@ public class Services.Store : GLib.Object {
         }
         
         if (Services.Database.get_default ().delete_source (source)) {
+            foreach (Objects.Label label in get_labels_by_source (source.id)) {
+                delete_label (label);
+            }
+            
             source.deleted ();
             source_deleted (source);
             _sources.remove (source);

--- a/src/Views/Label/LabelSourceRow.vala
+++ b/src/Views/Label/LabelSourceRow.vala
@@ -43,7 +43,8 @@ public class Views.LabelSourceRow : Gtk.ListBoxRow {
 
         group = new Layouts.HeaderItem (source.display_name) {
             reveal = true,
-            subheader_title = source.subheader_text
+            subheader_title = source.subheader_text,
+            show_separator = true
         };
         group.placeholder_message = _("No labels available. Create one by clicking on the '+' button");
         group.margin_bottom = 12;


### PR DESCRIPTION
Ensure that when a Source is deleted, all its associated tags are also removed to prevent orphaned records in the database