### PR TITLE
Disable animation when "Create More" is active and use quick notification

### DIFF
--- a/core/QuickAdd.vala
+++ b/core/QuickAdd.vala
@@ -439,7 +439,7 @@ public class Layouts.QuickAdd : Adw.Bin {
             }
         })] = event_controller_key;
 
-        signal_map[create_more_button.activate.connect (() => {
+        signal_map[create_more_button.toggled.connect (() => {
             Services.Settings.get_default ().settings.set_boolean ("quick-add-create-more", create_more_button.active);
         })] = create_more_button;
 

--- a/core/QuickAdd.vala
+++ b/core/QuickAdd.vala
@@ -226,12 +226,13 @@ public class Layouts.QuickAdd : Adw.Bin {
         submit_button.add_css_class ("padding-4");
 
         create_more_button = new Gtk.ToggleButton () {
-            css_classes = { "keep-adding-button" },
             tooltip_text = _("Keep adding"),
             icon_name = "arrow-turn-down-right-symbolic",
             valign = CENTER,
             active = Services.Settings.get_default ().settings.get_boolean ("quick-add-create-more")
         };
+        create_more_button.add_css_class ("flat");
+        create_more_button.add_css_class ("keep-adding-button");
 
         var submit_cancel_grid = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 6) {
             hexpand = true,

--- a/core/QuickAdd.vala
+++ b/core/QuickAdd.vala
@@ -217,15 +217,19 @@ public class Layouts.QuickAdd : Adw.Bin {
         quick_add_content.append (item_labels);
         quick_add_content.append (action_box);
 
-        submit_button = new Widgets.LoadingButton (LoadingButtonType.LABEL, _("Add")) {
+        submit_button = new Widgets.LoadingButton.with_icon ("paper-plane-symbolic") {
             valign = CENTER,
-            css_classes = { "suggested-action", "border-radius-6" }
+            width_request = 32,
+            tooltip_text = _("Add Task")
         };
+        submit_button.add_css_class ("suggested-action");
+        submit_button.add_css_class ("padding-4");
 
         create_more_button = new Gtk.ToggleButton () {
-            css_classes = { "flat", "keep-adding-button" },
+            css_classes = { "keep-adding-button" },
             tooltip_text = _("Keep adding"),
             icon_name = "arrow-turn-down-right-symbolic",
+            valign = CENTER,
             active = Services.Settings.get_default ().settings.get_boolean ("quick-add-create-more")
         };
 

--- a/data/io.github.alainm23.planify.gresource.xml
+++ b/data/io.github.alainm23.planify.gresource.xml
@@ -110,6 +110,7 @@
     <file alias="text-bold-symbolic.svg">resources/icons/text-bold-symbolic.svg</file>
     <file alias="dialog-information-symbolic.svg">resources/icons/dialog-information-symbolic.svg</file>
     <file alias="go-home-symbolic.svg">resources/icons/go-home-symbolic.svg</file>
+    <file alias="paper-plane-symbolic.svg">resources/icons/paper-plane-symbolic.svg</file>
   </gresource>
 
   <gresource prefix="/io/github/alainm23/planify/Devel/icons/scalable/actions">
@@ -189,6 +190,7 @@
     <file alias="text-bold-symbolic.svg">resources/icons/text-bold-symbolic.svg</file>
     <file alias="dialog-information-symbolic.svg">resources/icons/dialog-information-symbolic.svg</file>
     <file alias="go-home-symbolic.svg">resources/icons/go-home-symbolic.svg</file>
+    <file alias="paper-plane-symbolic.svg">resources/icons/paper-plane-symbolic.svg</file>
   </gresource>
 
   <gresource prefix="/io/github/alainm23/planify/quick-add/icons/scalable/actions">
@@ -268,5 +270,6 @@
     <file alias="text-bold-symbolic.svg">resources/icons/text-bold-symbolic.svg</file>
     <file alias="dialog-information-symbolic.svg">resources/icons/dialog-information-symbolic.svg</file>
     <file alias="go-home-symbolic.svg">resources/icons/go-home-symbolic.svg</file>
+    <file alias="paper-plane-symbolic.svg">resources/icons/paper-plane-symbolic.svg</file>
   </gresource>
 </gresources>

--- a/data/resources/icons/paper-plane-symbolic.svg
+++ b/data/resources/icons/paper-plane-symbolic.svg
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" height="16px" viewBox="0 0 16 16" width="16px"><path d="m 15 7.992188 l -14 -7 v 6 l 8 1 l -8 1 v 6 z m 0 0" fill="#222222"/></svg>

--- a/data/resources/stylesheet/stylesheet.css
+++ b/data/resources/stylesheet/stylesheet.css
@@ -19,6 +19,10 @@ check {
     padding: 0;
 }
 
+.padding-4 {
+    padding: 4px;
+}
+
 .padding-6 {
     padding: 6px;
 }


### PR DESCRIPTION
Replaced the animation with a fast notification when "Create More" is enabled, allowing multiple tasks to be created without waiting for the animation to finish

Fixes: #1768