### PR TITLE
Fix for sidebar reordering crash

### DIFF
--- a/src/Dialogs/Preferences/Pages/Sidebar.vala
+++ b/src/Dialogs/Preferences/Pages/Sidebar.vala
@@ -317,16 +317,15 @@ public class Dialogs.Preferences.Pages.Sidebar : Dialogs.Preferences.Pages.BaseP
                 reorder = null;
             }
 
+            foreach (var entry in signal_map.entries) {
+                entry.value.disconnect (entry.key);
+            }
+            signal_map.clear ();
+
             if (select_gesture != null && action_row != null) {
                 action_row.remove_controller (select_gesture);
                 select_gesture = null;
             }
-
-            foreach (var entry in signal_map.entries) {
-                entry.value.disconnect (entry.key);
-            }
-
-            signal_map.clear ();
             
             check_button = null;
             main_revealer = null;

--- a/src/Widgets/ReorderChild.vala
+++ b/src/Widgets/ReorderChild.vala
@@ -168,8 +168,9 @@ public class Widgets.ReorderChild : Adw.Bin {
         var source_list = (Gtk.ListBox) picked_widget.row.parent;
         var target_list = (Gtk.ListBox) target_widget.row.parent;
 
-        source_list.remove (picked_widget.row);
-        target_list.insert (picked_widget.row, target_widget.row.get_index () + (bottom ? 1 : 0));
+        var picked_row = picked_widget.row;
+        source_list.remove (picked_row);
+        target_list.insert (picked_row, target_widget.row.get_index () + (bottom ? 1 : 0));
 
         on_drop_end (target_list);
         return true;


### PR DESCRIPTION
This attempts to provide a fix for issue #1805.

This changes the following:

- In the `clean_up` method of `SidebarRow`, the `select_gesture` member was removed before it was supposed to be used to disconnect signals, causing a SEGFAULT. The fix changes the order so that the signal disconnect happens before `select_gesture` is removed.
- In the `on_drop` method of `ReorderChild`, the row seems to be cleaned up by GObject between it being removed and re-added to the list, causing a SEGFAULT. The fix adds an explicit reference, which seems to keep the row in memory, preventing the SEGFAULT.

Fixes #1805