### PR TITLE
feat: Add context menus

### DIFF
--- a/src/Dialogs/Preferences/PreferencesWindow.vala
+++ b/src/Dialogs/Preferences/PreferencesWindow.vala
@@ -519,6 +519,13 @@ public class Dialogs.Preferences.PreferencesWindow : Adw.PreferencesDialog {
         return page_map[page];
     }
 
+    public void show_page (string page_key) {
+        var page = build_page (page_key);
+        if (page != null) {
+            push_subpage (page);
+        }
+    }
+
     public void clean_up () {
         foreach (var entry in signal_map.entries) {
             entry.value.disconnect (entry.key);

--- a/src/Layouts/ItemBoard.vala
+++ b/src/Layouts/ItemBoard.vala
@@ -367,6 +367,25 @@ public class Layouts.ItemBoard : Layouts.ItemBase {
         var detail_gesture_click = new Gtk.GestureClick ();
         card_widget.add_controller (detail_gesture_click);
         signals_map[detail_gesture_click.released.connect ((n_press, x, y) => {
+            if (Services.EventBus.get_default ().ctrl_key_pressed) {
+                Idle.add (() => {
+                    if (item.project == null) {
+                        return GLib.Source.REMOVE;
+                    }
+                    
+                    if (!Services.EventBus.get_default ().multi_select_enabled) {
+                        item.project.show_multi_select = true;
+                    }
+                    
+                    select_checkbutton.active = !select_checkbutton.active;
+                    selected_toggled (select_checkbutton.active);
+                    
+                    return GLib.Source.REMOVE;
+                });
+                
+                return;
+            }
+            
             if (Services.EventBus.get_default ().multi_select_enabled) {
                 select_checkbutton.active = !select_checkbutton.active;
                 selected_toggled (select_checkbutton.active);

--- a/src/Layouts/ItemRow.vala
+++ b/src/Layouts/ItemRow.vala
@@ -776,8 +776,9 @@ public class Layouts.ItemRow : Layouts.ItemBase {
         var menu_handle_gesture = new Gtk.GestureClick ();
         menu_handle_gesture.set_button (3);
         itemrow_box.add_controller (menu_handle_gesture);
-        signals_map[menu_handle_gesture.released.connect ((n_press, x, y) => {
+        signals_map[menu_handle_gesture.pressed.connect ((n_press, x, y) => {
             if (!item.project.is_deck) {
+                menu_handle_gesture.set_state (Gtk.EventSequenceState.CLAIMED);
                 build_handle_context_menu (x, y);
             }
         })] = menu_handle_gesture;


### PR DESCRIPTION
**Context Menus**
- Added right-click context menu to Sidebar with options: New Project, Add Account, Customize Sidebar
- Added right-click context menu to Project view with options: New Task, New Section
- Fixed event propagation conflicts between ItemRow and Project context menus
- All menus positioned below cursor, aligned to the right

**Multi-Select Enhancement**
- Added Ctrl+Click on tasks (ItemBoard) to activate multi-select mode

Fixes: #734

