### PR TITLE
Use plural forms for translatable strings

### DIFF
--- a/core/Enum.vala
+++ b/core/Enum.vala
@@ -206,49 +206,28 @@ public enum RecurrencyType {
     EVERY_YEAR,
     NONE;
 
-    public string to_friendly_string (int ? interval = null) {
+    public string to_friendly_string (int? interval = null) {
+        int count = (interval == null || interval == 0) ? 1 : interval;
+
+        string pluralized (string singular, string plural) {
+            return GLib.ngettext (singular, plural, count).printf (count);
+        }
+
         switch (this) {
             case NONE:
                 return _("Don't Repeat");
             case MINUTELY:
-                if (interval == null || interval == 0) {
-                    return _("Every minute");
-                } else {
-                    return GLib.ngettext (_("Every minute"), _("Every %d minutes"), interval).printf (interval);
-                }
+                return pluralized (_("Every minute"), _("Every %d minutes"));
             case HOURLY:
-                if (interval == null || interval == 0) {
-                    return _("Every hour");
-                } else {
-                    return GLib.ngettext (_("Every hour"), _("Every %d hours"), interval).printf (interval);
-                }
+                return pluralized (_("Every hour"), _("Every %d hours"));
             case EVERY_DAY:
-                if (interval == null || interval == 0) {
-                    return _("Every day");
-                } else {
-                    return GLib.ngettext (_("Every day"), _("Every %d days"), interval).printf (interval);
-                }
+                return pluralized (_("Every day"), _("Every %d days"));
             case EVERY_WEEK:
-                if (interval == null || interval == 0) {
-                    return _("Every week");
-                } else {
-                    return GLib.ngettext (_("Every week"), _("Every %d weeks"), interval).printf (interval);
-                }
-
+                return pluralized (_("Every week"), _("Every %d weeks"));
             case EVERY_MONTH:
-                if (interval == null || interval == 0) {
-                    return _("Every month");
-                } else {
-                    return GLib.ngettext (_("Every month"), _("Every %d months"), interval).printf (interval);
-                }
-
+                return pluralized (_("Every month"), _("Every %d months"));
             case EVERY_YEAR:
-                if (interval == null || interval == 0) {
-                    return _("Every year");
-                } else {
-                    return GLib.ngettext (_("Every year"), _("Every %d years"), interval).printf (interval);
-                }
-
+                return pluralized (_("Every year"), _("Every %d years"));
             default:
                 assert_not_reached ();
         }

--- a/src/Dialogs/CompletedTasks.vala
+++ b/src/Dialogs/CompletedTasks.vala
@@ -160,8 +160,12 @@ public class Dialogs.CompletedTasks : Adw.Dialog {
             var items = Services.Store.instance ().get_items_checked_by_project (project);
 
             var dialog = new Adw.AlertDialog (
-                _ ("Delete All Completed Tasks"),
-                _ ("This will delete %d completed tasks and their subtasks from project %s".printf (items.size, project.name))
+                _("Delete All Completed Tasks"),
+                GLib.ngettext (
+                    _("This will delete %d completed task and its subtasks from project %s"),
+                    _("This will delete %d completed tasks and their subtasks from project %s"),
+                    items.size
+                ).printf (items.size, project.name)
             );
 
             dialog.body_use_markup = true;

--- a/src/Dialogs/ItemChangeHistory.vala
+++ b/src/Dialogs/ItemChangeHistory.vala
@@ -132,7 +132,13 @@ public class Dialogs.ItemChangeHistory : Adw.Dialog {
         }
 
         listbox.invalidate_headers ();
-        load_button.label = _("Load more history from %d weeks ago…".printf ((end_week / 7) + 1));
+
+        int weeks = (end_week / 7) + 1;
+        load_button.label = GLib.ngettext (
+            _("Load more history from %d week ago…"),
+            _("Load more history from %d weeks ago…"),
+            weeks
+        ).printf (weeks);
     }
 
     private void header_completed_function (Gtk.ListBoxRow lbrow, Gtk.ListBoxRow ? lbbefore) {

--- a/src/Views/Filter.vala
+++ b/src/Views/Filter.vala
@@ -608,8 +608,16 @@ public class Views.Filter : Adw.Bin {
             var items = Services.Store.instance ().get_items_checked ();
 
             var dialog = new Adw.AlertDialog (
-                _("Delete All Completed Tasks"),
-                _("This will delete %d completed tasks and their subtasks".printf (items.size))
+                GLib.ngettext (
+                    _("Delete Completed Task"),
+                    _("Delete Completed Tasks"),
+                    items.size
+                ),
+                GLib.ngettext (
+                    _("This will delete %d completed task and its subtasks"),
+                    _("This will delete %d completed tasks and their subtasks"),
+                    items.size
+                ).printf (items.size)
             );
 
             dialog.body_use_markup = true;

--- a/src/Widgets/MultiSelectToolbar.vala
+++ b/src/Widgets/MultiSelectToolbar.vala
@@ -238,11 +238,19 @@ public class Widgets.MultiSelectToolbar : Adw.Bin {
         delete_item.clicked.connect (() => {
             string title = _ ("Delete To-Do");
             string message = _ ("Are you sure you want to delete this to-do?");
-            if (items_selected.size > 1) {
-                title = _ ("Delete %d To-Dos".printf (items_selected.size));
-                message = _ ("Are you sure you want to delete these %d to-dos?".printf (items_selected.size));
-            }
+            if (items_selected.size > 0) {
+                title = GLib.ngettext (
+                    _("Delete %d To-Do"),
+                    _("Delete %d To-Dos"),
+                    items_selected.size
+                ).printf (items_selected.size);
 
+                message = GLib.ngettext (
+                    _("Are you sure you want to delete this %d to-do?"),
+                    _("Are you sure you want to delete these %d to-dos?"),
+                    items_selected.size
+                ).printf (items_selected.size);
+            }
 
             var dialog = new Adw.AlertDialog (title, message);
 


### PR DESCRIPTION
Replaced separate singular and plural strings with `ngettext()` to properly support plural forms in all languages.

Fixes: #1861