### PR TITLE
QuickAdd: Preserve task attributes in "Keep adding" mode

### DIFF
--- a/core/meson.build
+++ b/core/meson.build
@@ -1,7 +1,7 @@
 core_files = files(
     'Enum.vala',
     'Constants.vala',
-    'QuickAdd.vala',
+    'QuickAddCore.vala',
 
     'Utils/Util.vala',
     'Utils/Datetime.vala',

--- a/quick-add/MainWindow.vala
+++ b/quick-add/MainWindow.vala
@@ -1,5 +1,5 @@
 public class MainWindow : Adw.ApplicationWindow {
-    private Layouts.QuickAdd quick_add_widget;
+    private Layouts.QuickAddCore quick_add_widget;
 
     public bool can_close { get; set; default = true; }
     public MainWindow (QuickAdd application) {
@@ -21,7 +21,7 @@ public class MainWindow : Adw.ApplicationWindow {
     construct {
         Services.Database.get_default ().init_database ();
 
-        quick_add_widget = new Layouts.QuickAdd (true);
+        quick_add_widget = new Layouts.QuickAddCore (true);
         set_content (quick_add_widget);
 
         quick_add_widget.hide_destroy.connect (hide_destroy);

--- a/src/Dialogs/QuickAdd.vala
+++ b/src/Dialogs/QuickAdd.vala
@@ -22,7 +22,7 @@
 public class Dialogs.QuickAdd : Adw.Dialog {
     public Objects.Item item { get; construct; }
 
-    private Layouts.QuickAdd quick_add_widget;
+    private Layouts.QuickAddCore quick_add_widget;
 
     public int position {
         set {
@@ -49,7 +49,7 @@ public class Dialogs.QuickAdd : Adw.Dialog {
     construct {
         Services.EventBus.get_default ().disconnect_all_accels ();
 
-        quick_add_widget = new Layouts.QuickAdd ();
+        quick_add_widget = new Layouts.QuickAddCore ();
         child = quick_add_widget;
 
         signal_map[quick_add_widget.hide_destroy.connect (() => {


### PR DESCRIPTION
Preserves due date, pinned state, and labels when creating multiple tasks consecutively. Improves UX by maintaining user-set attributes across task creation sessions when "Keep adding" is enabled.

