### PR TITLE
feat: Add configurable inbox project setting

### DIFF
--- a/core/Widgets/IconColorProject.vala
+++ b/core/Widgets/IconColorProject.vala
@@ -64,7 +64,7 @@ public class Widgets.IconColorProject : Adw.Bin {
         stack = new Gtk.Stack () {
             transition_type = CROSSFADE,
             vhomogeneous = true,
-            hhomogeneous = true
+            hhomogeneous = false
         };
 
         stack.add_named (color_emoji_stack, "color-emoji");

--- a/src/Dialogs/Preferences/Pages/Accounts/Accounts.vala
+++ b/src/Dialogs/Preferences/Pages/Accounts/Accounts.vala
@@ -21,6 +21,7 @@
 
 public class Dialogs.Preferences.Pages.Accounts : Dialogs.Preferences.Pages.BasePage {
     private Layouts.HeaderItem sources_group;
+    private Gtk.Label inbox_page_name;
 
     public Accounts (Adw.PreferencesDialog preferences_dialog) {
         Object (
@@ -67,6 +68,35 @@ public class Dialogs.Preferences.Pages.Accounts : Dialogs.Preferences.Pages.Base
 
         sources_group.add_widget_end (add_source_button);
 
+        inbox_page_name = new Gtk.Label (null) {
+            ellipsize = END,
+            max_width_chars = 24
+        };
+        inbox_page_name.add_css_class ("caption");
+        inbox_page_name.add_css_class ("dimmed");
+
+        var arrow_icon = new Gtk.Image.from_icon_name ("go-next-symbolic");
+
+        var inbox_box = new Gtk.Box (HORIZONTAL, 6) {
+            halign = END,
+            valign = CENTER,
+            hexpand = true
+        };
+        inbox_box.append (inbox_page_name);
+        inbox_box.append (arrow_icon);
+
+        var inbox_page_row = new Adw.ActionRow () {
+            activatable = true,
+            title = _("Inbox Page")
+        };
+        inbox_page_row.add_prefix (new Gtk.Image.from_icon_name ("mailbox-symbolic"));
+        inbox_page_row.add_suffix (inbox_box);
+
+        var inbox_group = new Adw.PreferencesGroup () {
+            margin_top = 12
+        };
+        inbox_group.add (inbox_page_row);
+
         var content_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 3);
         content_box.append (sources_group);
         content_box.append (new Gtk.Label (_("You can sort your accounts by dragging and dropping")) {
@@ -74,6 +104,7 @@ public class Dialogs.Preferences.Pages.Accounts : Dialogs.Preferences.Pages.Base
             halign = START,
             margin_start = 12
         });
+        content_box.append (inbox_group);
 
         var content_clamp = new Adw.Clamp () {
             maximum_size = 600,
@@ -89,18 +120,19 @@ public class Dialogs.Preferences.Pages.Accounts : Dialogs.Preferences.Pages.Base
         toolbar_view.add_top_bar (new Adw.HeaderBar ());
 
         child = toolbar_view;
+        update_inbox_page_name ();
 
         Gee.HashMap<string, SourceRow> sources_hashmap = new Gee.HashMap<string, SourceRow> ();
         foreach (Objects.Source source in Services.Store.instance ().sources) {
             if (!sources_hashmap.has_key (source.id)) {
-                sources_hashmap[source.id] = new SourceRow (source);
+                sources_hashmap[source.id] = new SourceRow (source, preferences_dialog);
                 sources_group.add_child (sources_hashmap[source.id]);
             }
         }
 
         signal_map[Services.Store.instance ().source_added.connect ((source) => {
             if (!sources_hashmap.has_key (source.id)) {
-                sources_hashmap[source.id] = new SourceRow (source);
+                sources_hashmap[source.id] = new SourceRow (source, preferences_dialog);
                 sources_group.add_child (sources_hashmap[source.id]);
             }
         })] = Services.Store.instance ();
@@ -133,6 +165,14 @@ public class Dialogs.Preferences.Pages.Accounts : Dialogs.Preferences.Pages.Base
             preferences_dialog.push_subpage (new Dialogs.Preferences.Pages.SourceView (preferences_dialog, source));
         })] = sources_group;
 
+        inbox_page_row.activated.connect (() => {
+            preferences_dialog.push_subpage (new Dialogs.Preferences.Pages.InboxPage (preferences_dialog));
+        });
+        
+        Services.Settings.get_default ().settings.changed["local-inbox-project-id"].connect (() => {
+            update_inbox_page_name ();
+        });
+
         destroy.connect (() => {
             clean_up ();
         });
@@ -161,6 +201,20 @@ public class Dialogs.Preferences.Pages.Accounts : Dialogs.Preferences.Pages.Base
         }
 
         signal_map.clear ();
