### PR TITLE
Auto-update task due dates when day changes

### DIFF
--- a/src/Layouts/ItemBoard.vala
+++ b/src/Layouts/ItemBoard.vala
@@ -478,6 +478,10 @@ public class Layouts.ItemBoard : Layouts.ItemBase {
             item.update_pin (false);
         })] = hide_loading_button;
 
+        signals_map[Services.EventBus.get_default ().day_changed.connect (() => {
+            update_due_label ();
+        })] = Services.EventBus.get_default ();
+
         signals_map[activate.connect (() => {
             open_detail ();
         })] = this;

--- a/src/Layouts/ItemRow.vala
+++ b/src/Layouts/ItemRow.vala
@@ -919,6 +919,10 @@ public class Layouts.ItemRow : Layouts.ItemBase {
             }
         })] = Services.EventBus.get_default ();
 
+        signals_map[Services.EventBus.get_default ().day_changed.connect (() => {
+            schedule_button.update_from_item (item);
+        })] = Services.EventBus.get_default ();
+
         signals_map[notify["edit"].connect (() => {
             if (!edit) {
                 if (Services.Settings.get_default ().settings.get_boolean ("attention-at-one")) {


### PR DESCRIPTION
Fixes scheduled task dates not updating automatically when the app stays open overnight.

Fixes: #1964 