### PR TITLE
fix: Prevent crash when closing CompletedTasks dialog after navigation

### DIFF
--- a/core/Widgets/MarkdownEditor.vala
+++ b/core/Widgets/MarkdownEditor.vala
@@ -1327,12 +1327,18 @@ public class Widgets.MarkdownEditor : Adw.Bin {
     
     public void cleanup () {
         if (format_popover != null) {
-            format_popover.unparent ();
+            if (format_popover.get_parent () != null) {
+                format_popover.popdown ();
+                format_popover.unparent ();
+            }
             format_popover = null;
         }
         
         if (link_popover != null) {
-            link_popover.unparent ();
+            if (link_popover.get_parent () != null) {
+                link_popover.popdown ();
+                link_popover.unparent ();
+            }
             link_popover = null;
         }
     }

--- a/src/Dialogs/CompletedTasks.vala
+++ b/src/Dialogs/CompletedTasks.vala
@@ -210,6 +210,9 @@ public class Dialogs.CompletedTasks : Adw.Dialog {
             }
         })] = Services.Store.instance ();
 
+        // No necesitamos llamar clean_up manualmente aquí
+        // El signal destroy lo hará automáticamente
+
         closed.connect (() => {
             clean_up ();
             Services.EventBus.get_default ().connect_typing_accel ();
@@ -217,18 +220,14 @@ public class Dialogs.CompletedTasks : Adw.Dialog {
     }
 
     private void view_item (Objects.Item item) {
-        var headerbar = new Adw.HeaderBar ();
-        headerbar.add_css_class ("flat");
-
-        Widgets.ItemDetailCompleted item_detail = new Widgets.ItemDetailCompleted (item);
-        signals_map[item_detail.view_item.connect (view_item)] = item_detail;
-
-        var toolbar_view = new Adw.ToolbarView ();
-        toolbar_view.add_top_bar (headerbar);
-        toolbar_view.content = item_detail;
-
-        var item_page = new Adw.NavigationPage (toolbar_view, _ ("Task Detail"));
-        navigation_view.push (item_page);
+        Widgets.ItemDetailCompleted item_detail_page = new Widgets.ItemDetailCompleted (item);
+        var signal_id = item_detail_page.view_item.connect (view_item);
+        
+        item_detail_page.destroy.connect (() => {
+            item_detail_page.disconnect (signal_id);
+        });
+        
+        navigation_view.push (item_detail_page);
     }
 
     private void add_items () {

--- a/src/Widgets/ItemDetailCompleted.vala
+++ b/src/Widgets/ItemDetailCompleted.vala
@@ -19,7 +19,7 @@
  * Authored by: Alain M. <alainmh23@gmail.com>
  */
 
-public class Widgets.ItemDetailCompleted : Adw.Bin {
+public class Widgets.ItemDetailCompleted : Adw.NavigationPage {
     public Objects.Item item { get; construct; }
 
     private Gtk.ListBox listbox;
@@ -28,7 +28,7 @@ public class Widgets.ItemDetailCompleted : Adw.Bin {
     public signal void view_item (Objects.Item item);
 
     private Gee.HashMap<string, Widgets.CompletedTaskRow> items_checked = new Gee.HashMap<string, Widgets.CompletedTaskRow> ();
-    private Gee.HashMap<ulong, weak GLib.Object> signals_map = new Gee.HashMap<ulong, weak GLib.Object> ();
+    private Gee.HashMap<ulong, weak GLib.Object> signal_map = new Gee.HashMap<ulong, weak GLib.Object> ();
 
     public ItemDetailCompleted (Objects.Item item) {
         Object (
@@ -145,10 +145,15 @@ public class Widgets.ItemDetailCompleted : Adw.Bin {
 
         var scrolled_window = new Widgets.ScrolledWindow (content);
 
-        child = scrolled_window;
+        var toolbar_view = new Adw.ToolbarView ();
+        toolbar_view.add_top_bar (new Adw.HeaderBar ());
+        toolbar_view.content = scrolled_window;
+
+        child = toolbar_view;
+
         add_items ();
 
-        signals_map[Services.EventBus.get_default ().checked_toggled.connect ((_item, old_checked) => {
+        signal_map[Services.EventBus.get_default ().checked_toggled.connect ((_item, old_checked) => {
             if (_item.parent_id != item.id) {
                 return;
             }
@@ -166,7 +171,7 @@ public class Widgets.ItemDetailCompleted : Adw.Bin {
             }
         })] = Services.EventBus.get_default ();
 
-        signals_map[listbox.row_activated.connect ((row) => {
+        signal_map[listbox.row_activated.connect ((row) => {
             Objects.Item item = ((Widgets.CompletedTaskRow) row).item;
             view_item (item);
         })] = listbox;
@@ -223,14 +228,10 @@ public class Widgets.ItemDetailCompleted : Adw.Bin {
     }
 
     public void clean_up () {
-        if (markdown_editor != null) {
-            markdown_editor.cleanup ();
-        }
-
-        foreach (var entry in signals_map.entries) {
+        foreach (var entry in signal_map.entries) {
             entry.value.disconnect (entry.key);
         }
 
-        signals_map.clear ();
+        signal_map.clear ();
     }
 }


### PR DESCRIPTION
**Problem**
The application was crashing with a segmentation fault when closing the CompletedTasks dialog after navigating through multiple task details. This occurred because weak references to destroyed `ItemDetailCompleted` pages were being stored in `signals_map`, and attempting to disconnect signals from these destroyed objects caused memory access violations.

**Root Cause**
When navigating to task details, the signal connection was stored as:
```vala
signals_map[item_detail_page.view_item.connect (view_item)] = item_detail_page;
