### PR TITLE
Add optional spell checking setting

### DIFF
--- a/core/Widgets/MarkdownEditor.vala
+++ b/core/Widgets/MarkdownEditor.vala
@@ -102,11 +102,15 @@ public class Widgets.MarkdownEditor : Adw.Bin {
         create_format_popover ();
         update_mode ();
 
-#if LIBSPELLING
+#if WITH_LIBSPELLING
         var adapter = new Spelling.TextBufferAdapter (buffer, Spelling.Checker.get_default ());
         text_view.extra_menu = adapter.get_menu_model ();
         text_view.insert_action_group ("spelling", adapter);
-        adapter.enabled = true;
+        adapter.enabled = Services.Settings.get_default ().settings.get_boolean ("spell-checking-enabled");
+        
+        Services.Settings.get_default ().settings.changed["spell-checking-enabled"].connect (() => {
+            adapter.enabled = Services.Settings.get_default ().settings.get_boolean ("spell-checking-enabled");
+        });
 #endif
         
         Services.Settings.get_default ().settings.changed["enable-markdown-formatting"].connect (() => {

--- a/data/io.github.alainm23.planify.gschema.xml
+++ b/data/io.github.alainm23.planify.gschema.xml
@@ -327,5 +327,11 @@
             <summary>List View for Filters</summary>
             <description>Show filters in a simple list instead of a grid.</description>
         </key>
+
+        <key name="spell-checking-enabled" type="b">
+            <default>true</default>
+            <summary>Enable Spell Checking</summary>
+            <description>Enable spell checking in task descriptions and notes to help catch spelling errors</description>
+        </key>
     </schema>
 </schemalist>

--- a/meson.build
+++ b/meson.build
@@ -35,7 +35,7 @@ if get_option('webkit')
 endif
 
 if libspelling.found ()
-  add_project_arguments(['--define=LIBSPELLING'], language: 'vala')
+  add_project_arguments(['--define=WITH_LIBSPELLING'], language: 'vala')
 endif
 
 if get_option('portal')

--- a/src/Dialogs/Preferences/Pages/TaskSetting.vala
+++ b/src/Dialogs/Preferences/Pages/TaskSetting.vala
@@ -132,6 +132,14 @@ public class Dialogs.Preferences.Pages.TaskSetting : Dialogs.Preferences.Pages.B
 
         group.add (always_show_sidebar_item);
 
+        var spell_checking_item = new Adw.SwitchRow ();
+        spell_checking_item.title = _("Enable Spell Checking");
+        spell_checking_item.subtitle = _("Check spelling in task descriptions and notes");
+        Services.Settings.get_default ().settings.bind ("spell-checking-enabled", spell_checking_item,
+                                                        "active", GLib.SettingsBindFlags.DEFAULT);
+
+        group.add (spell_checking_item);
+
         var reminders_group = new Adw.PreferencesGroup () {
             title = _("Reminders")
         };

--- a/src/Layouts/ItemRow.vala
+++ b/src/Layouts/ItemRow.vala
@@ -361,14 +361,18 @@ public class Layouts.ItemRow : Layouts.ItemBase {
         content_textview.remove_css_class ("view");
         content_textview.add_css_class ("font-bold");
 
-#if LIBSPELLING
+#if WITH_LIBSPELLING
         var source_buffer = new GtkSource.Buffer (null);
         content_textview.buffer = source_buffer;
         
         var adapter = new Spelling.TextBufferAdapter (source_buffer, Spelling.Checker.get_default ());
         content_textview.extra_menu = adapter.get_menu_model ();
         content_textview.insert_action_group ("spelling", adapter);
-        adapter.enabled = true;
+        adapter.enabled = Services.Settings.get_default ().settings.get_boolean ("spell-checking-enabled");
+        
+        Services.Settings.get_default ().settings.changed["spell-checking-enabled"].connect (() => {
+            adapter.enabled = Services.Settings.get_default ().settings.get_boolean ("spell-checking-enabled");
+        });
 #endif
 
         content_entry_revealer = new Gtk.Revealer () {

--- a/src/Layouts/ItemSidebarView.vala
+++ b/src/Layouts/ItemSidebarView.vala
@@ -122,14 +122,18 @@ public class Layouts.ItemSidebarView : Adw.Bin {
         content_textview.remove_css_class ("view");
         content_textview.add_css_class ("card");
 
-#if LIBSPELLING
+#if WITH_LIBSPELLING
         var source_buffer = new GtkSource.Buffer (null);
         content_textview.buffer = source_buffer;
         
         var adapter = new Spelling.TextBufferAdapter (source_buffer, Spelling.Checker.get_default ());
         content_textview.extra_menu = adapter.get_menu_model ();
         content_textview.insert_action_group ("spelling", adapter);
-        adapter.enabled = true;
+        adapter.enabled = Services.Settings.get_default ().settings.get_boolean ("spell-checking-enabled");
+        
+        Services.Settings.get_default ().settings.changed["spell-checking-enabled"].connect (() => {
+            adapter.enabled = Services.Settings.get_default ().settings.get_boolean ("spell-checking-enabled");
+        });
 #endif
 
         var content_group = new Adw.PreferencesGroup () {


### PR DESCRIPTION
Adds a new boolean setting to make spell checking optional in task descriptions and notes.

Changes:
- Added `spell-checking-enabled` GSettings key (default: true)
- Added toggle switch in Task Settings preferences
- Spell checker now respects user preference and updates dynamically

Fixes: #1991

<img width="454" height="328" alt="image" src="https://github.com/user-attachments/assets/780383f5-edee-49b7-b301-cc6506fb0a62" />