+    }
+
+    private void update_inbox_page_name () {
+        Objects.Project ? inbox_project = Services.Store.instance ().get_project (
+            Services.Settings.get_default ().settings.get_string ("local-inbox-project-id")
+        );
+
+        if (inbox_project == null) {
+            return;
+        }
+        
+        string label = "%s (%s)".printf (inbox_project.name, inbox_project.source.display_name);
+        inbox_page_name.label = label;
+        inbox_page_name.tooltip_text = label;
     }
 
     public Gtk.Widget build_sync_page () {
@@ -193,15 +247,17 @@ public class Dialogs.Preferences.Pages.Accounts : Dialogs.Preferences.Pages.Base
 
     public class SourceRow : Gtk.ListBoxRow {
         public Objects.Source source { get; construct; }
+        public Adw.PreferencesDialog preferences_dialog { get; construct; }
 
         private Widgets.ReorderChild reorder;
         private Gtk.Revealer main_revealer;
         private Gtk.Switch visible_checkbutton;
         private Gee.HashMap<ulong, weak GLib.Object> signal_map = new Gee.HashMap<ulong, weak GLib.Object> ();
 
-        public SourceRow (Objects.Source source) {
+        public SourceRow (Objects.Source source, Adw.PreferencesDialog preferences_dialog) {
             Object (
-                source: source
+                source: source,
+                preferences_dialog: preferences_dialog
             );
         }
 
@@ -236,9 +292,6 @@ public class Dialogs.Preferences.Pages.Accounts : Dialogs.Preferences.Pages.Base
                 active = source.is_visible,
                 valign = CENTER
             };
-
-            update_switch_sensitivity ();
-
 
             Gtk.Image ? warning_image = null;
             if (source.source_type == SourceType.CALDAV && source.caldav_data.ignore_ssl) {
@@ -288,6 +341,7 @@ public class Dialogs.Preferences.Pages.Accounts : Dialogs.Preferences.Pages.Base
 
             child = main_revealer;
             reorder.build_drag_and_drop ();
+            update_switch_sensitivity ();
 
             Timeout.add (main_revealer.transition_duration, () => {
                 main_revealer.reveal_child = true;
@@ -309,6 +363,15 @@ public class Dialogs.Preferences.Pages.Accounts : Dialogs.Preferences.Pages.Base
                     
                     if (visible_count <= 1) {
                         visible_checkbutton.active = true;
+                        return;
+                    }
+
+                    string current_inbox_id = Services.Settings.get_default ().settings.get_string ("local-inbox-project-id");
+                    var inbox_project = Services.Store.instance ().get_project (current_inbox_id);
+                    
+                    if (inbox_project != null && inbox_project.source_id == source.id) {
+                        visible_checkbutton.active = true;
+                        show_inbox_warning_dialog ();
                         return;
                     }
                 }
@@ -333,6 +396,26 @@ public class Dialogs.Preferences.Pages.Accounts : Dialogs.Preferences.Pages.Base
             signal_map[main_revealer.notify["child-revealed"].connect (() => {
                 reorder.draw_motion_widgets ();
             })] = main_revealer;
+        }
+
+        private void show_inbox_warning_dialog () {
+            var dialog = new Adw.AlertDialog (
+                _("Cannot Hide This Account"),
+                _("This account contains your current Inbox project. Please change your Inbox project first.")
+            );
+
+            dialog.add_response ("cancel", _("Cancel"));
+            dialog.add_response ("change", _("Change Inbox"));
+            dialog.set_response_appearance ("change", Adw.ResponseAppearance.SUGGESTED);
+            dialog.set_default_response ("change");
+            dialog.set_close_response ("cancel");
+
+            dialog.choose.begin (Planify._instance.main_window, null, (obj, res) => {
+                string response = dialog.choose.end (res);
+                if (response == "change") {
+                    preferences_dialog.push_subpage (new Dialogs.Preferences.Pages.InboxPage (preferences_dialog));
+                }
+            });
         }
 
         private void update_views_order (Gtk.ListBox listbox) {

--- a/src/Dialogs/Preferences/Pages/Accounts/InboxPage.vala
+++ b/src/Dialogs/Preferences/Pages/Accounts/InboxPage.vala
@@ -37,8 +37,9 @@ public class Dialogs.Preferences.Pages.InboxPage : Dialogs.Preferences.Pages.Bas
         var description_label = new Gtk.Label (_("Your Inbox is where new tasks land by default. Based on David Allen's Getting Things Done methodology, it's your capture point for quick ideas and tasks that you'll organize later")) {
             wrap = true,
             xalign = 0,
-            css_classes = { "dim-label", "body" },
-            margin_bottom = 12
+            margin_bottom = 6,
+            margin_start = 3,
+            margin_end = 3
         };
 
         group_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 12);

--- a/src/Dialogs/Preferences/Pages/Accounts/InboxPage.vala
+++ b/src/Dialogs/Preferences/Pages/Accounts/InboxPage.vala
@@ -1,0 +1,179 @@
+/*
+ * Copyright © 2025 Alain M. (https://github.com/alainm23/planify)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA
+ *
+ * Authored by: Alain M. <alainmh23@gmail.com>
+ */
+
+public class Dialogs.Preferences.Pages.InboxPage : Dialogs.Preferences.Pages.BasePage {
+    private Gtk.Box group_box;
+
+    public InboxPage (Adw.PreferencesDialog preferences_dialog) {
+        Object (
+            preferences_dialog: preferences_dialog,
+            title: _("Inbox Project")
+        );
+    }
+
+    ~InboxPage () {
+        debug ("Destroying Dialogs.Preferences.Pages.InboxPage\n");
+    }
+
+    construct {
+        var description_label = new Gtk.Label (_("Your Inbox is where new tasks land by default. Based on David Allen's Getting Things Done methodology, it's your capture point for quick ideas and tasks that you'll organize later")) {
+            wrap = true,
+            xalign = 0,
+            css_classes = { "dim-label", "body" },
+            margin_bottom = 12
+        };
+
+        group_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 12);
+        group_box.append (description_label);
+
+        var content_clamp = new Adw.Clamp () {
+            maximum_size = 400,
+            margin_start = 24,
+            margin_end = 24,
+            margin_top = 12,
+            margin_bottom = 24,
+            child = group_box
+        };
+
+        var scrolled_window = new Gtk.ScrolledWindow () {
+            hscrollbar_policy = Gtk.PolicyType.NEVER,
+            hexpand = true,
+            vexpand = true,
+            child = content_clamp
+        };
+
+        var toolbar_view = new Adw.ToolbarView () {
+            content = scrolled_window
+        };
+        toolbar_view.add_top_bar (new Adw.HeaderBar ());
+
+        child = toolbar_view;
+        add_projects ();
+    }
+
+    private void add_projects () {
+        var fake_radio = new Gtk.CheckButton ();
+
+        foreach (Objects.Source source in Services.Store.instance ().sources) {
+            var source_group = new Layouts.HeaderItem (source.display_name) {
+                card = true,
+                reveal = source.is_visible
+            };
+
+            foreach (Objects.Project project in Services.Store.instance ().get_projects_by_source (source.id)) {
+                var row = new ProjectRow (project) {
+                    active = project.is_inbox_project,
+                    group = fake_radio
+                };
+
+                signal_map[row.toggled.connect (() => {
+                    if (row.active) {
+                        Services.Settings.get_default ().settings.set_string ("local-inbox-project-id", project.id);
+                    }
+                })] = row;
+
+                source_group.add_child (row);
+            }
+
+            group_box.append (source_group);
+        }
+    }
+
+    private Gtk.Widget get_header_box (string title) {
+        var header_label = new Gtk.Label (title) {
+            css_classes = { "heading" },
+            halign = START,
+            margin_start = 3
+        };
+
+        var header_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 6) {
+            margin_top = 6,
+            margin_start = 3,
+            margin_bottom = 3
+        };
+
+        header_box.append (header_label);
+
+        return header_box;
+    }
+
+    public class ProjectRow : Gtk.ListBoxRow {
+        public Objects.Project project { get; construct; }
+
+        public Gtk.CheckButton radio_button; 
+
+        public Gtk.CheckButton group {
+            set {
+                radio_button.group = value;
+            }
+        }
+
+        public bool active {
+            set {
+                radio_button.active = value;
+            }
+
+            get {
+                return radio_button.active;
+            }
+        }
+
+        public signal void toggled ();
+
+        public ProjectRow (Objects.Project project) {
+            Object (
+                project: project
+            );
+        }
+
+        ~ProjectRow () {
+            debug ("Destroying - ProjectRow\n");
+        }
+
+        construct {
+            add_css_class ("sidebar-row");
+            add_css_class ("transition");
+            add_css_class ("no-padding");
+            
+            radio_button = new Gtk.CheckButton ();
+
+            var action_row = new Adw.ActionRow () {
+                title = project.name,
+                activatable = true
+            };
+
+            action_row.add_prefix (new Widgets.IconColorProject (20) {
+                project = project
+            });
+
+            action_row.add_suffix (radio_button);
+
+            child = action_row;
+
+            var select_gesture = new Gtk.GestureClick ();
+            action_row.add_controller (select_gesture);
+            select_gesture.released.connect (() => {
+                radio_button.active = !radio_button.active;
+                toggled ();
+            });
+        }
+    }
+}

--- a/src/Dialogs/Preferences/Pages/Backup.vala
+++ b/src/Dialogs/Preferences/Pages/Backup.vala
@@ -41,8 +41,8 @@ public class Dialogs.Preferences.Pages.Backup : Dialogs.Preferences.Pages.BasePa
             use_markup = true,
             wrap = true,
             xalign = 0,
-            margin_end = 6,
-            margin_start = 6
+            margin_end = 3,
+            margin_start = 3
         };
 
         var add_button = new Gtk.Button.with_label (_("Create Backup")) {

--- a/src/Dialogs/Preferences/Pages/QuickAdd.vala
+++ b/src/Dialogs/Preferences/Pages/QuickAdd.vala
@@ -47,8 +47,8 @@ public class Dialogs.Preferences.Pages.QuickAdd : Dialogs.Preferences.Pages.Base
             use_markup = true,
             wrap = true,
             xalign = 0,
-            margin_end = 6,
-            margin_start = 6
+            margin_end = 3,
+            margin_start = 3
         };
 
         var description2_label = new Gtk.Label (
@@ -59,8 +59,8 @@ public class Dialogs.Preferences.Pages.QuickAdd : Dialogs.Preferences.Pages.Base
             wrap = true,
             xalign = 0,
             margin_top = 6,
-            margin_end = 6,
-            margin_start = 6
+            margin_end = 3,
+            margin_start = 3
         };
 
         var copy_button = new Gtk.Button.from_icon_name ("edit-copy-symbolic") {

--- a/src/Layouts/FilterPaneChild.vala
+++ b/src/Layouts/FilterPaneChild.vala
@@ -25,6 +25,8 @@ public class Layouts.FilterPaneChild : Gtk.FlowBoxChild {
 
     private Gtk.Label count_label;
     private Gtk.Revealer indicator_revealer;
+    private Objects.Project? current_inbox_project = null;
+    private ulong inbox_count_signal_id = 0;
     private Gee.HashMap<ulong, weak GLib.Object> signals_map = new Gee.HashMap<ulong, weak GLib.Object> ();
 
     public FilterPaneChild (Objects.BaseObject filter_type) {
@@ -140,6 +142,10 @@ public class Layouts.FilterPaneChild : Gtk.FlowBoxChild {
     public void init_badge_count () {
         if (filter_type is Objects.Filters.Inbox) {
             init_inbox_count ();
+
+            Services.Settings.get_default ().settings.changed["local-inbox-project-id"].connect (() => {
+                init_inbox_count ();
+            });
         } else if (filter_type is Objects.Filters.Today) {
             var today_filter = filter_type as Objects.Filters.Today;
             update_count_label (today_filter.item_count + today_filter.overdeue_count);
@@ -157,14 +163,18 @@ public class Layouts.FilterPaneChild : Gtk.FlowBoxChild {
     }
 
     private void init_inbox_count () {
-        Objects.Project inbox_project = Services.Store.instance ().get_project (
+        if (current_inbox_project != null && inbox_count_signal_id > 0) {
+            current_inbox_project.disconnect (inbox_count_signal_id);
+        }
+
+        current_inbox_project = Services.Store.instance ().get_project (
             Services.Settings.get_default ().settings.get_string ("local-inbox-project-id")
         );
 
-        update_count_label (inbox_project.item_count);
-        signals_map[inbox_project.count_updated.connect (() => {
-            update_count_label (inbox_project.item_count);
-        })] = inbox_project;
+        update_count_label (current_inbox_project.item_count);
+        inbox_count_signal_id = current_inbox_project.count_updated.connect (() => {
+            update_count_label (current_inbox_project.item_count);
+        });
     }
 
     public int item_order () {

--- a/src/Layouts/ProjectRow.vala
+++ b/src/Layouts/ProjectRow.vala
@@ -33,7 +33,6 @@ public class Layouts.ProjectRow : Gtk.ListBoxRow {
     private Gtk.ListBox listbox;
     private Adw.Bin handle_grid;
     private Gtk.Revealer listbox_revealer;
-    private Gtk.Stack progress_emoji_stack;
     private Gtk.Label due_label;
     private Gtk.Stack menu_stack;
     private Gtk.Revealer loading_revealer;
@@ -248,11 +247,8 @@ public class Layouts.ProjectRow : Gtk.ListBoxRow {
             add_subprojects ();
         }
 
-        Timeout.add (main_revealer.transition_duration, () => {
-            if (progress_emoji_stack != null) { // TODO: progress_emoji_stack seems to be used nowhere?
-                progress_emoji_stack.visible_child_name = project.icon_style == ProjectIconStyle.PROGRESS ? "progress" : "emoji";
-            }
-            main_revealer.reveal_child = true;
+        Timeout.add (main_revealer.transition_duration, () => {            
+            main_revealer.reveal_child = !project.is_inbox_project;
             return GLib.Source.REMOVE;
         });
 
@@ -346,14 +342,6 @@ public class Layouts.ProjectRow : Gtk.ListBoxRow {
             }
         })] = Services.EventBus.get_default ();
 
-        destroy.connect (() => {
-            foreach (var entry in signals_map.entries) {
-                entry.value.disconnect (entry.key);
-            }
-
-            signals_map.clear ();
-        });
-
         Services.EventBus.get_default ().projects_drag_begin.connect ((source_id) => {
             if (source_id == project.source.id) {
                 var listbox_parent = parent as Gtk.ListBox;
@@ -374,6 +362,18 @@ public class Layouts.ProjectRow : Gtk.ListBoxRow {
             if (source_id == project.source.id) {
                 drop_target_end_revealer.reveal_child = false;
             }
+        });
+
+        Services.Settings.get_default ().settings.changed["local-inbox-project-id"].connect (() => {
+            main_revealer.reveal_child = !project.is_inbox_project;
+        });
+
+        destroy.connect (() => {
+            foreach (var entry in signals_map.entries) {
+                entry.value.disconnect (entry.key);
+            }
+
+            signals_map.clear ();
         });
     }
 

--- a/src/Layouts/SidebarSourceRow.vala
+++ b/src/Layouts/SidebarSourceRow.vala
@@ -186,7 +186,7 @@ public class Layouts.SidebarSourceRow : Gtk.ListBoxRow {
     }
 
     private void add_row_project (Objects.Project project) {
-        if (project.source_id == source.id && !project.is_inbox_project && project.parent_id == "" && !project.is_archived) {
+        if (project.source_id == source.id && project.parent_id == "" && !project.is_archived) {
             if (!projects_hashmap.has_key (project.id)) {
                 projects_hashmap[project.id] = new Layouts.ProjectRow (project);
                 group.add_child (projects_hashmap[project.id]);

--- a/src/Views/Project/Board.vala
+++ b/src/Views/Project/Board.vala
@@ -47,7 +47,7 @@ public class Views.Board : Adw.Bin {
     }
 
     construct {
-        icon_project = new Widgets.IconColorProject (24) {
+        icon_project = new Widgets.IconColorProject (22) {
             project = project
         };
         icon_project.add_css_class ("title-2");

--- a/src/Views/Project/List.vala
+++ b/src/Views/Project/List.vala
@@ -55,7 +55,7 @@ public class Views.List : Adw.Bin {
     }
 
     construct {
-        icon_project = new Widgets.IconColorProject (24) {
+        icon_project = new Widgets.IconColorProject (22) {
             project = project
         };
         icon_project.add_css_class ("title-2");

--- a/src/meson.build
+++ b/src/meson.build
@@ -133,7 +133,8 @@ sources = files(
   'Dialogs/Preferences/Pages/Accounts/NextcloudSetup.vala',
   'Dialogs/Preferences/Pages/Accounts/CalDAVSetup.vala',
   'Dialogs/Preferences/Pages/Accounts/TodoistSetup.vala',
-  'Dialogs/Preferences/Pages/Accounts/SourceView.vala'
+  'Dialogs/Preferences/Pages/Accounts/SourceView.vala',
+  'Dialogs/Preferences/Pages/Accounts/InboxPage.vala'
 )
 
 if get_option('evolution')


### PR DESCRIPTION
## Summary
Implements user-configurable inbox project selection, allowing users to choose any project as their default inbox instead of being limited to the local inbox project.

**Changes**

- **Inbox Project Selector**: New preferences page to select inbox project from any available source (Local, Todoist, Nextcloud, CalDAV)
- **Dynamic Inbox Detection**: Projects now dynamically check if they're the current inbox via settings
- **Source Protection**: Prevents hiding accounts that contain the current inbox project with warning dialog

**UI/UX Improvements**

- Added "Inbox Project" option in Accounts preferences with current selection display
- Descriptive text explaining inbox concept based on GTD methodology
- Alert dialog when attempting to hide inbox source with option to change inbox
- Radio button selection for easy inbox project switching

FIxes: #1616 #1508 #1162
