### PR TITLE
Add ComboWrapRow widget as alternative to Adw.ComboRow for better selection visibility

### DIFF
--- a/data/resources/stylesheet/stylesheet.css
+++ b/data/resources/stylesheet/stylesheet.css
@@ -359,6 +359,11 @@ entry.flat:focus-within {
     padding: 0px 12px;
 }
 
+.tiny-button {
+    padding: 0 6px;
+    font-weight: 600;
+}
+
 .pane-due-button {
     background-color: @upcoming_bg_color;
     border-radius: 6px;

--- a/src/Dialogs/Preferences/Pages/TaskSetting.vala
+++ b/src/Dialogs/Preferences/Pages/TaskSetting.vala
@@ -38,7 +38,7 @@ public class Dialogs.Preferences.Pages.TaskSetting : Dialogs.Preferences.Pages.B
         complete_tasks_model.append (_("Complete Instantly"));
         complete_tasks_model.append (_("Complete with Undo"));
 
-        var complete_tasks_row = new Adw.ComboRow ();
+        var complete_tasks_row = new Widgets.ComboWrapRow ();
         complete_tasks_row.title = _("Task Completion");
         complete_tasks_row.subtitle = _("Choose how tasks behave when marked as complete");
         complete_tasks_row.model = complete_tasks_model;
@@ -150,7 +150,7 @@ public class Dialogs.Preferences.Pages.TaskSetting : Dialogs.Preferences.Pages.B
         reminders_model.append (_("2 hours before"));
         reminders_model.append (_("3 hours before"));
 
-        var reminders_comborow = new Adw.ComboRow ();
+        var reminders_comborow = new Widgets.ComboWrapRow ();
         reminders_comborow.title = _("Automatic reminders");
         reminders_comborow.subtitle =
             _("When enabled, a reminder before the task’s due time will be added by default.");
@@ -162,35 +162,31 @@ public class Dialogs.Preferences.Pages.TaskSetting : Dialogs.Preferences.Pages.B
         reminders_group.add (automatic_reminders);
         reminders_group.add (reminders_comborow);
 
-        var content_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 12);
-        content_box.append (group);
-        content_box.append (reminders_group);
-
-        var content_clamp = new Adw.Clamp () {
-            maximum_size = 600,
+        var content_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 12) {
             margin_start = 24,
             margin_end = 24,
             margin_bottom = 24,
             margin_top = 24
         };
-
-        content_clamp.child = content_box;
+        content_box.append (group);
+        content_box.append (reminders_group);
 
         var scrolled_window = new Gtk.ScrolledWindow () {
             hscrollbar_policy = Gtk.PolicyType.NEVER,
             hexpand = true,
-            vexpand = true
+            vexpand = true,
+            child = content_box
         };
-        scrolled_window.child = content_clamp;
 
-        var toolbar_view = new Adw.ToolbarView ();
+        var toolbar_view = new Adw.ToolbarView () {
+            content = scrolled_window
+        };
         toolbar_view.add_top_bar (new Adw.HeaderBar ());
