### PR TITLE
Add ESC key support to close modals and exit modes

### DIFF
--- a/core/Services/EventBus.vala
+++ b/core/Services/EventBus.vala
@@ -34,6 +34,7 @@ public class Services.EventBus : Object {
     public signal void connect_typing_accel ();
     public signal void disconnect_all_accels ();
     public signal void connect_all_accels ();
+    public signal void escape_pressed ();
 
     // General
     public signal void theme_changed ();

--- a/src/Layouts/ItemRow.vala
+++ b/src/Layouts/ItemRow.vala
@@ -924,7 +924,7 @@ public class Layouts.ItemRow : Layouts.ItemBase {
                 Services.EventBus.get_default ().item_edit_active = true;
                 Services.EventBus.get_default ().dim_content (true, item.id);
             } else {
-                Services.EventBus.get_default ().item_selected (item.id);
+                edit = true;
             }
         }
     }

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -313,6 +313,9 @@ public class MainWindow : Adw.ApplicationWindow {
             if (overlay_split_view.collapsed) {
                 overlay_split_view.show_sidebar = false;
             }
+
+            Services.EventBus.get_default ().item_edit_active = false;
+            Services.EventBus.get_default ().dim_content (false, "");
         });
 
         Services.EventBus.get_default ().send_toast.connect ((toast) => {
@@ -386,6 +389,26 @@ public class MainWindow : Adw.ApplicationWindow {
         Timeout.add_seconds (120, () => {
             cleanup_unused_views ();
             return Source.CONTINUE;
+        });
+
+        var key_controller = new Gtk.EventControllerKey ();
+        ((Gtk.Widget) this).add_controller (key_controller);
+        key_controller.key_pressed.connect ((keyval, keycode, state) => {
+            if (keyval == Gdk.Key.Escape) {
+                Services.EventBus.get_default ().escape_pressed ();
+                
+                if (Services.EventBus.get_default ().item_edit_active) {
+                    Services.EventBus.get_default ().item_edit_active = false;
+                    Services.EventBus.get_default ().dim_content (false, "");
+                    return true;
+                }
+                
+                if (views_split_view.show_sidebar) {
+                    views_split_view.show_sidebar = false;
+                    return true;
+                }
+            }
+            return false;
         });
 
         var window_gesture = new Gtk.GestureClick ();

--- a/src/Views/Project/Project.vala
+++ b/src/Views/Project/Project.vala
@@ -162,7 +162,7 @@ public class Views.Project : Adw.Bin {
 
         signal_map[project.show_multi_select_change.connect (() => {
             toolbar_view.reveal_bottom_bars = project.show_multi_select;
-
+            
             if (project.show_multi_select) {
                 Services.EventBus.get_default ().multi_select_enabled = true;
                 Services.EventBus.get_default ().show_multi_select (true);
@@ -202,6 +202,12 @@ public class Views.Project : Adw.Bin {
         signal_map[project.handle_scroll_visibility_change.connect ((visible) => {
             headerbar.update_title_box_visibility (visible);
         })] = project;
+
+        signal_map[Services.EventBus.get_default ().escape_pressed.connect (() => {
+            if (project.show_multi_select) {
+                project.show_multi_select = false;
+            }
+        })] = Services.EventBus.get_default ();
     }
 
     private void check_default_filters () {

--- a/src/Widgets/MultiSelectToolbar.vala
+++ b/src/Widgets/MultiSelectToolbar.vala
@@ -147,6 +147,13 @@ public class Widgets.MultiSelectToolbar : Adw.Bin {
         priority_button.changed.connect ((priority) => {
             set_priority (priority);
         });
+
+        Services.EventBus.get_default ().escape_pressed.connect (() => {
+            if (Services.EventBus.get_default ().multi_select_enabled) {
+                print ("Se Activo\n");
+                unselect_all ();
+            }
+        });
     }
 
     private void update_items (Gee.ArrayList<Objects.Item> objects) {
@@ -281,7 +288,7 @@ public class Widgets.MultiSelectToolbar : Adw.Bin {
 
         items_selected.clear ();
         labels.clear ();
-        size_label.label = null;
+        size_label.label = "0";
         closed ();
     }
 


### PR DESCRIPTION
Adds global ESC key handling to improve navigation and user experience:

- Close task editing mode when ESC is pressed
- Exit multi-select mode and deselect all items
- Close task detail sidebar
- Added global escape_pressed signal in EventBus
- Implemented priority-based handling: editing > multi-select > sidebar

This provides a consistent and intuitive way to exit different UI states using the ESC key.

Fixes: #1817