-        toolbar_view.content = scrolled_window;
 
         child = toolbar_view;
 
         signal_map[complete_tasks_row.notify["selected"].connect (() => {
-            Services.Settings.get_default ().settings.set_enum ("complete-task", (int) complete_tasks_row.selected);
+            Services.Settings.get_default ().settings.set_enum ("complete-task", complete_tasks_row.selected);
         })] = complete_tasks_row;
 
         signal_map[default_priority_row.notify["selected"].connect (() => {
@@ -209,8 +205,7 @@ public class Dialogs.Preferences.Pages.TaskSetting : Dialogs.Preferences.Pages.B
         })] = underline_completed_switch;
 
         signal_map[reminders_comborow.notify["selected"].connect (() => {
-            Services.Settings.get_default ().settings.set_enum ("automatic-reminders",
-                                                                (int) reminders_comborow.selected);
+            Services.Settings.get_default ().settings.set_enum ("automatic-reminders", reminders_comborow.selected);
         })] = reminders_comborow;
 
         destroy.connect (() => {

--- a/src/Widgets/ComboWrapRow.vala
+++ b/src/Widgets/ComboWrapRow.vala
@@ -1,0 +1,139 @@
+/*
+* Copyright © 2025 Alain M. (https://github.com/alainm23/planify)
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU General Public
+* License as published by the Free Software Foundation; either
+* version 3 of the License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* General Public License for more details.
+*
+* You should have received a copy of the GNU General Public
+* License along with this program; if not, write to the
+* Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+* Boston, MA 02110-1301 USA
+*
+* Authored by: Alain M. <alainmh23@gmail.com>
+*/
+
+public class Widgets.ComboWrapRow : Adw.PreferencesRow {
+    private Gtk.Label _title_label;
+    private Gtk.Label _subtitle_label;
+    private Adw.WrapBox _wrap_box;
+
+    public string title {
+        owned get {
+             return _title_label.label;
+        }
+
+        set {
+            _title_label.label = value;
+        }
+    }
+
+    public string subtitle {
+        owned get {
+            return _subtitle_label.label;
+        }
+
+        set {
+            _subtitle_label.label = value;
+        }
+    }
+
+    public Gtk.StringList model {
+        set {
+            for (uint i = 0; i < value.get_n_items (); i++) {
+                var button = new Gtk.Button.with_label (value.get_string (i));
+                button.add_css_class ("tiny-button");
+                button.add_css_class ("caption");
+
+                int index = (int) i;
+                button.clicked.connect (() => {
+                    selected = index;
+                });
+
+                _wrap_box.append (button);
+            }
+        }
+    }
+
+    public int selected {
+        set {
+            var child = _wrap_box.get_first_child ();
+            int index = 0;
+            while (child != null) {
+                if (child is Gtk.Button) {
+                    var button = (Gtk.Button) child;
+                    if (index == value) {
+                        button.add_css_class ("color-primary");
+                    } else {
+                        button.remove_css_class ("color-primary");
+                    }
+                }
+                child = child.get_next_sibling ();
+                index++;
+            }
+        }
+
+        get {
+            var child = _wrap_box.get_first_child ();
+            int index = 0;
+            while (child != null) {
+                if (child is Gtk.Button && ((Gtk.Button) child).has_css_class ("color-primary")) {
+                    return index;
+                }
+                child = child.get_next_sibling ();
+                index++;
+            }
+            return -1;
+        }
+    }
+
+    construct {
+        _title_label = new Gtk.Label (null) {
+            hexpand = true,
+            xalign = 0,
+            wrap = true
+        };
+
+        _subtitle_label = new Gtk.Label (null) {
+            xalign = 0,
+            hexpand = true,
+            use_markup = true,
+            wrap = true
+        };
+        _subtitle_label.add_css_class ("dimmed");
+        _subtitle_label.add_css_class ("caption");
+
+        var _text_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 3) {
+            hexpand = true,
+            valign = Gtk.Align.CENTER
+        };
+
+        _text_box.append (_title_label);
+        _text_box.append (_subtitle_label);
+
+        _wrap_box = new Adw.WrapBox () {
+            line_spacing = 6,
+            child_spacing = 6
+        };
+
+        var main_box = new Gtk.Box (VERTICAL, 12) {
+            margin_start = 12,
+            margin_end = 12,
+            margin_top = 8,
+            margin_bottom = 8
+        };
+        
+        main_box.append (_text_box);
+        main_box.append (_wrap_box);
+
+        child = main_box;
+    }
+
+
+}

--- a/src/Widgets/TranslationRow.vala
+++ b/src/Widgets/TranslationRow.vala
@@ -277,12 +277,16 @@ public class Widgets.TranslationRow : Adw.PreferencesRow {
         };
 
         _title_label = new Gtk.Label (null) {
-            halign = Gtk.Align.START,
+            hexpand = true,
+            xalign = 0,
+            wrap = true
         };
 
         _subtitle_label = new Gtk.Label (null) {
-            halign = Gtk.Align.START,
-            use_markup = true
+            xalign = 0,
+            hexpand = true,
+            use_markup = true,
+            wrap = true
         };
         _subtitle_label.add_css_class ("dimmed");
         _subtitle_label.add_css_class ("caption");

--- a/src/meson.build
+++ b/src/meson.build
@@ -85,6 +85,7 @@ sources = files(
   'Widgets/NewVersionPopup.vala',
   'Widgets/ProjectItemRow.vala',
   'Widgets/SectionItemRow.vala',
+  'Widgets/ComboWrapRow.vala',
 
   'Views/Project/Project.vala',
   'Views/Project/List.vala',


### PR DESCRIPTION
Introduces `ComboWrapRow` as an alternative to `Adw.ComboRow` that improves selection visibility by displaying all options as buttons with clear visual feedback for the selected item.

Fixes: #1936 #1921

<img width="484" height="625" alt="image" src="https://github.com/user-attachments/assets/b1f464d9-2adb-49a2-b937-ebabd5c34e6c" />

<img width="484" height="625" alt="image" src="https://github.com/user-attachments/assets/a9251a56-af3e-4f0f-a294-23d087756e2e" />

