### PR TITLE
Add Spanish language support to Chrono date parser

### DIFF
--- a/core/QuickAddCore.vala
+++ b/core/QuickAddCore.vala
@@ -104,7 +104,7 @@ public class Layouts.QuickAddCore : Adw.Bin {
     }
 
     construct {
-        chrono = new Chrono.Chrono ();
+        chrono = new Chrono.Chrono (Util.get_user_language ());
         date_auto_detection_enabled = Services.Settings.get_default ().settings.get_boolean ("smart-date-recognition");
         
         item = new Objects.Item ();

--- a/core/Services/Chrono/Chrono.vala
+++ b/core/Services/Chrono/Chrono.vala
@@ -22,12 +22,14 @@
 namespace Chrono {
     public class Chrono : Object {
         private Parser parser;
+        private string language;
         
-        public Chrono () {
+        public Chrono (string language = "en") {
+            this.language = language;
             parser = new Parser ();
         }
         
-        public ParseResult? parse (string text, string language = "en", bool parse_recurrence = false) {
+        public ParseResult? parse (string text, bool parse_recurrence = false) {
             return parser.parse (text, language, parse_recurrence);
         }
     }

--- a/core/Services/Chrono/Locales/README.md
+++ b/core/Services/Chrono/Locales/README.md
@@ -1,0 +1,104 @@
+# 🌍 Multi-language Support for Planify
+
+This directory contains multi-language support for Planify's date parsing system.
+
+## 📁 Structure
+
+```
+Locales/
+├── en/                 # English
+├── es/                 # Spanish  
+├── template/           # Template files for new languages
+├── create_language.sh  # Script to create new languages
+├── TEMPLATE.md         # Detailed guide
+└── README.md          # This file
+```
+
+## 🚀 Adding a New Language
+
+1. Copy the `template/` folder to `[language_code]/`
+2. Rename files replacing `TEMPLATE` with your code
+3. Edit each file with corresponding translations
+4. Register the parser in `Chrono.vala`
+
+## 📝 Files per Language
+
+Each language must implement these parsers:
+
+| File | Purpose | Examples |
+|------|---------|----------|
+| `Constants.vala` | Months and time units | "january", "week", "year" |
+| `CasualDateParser.vala` | Casual dates | "today", "tomorrow", "yesterday" |
+| `RelativeDateFormatParser.vala` | Relative dates | "next week", "last month" |
+| `CasualTimeParser.vala` | Casual times | "in the morning", "at night" |
+| `MonthNameParser.vala` | Month names | "January 15", "March 2024" |
+| `TimeExpressionParser.vala` | Time expressions | "at 3pm", "14:30" |
+| `DateTimeComboParser.vala` | Combinations | "tomorrow at 9am" |
+| `[Language]Parser.vala` | Main parser | Coordinates all parsers |
+
+## 🎯 Common Patterns by Language
+
+### Spanish
+- **Casual dates**: hoy, mañana, ayer, pasado mañana
+- **Relative dates**: próxima semana, mes pasado, este año
+- **Times**: por la mañana, en la tarde, por la noche
+
+### English  
+- **Casual dates**: today, tomorrow, yesterday
+- **Relative dates**: next week, last month, this year
+- **Times**: in the morning, in the afternoon, at night
+
+### French (example)
+- **Casual dates**: aujourd'hui, demain, hier
+- **Relative dates**: la semaine prochaine, le mois dernier
+- **Times**: le matin, l'après-midi, le soir
+
+## 🔧 Implementation Tips
+
+### 1. Regular Expressions
+- Use `RegexCompileFlags.CASELESS` to ignore case
+- Include variations with and without accents
+- Consider plural and singular forms
+
+### 2. Constants
+- Add full names and abbreviations for months
+- Include all variations of time units
+- Consider common synonyms
+
+### 3. Testing
+- Test with phrases users would actually write
+- Include edge cases like accents, capitals, extra spaces
+- Verify no conflicts between parsers
+
+## ✅ Checklist
+
+Before submitting your implementation:
+
+- [ ] All files created and compiling
+- [ ] Constants fully translated  
+- [ ] Regex patterns working correctly
+- [ ] Parser registered in `Chrono.vala`
+- [ ] Basic tests passing
+- [ ] No conflicts with other languages
+
+## 🤝 Contributing
+
+1. **Fork** the repository
+2. **Create** a branch: `git checkout -b add-[language]-support`
+3. **Implement** your language following this guide
+4. **Test** your implementation
+5. **Submit** a pull request
+
+## 📚 Useful Resources
+
+- [ISO Language Codes](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes)
+- [Vala Regex Documentation](https://valadoc.org/glib-2.0/GLib.Regex.html)
+- [Complete guide in TEMPLATE.md](TEMPLATE.md)
+
+## 🌟 Supported Languages
+
+- ✅ **English** (en) - Complete
+- ✅ **Spanish** (es) - Complete
+- 🚧 **Your language here** - Contribute!
+
+Help us make Planify accessible to more people! 🚀

--- a/core/Services/Chrono/Locales/TEMPLATE.md
+++ b/core/Services/Chrono/Locales/TEMPLATE.md
@@ -1,0 +1,100 @@
+# Adding New Language Support
+
+This guide will help you add support for a new language in Planify's date parsing system.
+
+## 📁 File Structure
+
+To add a new language, you need to create a folder with the ISO language code (e.g., `fr` for French, `de` for German) inside `core/Services/Chrono/Locales/`.
+
+### Required Files
+
+Each language must have these files:
+
+```
+Locales/[language_code]/
+├── [CODE]Constants.vala          # Language constants
+├── [CODE]CasualDateParser.vala   # Casual date parser
+├── [CODE]CasualTimeParser.vala   # Casual time parser  
+├── [CODE]MonthNameParser.vala    # Month name parser
+├── [CODE]RelativeDateFormatParser.vala # Relative date parser
+├── [CODE]TimeExpressionParser.vala     # Time expression parser
+├── [CODE]DateTimeComboParser.vala      # Combined parser
+└── [Language]Parser.vala         # Main parser
+```
+
+## 🚀 Steps to Add a New Language
+
+### 1. Create Language Folder
+
+```bash
+mkdir core/Services/Chrono/Locales/[language_code]
+```
+
+### 2. Copy Templates
+
+Copy template files and rename them:
+
+```bash
+cp core/Services/Chrono/Locales/template/* core/Services/Chrono/Locales/[language_code]/
+```
+
+### 3. Customize Files
+
+Edit each file replacing:
+- `TEMPLATE` → language code in uppercase (e.g., `FR`, `DE`)
+- `Template` → language name (e.g., `French`, `German`)
+- Constants and patterns with corresponding translations
+
+### 4. Register New Parser
+
+Add the new parser in `core/Services/Chrono/Chrono.vala`:
+
+```vala
+// In constructor, add:
+parsers.add (new [Language]Parser ());
+```
+
+## 📝 Pattern Examples by Language
+
+### Relative Dates
+- **Spanish**: "la próxima semana", "el mes pasado"
+- **French**: "la semaine prochaine", "le mois dernier"
+- **German**: "nächste Woche", "letzten Monat"
+
+### Casual Dates
+- **Spanish**: "hoy", "mañana", "ayer"
+- **French**: "aujourd'hui", "demain", "hier"
+- **German**: "heute", "morgen", "gestern"
+
+### Times
+- **Spanish**: "por la mañana", "en la tarde"
+- **French**: "le matin", "l'après-midi"
+- **German**: "am Morgen", "am Nachmittag"
+
+## 🔧 Implementation Tips
+
+1. **Use flexible regex patterns** that capture common variations
+2. **Include accented and unaccented versions** for better compatibility
+3. **Consider plural and singular forms** of all words
+4. **Test with real phrases** users would actually write
+5. **Document supported patterns** in comments
+
+## ✅ Checklist
+
+- [ ] All files created and renamed
+- [ ] Constants translated (months, time units)
+- [ ] Regex patterns updated
+- [ ] Main parser registered in Chrono.vala
+- [ ] Basic tests working
+- [ ] Documentation updated
+
+## 🤝 Contributing
+
+Once your implementation is ready:
+
+1. Fork the repository
+2. Create a branch for your language: `git checkout -b add-[language]-support`
+3. Commit your changes: `git commit -m "Add [language] language support"`
+4. Submit a pull request
+
+Thanks for helping make Planify more accessible! 🌍

--- a/core/Services/Chrono/Locales/es/ESCasualDateParser.vala
+++ b/core/Services/Chrono/Locales/es/ESCasualDateParser.vala
@@ -1,0 +1,122 @@
+/*
+ * Copyright © 2025 Alain M. (https://github.com/alainm23/planify)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA
+ *
+ * Authored by: Alain M. <alainmh23@gmail.com>
+ */
+
+namespace Chrono {
+    /**
+     * Spanish casual date expressions parser
+     * 
+     * Supports: ahora, hoy, mañana, ayer, pasado mañana, anteayer
+     */
+    public class ESCasualDateParser : Object {
+        private Regex casual_regex;
+        
+        public ESCasualDateParser () {
+            try {
+                casual_regex = new Regex (
+                    "\\b(ahora|hoy|mañana|manana|ayer|pasado\\s*mañana|pasado\\s*manana|anteayer)\\b",
+                    RegexCompileFlags.CASELESS
+                );
+            } catch (Error e) {
+                warning ("Error creating casual date regex: %s", e.message);
+            }
+        }
+        
+        public ParseResult? parse (string text) {
+            try {
+                MatchInfo match;
+                if (!casual_regex.match (text, 0, out match)) {
+                    return null;
+                }
+                
+                string keyword = match.fetch (1).down ().replace (" ", "");
+                var now = new DateTime.now_local ();
+                DateTime date;
+                
+                switch (keyword) {
+                    case "ahora":
+                        date = now;
+                        break;
+                    case "hoy":
+                        date = new DateTime.local (
+                            now.get_year (),
+                            now.get_month (),
+                            now.get_day_of_month (),
+                            0, 0, 0
+                        );
+                        break;
+                    case "mañana":
+                    case "manana":
+                        var tomorrow = now.add_days (1);
+                        date = new DateTime.local (
+                            tomorrow.get_year (),
+                            tomorrow.get_month (),
+                            tomorrow.get_day_of_month (),
+                            0, 0, 0
+                        );
+                        break;
+                    case "pasadomañana":
+                    case "pasadomanana":
+                        var overmorrow = now.add_days (2);
+                        date = new DateTime.local (
+                            overmorrow.get_year (),
+                            overmorrow.get_month (),
+                            overmorrow.get_day_of_month (),
+                            0, 0, 0
+                        );
+                        break;
+                    case "ayer":
+                        var yesterday = now.add_days (-1);
+                        date = new DateTime.local (
+                            yesterday.get_year (),
+                            yesterday.get_month (),
+                            yesterday.get_day_of_month (),
+                            0, 0, 0
+                        );
+                        break;
+                    case "anteayer":
+                        var before_yesterday = now.add_days (-2);
+                        date = new DateTime.local (
+                            before_yesterday.get_year (),
+                            before_yesterday.get_month (),
+                            before_yesterday.get_day_of_month (),
+                            0, 0, 0
+                        );
+                        break;
+                    default:
+                        return null;
+                }
+                
+                var result = new ParseResult ();
+                result.date = date;
+                
+                int start_pos, end_pos;
+                match.fetch_pos (0, out start_pos, out end_pos);
+                result.start_index = start_pos;
+                result.end_index = end_pos;
+                result.matched_text = match.fetch (0);
+                
+                return result;
+            } catch (Error e) {
+                return null;
+            }
+        }
+    }
+}

--- a/core/Services/Chrono/Locales/es/ESCasualTimeParser.vala
+++ b/core/Services/Chrono/Locales/es/ESCasualTimeParser.vala
@@ -1,0 +1,96 @@
+/*
+ * Copyright © 2025 Alain M. (https://github.com/alainm23/planify)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA
+ *
+ * Authored by: Alain M. <alainmh23@gmail.com>
+ */
+ 
+namespace Chrono {
+    /**
+     * Spanish casual time expressions parser
+     * 
+     * Supports: mañana, tarde, noche, medianoche, mediodía
+     * With optional "esta" prefix
+     */
+    public class ESCasualTimeParser : Object {
+        private Regex casual_time_regex;
+        
+        public ESCasualTimeParser () {
+            try {
+                casual_time_regex = new Regex (
+                    "(?:esta)?\\s{0,3}(mañana|manana|tarde|noche|medianoche|mediodía|mediodia)(?=\\W|$)",
+                    RegexCompileFlags.CASELESS
+                );
+            } catch (Error e) {
+                warning ("Error creating casual time regex: %s", e.message);
+            }
+        }
+        
+        public ParseResult? parse (string text) {
+            try {
+                MatchInfo match;
+                if (!casual_time_regex.match (text, 0, out match)) {
+                    return null;
+                }
+                
+                string keyword = match.fetch (1).down ();
+                var now = new DateTime.now_local ();
+                int hour;
+                
+                switch (keyword) {
+                    case "mañana":
+                    case "manana":
+                        hour = 9;
+                        break;
+                    case "tarde":
+                        hour = 14;
+                        break;
+                    case "noche":
+                        hour = 20;
+                        break;
+                    case "medianoche":
+                        hour = 0;
+                        break;
+                    case "mediodía":
+                    case "mediodia":
+                        hour = 12;
+                        break;
+                    default:
+                        return null;
+                }
+                
+                var result = new ParseResult ();
+                result.date = new DateTime.local (
+                    now.get_year (),
+                    now.get_month (),
+                    now.get_day_of_month (),
+                    hour, 0, 0
+                );
+                
+                int start_pos, end_pos;
+                match.fetch_pos (0, out start_pos, out end_pos);
+                result.start_index = start_pos;
+                result.end_index = end_pos;
+                result.matched_text = match.fetch (0);
+                
+                return result;
+            } catch (Error e) {
+                return null;
+            }
+        }
+    }
+}

--- a/core/Services/Chrono/Locales/es/ESConstants.vala
+++ b/core/Services/Chrono/Locales/es/ESConstants.vala
@@ -1,0 +1,118 @@
+/*
+ * Copyright © 2025 Alain M. (https://github.com/alainm23/planify)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA
+ *
+ * Authored by: Alain M. <alainmh23@gmail.com>
+ */
+ 
+namespace Chrono {
+    public class ESConstants : Object {
+        private static Gee.HashMap<string, int>? _month_names = null;
+        private static Gee.HashMap<string, TimeUnit>? _time_units = null;
+        
+        private static Gee.HashMap<string, int> get_month_names () {
+            if (_month_names == null) {
+                _month_names = new Gee.HashMap<string, int> ();
+                
+                // Nombres completos
+                _month_names["enero"] = 1;
+                _month_names["febrero"] = 2;
+                _month_names["marzo"] = 3;
+                _month_names["abril"] = 4;
+                _month_names["mayo"] = 5;
+                _month_names["junio"] = 6;
+                _month_names["julio"] = 7;
+                _month_names["agosto"] = 8;
+                _month_names["septiembre"] = 9;
+                _month_names["octubre"] = 10;
+                _month_names["noviembre"] = 11;
+                _month_names["diciembre"] = 12;
+                
+                // Abreviaciones
+                _month_names["ene"] = 1;
+                _month_names["feb"] = 2;
+                _month_names["mar"] = 3;
+                _month_names["abr"] = 4;
+                _month_names["may"] = 5;
+                _month_names["jun"] = 6;
+                _month_names["jul"] = 7;
+                _month_names["ago"] = 8;
+                _month_names["sep"] = 9;
+                _month_names["sept"] = 9;
+                _month_names["oct"] = 10;
+                _month_names["nov"] = 11;
+                _month_names["dic"] = 12;
+            }
+            return _month_names;
+        }
+        
+        public static int? get_month (string name) {
+            string key = name.down ();
+            var months = get_month_names ();
+            if (months.has_key (key)) {
+                return months[key];
+            }
+            return null;
+        }
+        
+        private static Gee.HashMap<string, TimeUnit> get_time_units () {
+            if (_time_units == null) {
+                _time_units = new Gee.HashMap<string, TimeUnit> ();
+                
+                // Nombres completos
+                _time_units["segundo"] = TimeUnit.SECOND;
+                _time_units["segundos"] = TimeUnit.SECOND;
+                _time_units["minuto"] = TimeUnit.MINUTE;
+                _time_units["minutos"] = TimeUnit.MINUTE;
+                _time_units["hora"] = TimeUnit.HOUR;
+                _time_units["horas"] = TimeUnit.HOUR;
+                _time_units["día"] = TimeUnit.DAY;
+                _time_units["dia"] = TimeUnit.DAY;
+                _time_units["días"] = TimeUnit.DAY;
+                _time_units["dias"] = TimeUnit.DAY;
+                _time_units["semana"] = TimeUnit.WEEK;
+                _time_units["semanas"] = TimeUnit.WEEK;
+                _time_units["mes"] = TimeUnit.MONTH;
+                _time_units["meses"] = TimeUnit.MONTH;
+                _time_units["trimestre"] = TimeUnit.QUARTER;
+                _time_units["trimestres"] = TimeUnit.QUARTER;
+                _time_units["año"] = TimeUnit.YEAR;
+                _time_units["ano"] = TimeUnit.YEAR;
+                _time_units["años"] = TimeUnit.YEAR;
+                _time_units["anos"] = TimeUnit.YEAR;
+                
+                // Abreviaciones
+                _time_units["seg"] = TimeUnit.SECOND;
+                _time_units["min"] = TimeUnit.MINUTE;
+                _time_units["h"] = TimeUnit.HOUR;
+                _time_units["d"] = TimeUnit.DAY;
+                _time_units["sem"] = TimeUnit.WEEK;
+                _time_units["trim"] = TimeUnit.QUARTER;
+            }
+            return _time_units;
+        }
+        
+        public static TimeUnit? get_time_unit (string name) {
+            string key = name.down ();
+            var units = get_time_units ();
+            if (units.has_key (key)) {
+                return units[key];
+            }
+            return null;
+        }
+    }
+}

--- a/core/Services/Chrono/Locales/es/ESDateTimeComboParser.vala
+++ b/core/Services/Chrono/Locales/es/ESDateTimeComboParser.vala
@@ -1,0 +1,96 @@
+/*
+ * Copyright © 2025 Alain M. (https://github.com/alainm23/planify)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA
+ *
+ * Authored by: Alain M. <alainmh23@gmail.com>
+ */
+ 
+namespace Chrono {
+    /**
+     * Spanish date + time combination parser
+     * 
+     * Supports: mañana a las 3pm, lunes a las 9am, 15 de marzo a las 14:30
+     */
+    public class ESDateTimeComboParser : Object {
+        private Regex combo_regex;
+        private ESCasualDateParser casual_parser;
+        private TimeParser time_parser;
+        
+        public ESDateTimeComboParser () {
+            casual_parser = new ESCasualDateParser ();
+            time_parser = new TimeParser ();
+            
+            try {
+                // Match: [date expression] a las [time expression]
+                combo_regex = new Regex (
+                    "(.+?)\\s+a\\s+las\\s+(.+)",
+                    RegexCompileFlags.CASELESS
+                );
+            } catch (Error e) {
+                warning ("Error creating combo regex: %s", e.message);
+            }
+        }
+        
+        public ParseResult? parse (string text) {
+            try {
+                MatchInfo match;
+                if (!combo_regex.match (text, 0, out match)) {
+                    return null;
+                }
+                
+                string date_part = match.fetch (1).strip ();
+                string time_part = match.fetch (2).strip ();
+                
+                // Parse date part
+                ParseResult? date_result = casual_parser.parse (date_part);
+                
+                if (date_result == null || date_result.date == null) {
+                    return null;
+                }
+                
+                // Parse time part
+                ParseResult? time_result = time_parser.parse (time_part);
+                if (time_result == null || time_result.date == null) {
+                    return null;
+                }
+                
+                // Combine date and time
+                var combined_date = new DateTime.local (
+                    date_result.date.get_year (),
+                    date_result.date.get_month (),
+                    date_result.date.get_day_of_month (),
+                    time_result.date.get_hour (),
+                    time_result.date.get_minute (),
+                    time_result.date.get_second ()
+                );
+                
+                var result = new ParseResult ();
+                result.date = combined_date;
+                
+                int start_pos, end_pos;
+                match.fetch_pos (0, out start_pos, out end_pos);
+                result.start_index = start_pos;
+                result.end_index = end_pos;
+                result.matched_text = match.fetch (0);
+                
+                return result;
+            } catch (Error e) {
+                return null;
+            }
+        }
+    }
+}

--- a/core/Services/Chrono/Locales/es/ESMonthNameParser.vala
+++ b/core/Services/Chrono/Locales/es/ESMonthNameParser.vala
@@ -1,0 +1,140 @@
+/*
+ * Copyright © 2025 Alain M. (https://github.com/alainm23/planify)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA
+ *
+ * Authored by: Alain M. <alainmh23@gmail.com>
+ */
+ 
+namespace Chrono {
+    /**
+     * Spanish month name parser
+     * 
+     * Supports: 15 de marzo, 15 marzo, marzo 15, 15 mar 2024, enero 2012, enero
+     */
+    public class ESMonthNameParser : Object {
+        private Regex month_regex;
+        
+        public ESMonthNameParser () {
+            try {
+                month_regex = new Regex (
+                    "(?:el\\s+)?(\\d{1,2})\\s+(?:de\\s+)?(enero|febrero|marzo|abril|mayo|junio|julio|agosto|septiembre|octubre|noviembre|diciembre|ene|feb|mar|abr|may|jun|jul|ago|sep|sept|oct|nov|dic)(?:\\s+(?:de|del)\\s+(\\d{2,4}))?|" +
+                    "(?:el\\s+)?(enero|febrero|marzo|abril|mayo|junio|julio|agosto|septiembre|octubre|noviembre|diciembre|ene|feb|mar|abr|may|jun|jul|ago|sep|sept|oct|nov|dic)(?:,?\\s+(?:de|del)\\s+(\\d{4}))|" +
+                    "(?:el\\s+)?(enero|febrero|marzo|abril|mayo|junio|julio|agosto|septiembre|octubre|noviembre|diciembre|ene|feb|mar|abr|may|jun|jul|ago|sep|sept|oct|nov|dic)\\s+(\\d{1,2})(?:,?\\s+(?:de|del)\\s+(\\d{2,4}))?|" +
+                    "(?:el\\s+)?(enero|febrero|marzo|abril|mayo|junio|julio|agosto|septiembre|octubre|noviembre|diciembre|ene|feb|mar|abr|may|jun|jul|ago|sep|sept|oct|nov|dic)",
+                    RegexCompileFlags.CASELESS
+                );
+            } catch (Error e) {
+                warning ("Error creating month regex: %s", e.message);
+            }
+        }
+        
+        public ParseResult? parse (string text) {
+            try {
+                MatchInfo match;
+                if (!month_regex.match (text, 0, out match)) {
+                    return null;
+                }
+                
+                int day, month, year;
+                var now = new DateTime.now_local ();
+                year = now.get_year ();
+                day = 1;
+                
+                // Format: 15 de marzo or 15 marzo 2024
+                string? day_str = match.fetch (1);
+                if (day_str != null && day_str.length > 0) {
+                    day = int.parse (day_str);
+                    int? month_val = ESConstants.get_month (match.fetch (2));
+                    if (month_val == null) {
+                        return null;
+                    }
+                    month = month_val;
+                    
+                    string? year_str = match.fetch (3);
+                    if (year_str != null && year_str.length > 0) {
+                        year = int.parse (year_str);
+                        if (year < 100) {
+                            year += 2000;
+                        }
+                    }
+                } else {
+                    string? month_str = match.fetch (4);
+                    if (month_str != null && month_str.length > 0) {
+                        // Format: enero 2012 or enero de 2012
+                        int? month_val = ESConstants.get_month (month_str);
+                        if (month_val == null) {
+                            return null;
+                        }
+                        month = month_val;
+                        
+                        string? year_str = match.fetch (5);
+                        if (year_str != null && year_str.length > 0) {
+                            year = int.parse (year_str);
+                        }
+                    } else {
+                        month_str = match.fetch (6);
+                        if (month_str != null && month_str.length > 0) {
+                            // Format: marzo 15 or marzo 15 de 2024
+                            int? month_val = ESConstants.get_month (month_str);
+                            if (month_val == null) {
+                                return null;
+                            }
+                            month = month_val;
+                            
+                            string? day_str2 = match.fetch (7);
+                            if (day_str2 != null && day_str2.length > 0) {
+                                day = int.parse (day_str2);
+                            }
+                            
+                            string? year_str = match.fetch (8);
+                            if (year_str != null && year_str.length > 0) {
+                                year = int.parse (year_str);
+                                if (year < 100) {
+                                    year += 2000;
+                                }
+                            }
+                        } else {
+                            // Format: enero
+                            int? month_val = ESConstants.get_month (match.fetch (9));
+                            if (month_val == null) {
+                                return null;
+                            }
+                            month = month_val;
+                        }
+                    }
+                }
+                
+                if (year < 1000 && year >= 100) {
+                    return null;
+                }
+                
+                var result = new ParseResult ();
+                result.date = new DateTime.local (year, month, day, 0, 0, 0);
+                
+                int start_pos, end_pos;
+                match.fetch_pos (0, out start_pos, out end_pos);
+                result.start_index = start_pos;
+                result.end_index = end_pos;
+                result.matched_text = match.fetch (0);
+                
+                return result;
+            } catch (Error e) {
+                return null;
+            }
+        }
+    }
+}

--- a/core/Services/Chrono/Locales/es/ESRelativeDateFormatParser.vala
+++ b/core/Services/Chrono/Locales/es/ESRelativeDateFormatParser.vala
@@ -1,0 +1,131 @@
+/*
+ * Copyright © 2025 Alain M. (https://github.com/alainm23/planify)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA
+ *
+ * Authored by: Alain M. <alainmh23@gmail.com>
+ */
+ 
+namespace Chrono {
+    /**
+     * Spanish relative date format parser
+     * 
+     * Supports: esta semana, el mes pasado, el próximo año, la semana que viene
+     */
+    public class ESRelativeDateFormatParser : Object {
+        private Regex relative_regex;
+        
+        public ESRelativeDateFormatParser () {
+            try {
+                relative_regex = new Regex (
+                    "(?:el|la)?\\s*(?:próximo|proximo|próxima|proxima|siguiente|pasado|pasada|que\\s+viene)\\s+(segundo|segundos|minuto|minutos|hora|horas|día|dia|días|dias|semana|semanas|mes|meses|trimestre|trimestres|año|ano|años|anos)|" +
+                    "(?:el|la)?\\s*(segundo|segundos|minuto|minutos|hora|horas|día|dia|días|dias|semana|semanas|mes|meses|trimestre|trimestres|año|ano|años|anos)\\s+(?:próximo|proximo|próxima|proxima|siguiente|pasado|pasada|que\\s+viene)|" +
+                    "(?:este|esta)\\s+(segundo|segundos|minuto|minutos|hora|horas|día|dia|días|dias|semana|semanas|mes|meses|trimestre|trimestres|año|ano|años|anos)",
+                    RegexCompileFlags.CASELESS
+                );
+            } catch (Error e) {
+                warning ("Error creating relative date regex: %s", e.message);
+            }
+        }
+        
+        public ParseResult? parse (string text) {
+            try {
+                MatchInfo match;
+                if (!relative_regex.match (text, 0, out match)) {
+                    return null;
+                }
+                
+                string full_match = match.fetch (0).down ();
+                string? unit_str = null;
+                int amount = 0;
+                
+                // Try to get unit from different capture groups
+                for (int i = 1; i <= 3; i++) {
+                    string? temp = match.fetch (i);
+                    if (temp != null && temp.length > 0) {
+                        unit_str = temp;
+                        break;
+                    }
+                }
+                
+                if (unit_str == null) {
+                    return null;
+                }
+                
+                TimeUnit? time_unit = ESConstants.get_time_unit (unit_str);
+                if (time_unit == null) {
+                    return null;
+                }
+                
+                // Determine direction based on keywords
+                if (full_match.contains ("próximo") || full_match.contains ("proximo") || 
+                    full_match.contains ("próxima") || full_match.contains ("proxima") ||
+                    full_match.contains ("siguiente") || full_match.contains ("que viene")) {
+                    amount = 1;
+                } else if (full_match.contains ("pasado") || full_match.contains ("pasada")) {
+                    amount = -1;
+                } else if (full_match.contains ("este") || full_match.contains ("esta")) {
+                    amount = 0;
+                }
+                
+                var now = new DateTime.now_local ();
+                DateTime date = add_time_unit (now, time_unit, amount);
+                
+                var result = new ParseResult ();
+                result.date = date;
+                
+                int start_pos, end_pos;
+                match.fetch_pos (0, out start_pos, out end_pos);
+                result.start_index = start_pos;
+                result.end_index = end_pos;
+                result.matched_text = match.fetch (0);
+                
+                return result;
+            } catch (Error e) {
+                return null;
+            }
+        }
+        
+        private DateTime add_time_unit (DateTime date, TimeUnit unit, int amount) {
+            DateTime result;
+            switch (unit) {
+                case TimeUnit.SECOND:
+                    return date.add_seconds (amount);
+                case TimeUnit.MINUTE:
+                    return date.add_minutes (amount);
+                case TimeUnit.HOUR:
+                    return date.add_hours (amount);
+                case TimeUnit.DAY:
+                    result = date.add_days (amount);
+                    return new DateTime.local (result.get_year (), result.get_month (), result.get_day_of_month (), 0, 0, 0);
+                case TimeUnit.WEEK:
+                    result = date.add_weeks (amount);
+                    return new DateTime.local (result.get_year (), result.get_month (), result.get_day_of_month (), 0, 0, 0);
+                case TimeUnit.MONTH:
+                    result = date.add_months (amount);
+                    return new DateTime.local (result.get_year (), result.get_month (), result.get_day_of_month (), 0, 0, 0);
+                case TimeUnit.QUARTER:
+                    result = date.add_months (amount * 3);
+                    return new DateTime.local (result.get_year (), result.get_month (), result.get_day_of_month (), 0, 0, 0);
+                case TimeUnit.YEAR:
+                    result = date.add_years (amount);
+                    return new DateTime.local (result.get_year (), result.get_month (), result.get_day_of_month (), 0, 0, 0);
+                default:
+                    return date;
+            }
+        }
+    }
+}

--- a/core/Services/Chrono/Locales/es/ESTimeExpressionParser.vala
+++ b/core/Services/Chrono/Locales/es/ESTimeExpressionParser.vala
@@ -1,0 +1,98 @@
+/*
+ * Copyright © 2025 Alain M. (https://github.com/alainm23/planify)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA
+ *
+ * Authored by: Alain M. <alainmh23@gmail.com>
+ */
+ 
+namespace Chrono {
+    /**
+     * Spanish time expression parser
+     * 
+     * Supports: en 5 minutos, en 2 horas, en 3 días, dentro de 5 minutos
+     */
+    public class ESTimeExpressionParser : Object {
+        private Regex time_expr_regex;
+        
+        public ESTimeExpressionParser () {
+            try {
+                time_expr_regex = new Regex (
+                    "(?:en|dentro\\s+de)\\s+(\\d+)\\s+(segundo|segundos|minuto|minutos|hora|horas|día|dia|días|dias|semana|semanas|mes|meses|trimestre|trimestres|año|ano|años|anos|seg|min|h|d|sem|trim)",
+                    RegexCompileFlags.CASELESS
+                );
+            } catch (Error e) {
+                warning ("Error creating time expression regex: %s", e.message);
+            }
+        }
+        
+        public ParseResult? parse (string text) {
+            try {
+                MatchInfo match;
+                if (!time_expr_regex.match (text, 0, out match)) {
+                    return null;
+                }
+                
+                int amount = int.parse (match.fetch (1));
+                string unit_str = match.fetch (2);
+                
+                TimeUnit? time_unit = ESConstants.get_time_unit (unit_str);
+                if (time_unit == null) {
+                    return null;
+                }
+                
+                var now = new DateTime.now_local ();
+                DateTime date = add_time_unit (now, time_unit, amount);
+                
+                var result = new ParseResult ();
+                result.date = date;
+                
+                int start_pos, end_pos;
+                match.fetch_pos (0, out start_pos, out end_pos);
+                result.start_index = start_pos;
+                result.end_index = end_pos;
+                result.matched_text = match.fetch (0);
+                
+                return result;
+            } catch (Error e) {
+                return null;
+            }
+        }
+        
+        private DateTime add_time_unit (DateTime date, TimeUnit unit, int amount) {
+            switch (unit) {
+                case TimeUnit.SECOND:
+                    return date.add_seconds (amount);
+                case TimeUnit.MINUTE:
+                    return date.add_minutes (amount);
+                case TimeUnit.HOUR:
+                    return date.add_hours (amount);
+                case TimeUnit.DAY:
+                    return date.add_days (amount);
+                case TimeUnit.WEEK:
+                    return date.add_weeks (amount);
+                case TimeUnit.MONTH:
+                    return date.add_months (amount);
+                case TimeUnit.QUARTER:
+                    return date.add_months (amount * 3);
+                case TimeUnit.YEAR:
+                    return date.add_years (amount);
+                default:
+                    return date;
+            }
+        }
+    }
+}

--- a/core/Services/Chrono/Locales/es/SpanishParser.vala
+++ b/core/Services/Chrono/Locales/es/SpanishParser.vala
@@ -1,0 +1,97 @@
+/*
+ * Copyright © 2025 Alain M. (https://github.com/alainm23/planify)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA
+ *
+ * Authored by: Alain M. <alainmh23@gmail.com>
+ */
+ 
+namespace Chrono {
+    public class SpanishParser : LanguageParser {
+        private ESDateTimeComboParser combo_parser;
+        private ISOParser iso_parser;
+        private SlashParser slash_parser;
+        private TimeParser time_parser;
+        private ESCasualDateParser casual_parser;
+        private ESCasualTimeParser casual_time_parser;
+        private ESMonthNameParser month_parser;
+        private ESRelativeDateFormatParser relative_parser;
+        private ESTimeExpressionParser time_expr_parser;
+        
+        public SpanishParser () {
+            combo_parser = new ESDateTimeComboParser ();
+            iso_parser = new ISOParser ();
+            slash_parser = new SlashParser ();
+            time_parser = new TimeParser ();
+            casual_parser = new ESCasualDateParser ();
+            casual_time_parser = new ESCasualTimeParser ();
+            month_parser = new ESMonthNameParser ();
+            relative_parser = new ESRelativeDateFormatParser ();
+            time_expr_parser = new ESTimeExpressionParser ();
+        }
+        
+        public override ParseResult? parse (string text, bool parse_recurrence = false) {
+            ParseResult? result = null;
+            
+            result = combo_parser.parse (text);
+            if (result != null) {
+                return result;
+            }
+            
+            result = iso_parser.parse (text);
+            if (result != null) {
+                return result;
+            }
+            
+            result = slash_parser.parse (text);
+            if (result != null) {
+                return result;
+            }
+            
+            result = time_parser.parse (text);
+            if (result != null) {
+                return result;
+            }
+            
+            result = casual_parser.parse (text);
+            if (result != null) {
+                return result;
+            }
+            
+            result = casual_time_parser.parse (text);
+            if (result != null) {
+                return result;
+            }
+            
+            result = month_parser.parse (text);
+            if (result != null) {
+                return result;
+            }
+            
+            result = relative_parser.parse (text);
+            if (result != null) {
+                return result;
+            }
+            
+            result = time_expr_parser.parse (text);
+            if (result != null) {
+                return result;
+            }
+            
+            return null;
+        }
+    }
+}

--- a/core/Services/Chrono/Locales/template/TEMPLATECasualDateParser.vala
+++ b/core/Services/Chrono/Locales/template/TEMPLATECasualDateParser.vala
@@ -1,0 +1,87 @@
+/*
+ * Copyright © 2025 Alain M. (https://github.com/alainm23/planify)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA
+ *
+ * Authored by: Alain M. <alainmh23@gmail.com>
+ */
+ 
+namespace Chrono {
+    /**
+     * [LANGUAGE_NAME] casual date parser
+     * 
+     * TODO: Update patterns to support your language
+     * Examples: "today", "tomorrow", "yesterday"
+     */
+    public class TEMPLATECasualDateParser : Object {
+        private Regex casual_regex;
+        
+        public TEMPLATECasualDateParser () {
+            try {
+                // TODO: Update these patterns for your language
+                casual_regex = new Regex (
+                    "\\b(today|tomorrow|yesterday)\\b",
+                    RegexCompileFlags.CASELESS
+                );
+            } catch (Error e) {
+                warning ("Error creating casual date regex: %s", e.message);
+            }
+        }
+        
+        public ParseResult? parse (string text) {
+            try {
+                MatchInfo match;
+                if (!casual_regex.match (text, 0, out match)) {
+                    return null;
+                }
+                
+                string matched_word = match.fetch (1).down ();
+                var now = new DateTime.now_local ();
+                DateTime date;
+                
+                // TODO: Update these keywords for your language
+                switch (matched_word) {
+                    case "today":
+                        date = new DateTime.local (now.get_year (), now.get_month (), now.get_day_of_month (), 0, 0, 0);
+                        break;
+                    case "tomorrow":
+                        var tomorrow = now.add_days (1);
+                        date = new DateTime.local (tomorrow.get_year (), tomorrow.get_month (), tomorrow.get_day_of_month (), 0, 0, 0);
+                        break;
+                    case "yesterday":
+                        var yesterday = now.add_days (-1);
+                        date = new DateTime.local (yesterday.get_year (), yesterday.get_month (), yesterday.get_day_of_month (), 0, 0, 0);
+                        break;
+                    default:
+                        return null;
+                }
+                
+                var result = new ParseResult ();
+                result.date = date;
+                
+                int start_pos, end_pos;
+                match.fetch_pos (0, out start_pos, out end_pos);
+                result.start_index = start_pos;
+                result.end_index = end_pos;
+                result.matched_text = match.fetch (0);
+                
+                return result;
+            } catch (Error e) {
+                return null;
+            }
+        }
+    }
+}

--- a/core/Services/Chrono/Locales/template/TEMPLATEConstants.vala
+++ b/core/Services/Chrono/Locales/template/TEMPLATEConstants.vala
@@ -1,0 +1,111 @@
+/*
+ * Copyright © 2025 Alain M. (https://github.com/alainm23/planify)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA
+ *
+ * Authored by: Alain M. <alainmh23@gmail.com>
+ */
+ 
+namespace Chrono {
+    /**
+     * Constants for [LANGUAGE_NAME] language support
+     * 
+     * TODO: Replace with actual translations for your language
+     */
+    public class TEMPLATEConstants : Object {
+        private static Gee.HashMap<string, int>? _month_names = null;
+        private static Gee.HashMap<string, TimeUnit>? _time_units = null;
+        
+        private static Gee.HashMap<string, int> get_month_names () {
+            if (_month_names == null) {
+                _month_names = new Gee.HashMap<string, int> ();
+                
+                // TODO: Add full month names in your language
+                _month_names["month1"] = 1;  // January
+                _month_names["month2"] = 2;  // February
+                _month_names["month3"] = 3;  // March
+                _month_names["month4"] = 4;  // April
+                _month_names["month5"] = 5;  // May
+                _month_names["month6"] = 6;  // June
+                _month_names["month7"] = 7;  // July
+                _month_names["month8"] = 8;  // August
+                _month_names["month9"] = 9;  // September
+                _month_names["month10"] = 10; // October
+                _month_names["month11"] = 11; // November
+                _month_names["month12"] = 12; // December
+                
+                // TODO: Add month abbreviations in your language
+                _month_names["m1"] = 1;   // Jan
+                _month_names["m2"] = 2;   // Feb
+                _month_names["m3"] = 3;   // Mar
+                // ... continue for all months
+            }
+            return _month_names;
+        }
+        
+        public static int? get_month (string name) {
+            string key = name.down ();
+            var months = get_month_names ();
+            if (months.has_key (key)) {
+                return months[key];
+            }
+            return null;
+        }
+        
+        private static Gee.HashMap<string, TimeUnit> get_time_units () {
+            if (_time_units == null) {
+                _time_units = new Gee.HashMap<string, TimeUnit> ();
+                
+                // TODO: Add time unit names in your language
+                _time_units["second"] = TimeUnit.SECOND;
+                _time_units["seconds"] = TimeUnit.SECOND;
+                _time_units["minute"] = TimeUnit.MINUTE;
+                _time_units["minutes"] = TimeUnit.MINUTE;
+                _time_units["hour"] = TimeUnit.HOUR;
+                _time_units["hours"] = TimeUnit.HOUR;
+                _time_units["day"] = TimeUnit.DAY;
+                _time_units["days"] = TimeUnit.DAY;
+                _time_units["week"] = TimeUnit.WEEK;
+                _time_units["weeks"] = TimeUnit.WEEK;
+                _time_units["month"] = TimeUnit.MONTH;
+                _time_units["months"] = TimeUnit.MONTH;
+                _time_units["quarter"] = TimeUnit.QUARTER;
+                _time_units["quarters"] = TimeUnit.QUARTER;
+                _time_units["year"] = TimeUnit.YEAR;
+                _time_units["years"] = TimeUnit.YEAR;
+                
+                // TODO: Add abbreviations in your language
+                _time_units["s"] = TimeUnit.SECOND;
+                _time_units["m"] = TimeUnit.MINUTE;
+                _time_units["h"] = TimeUnit.HOUR;
+                _time_units["d"] = TimeUnit.DAY;
+                _time_units["w"] = TimeUnit.WEEK;
+                _time_units["mo"] = TimeUnit.MONTH;
+                _time_units["y"] = TimeUnit.YEAR;
+            }
+            return _time_units;
+        }
+        
+        public static TimeUnit? get_time_unit (string name) {
+            string key = name.down ();
+            var units = get_time_units ();
+            if (units.has_key (key)) {
+                return units[key];
+            }
+            return null;
+        }
+    }
+}

--- a/core/Services/Chrono/Locales/template/TEMPLATERelativeDateFormatParser.vala
+++ b/core/Services/Chrono/Locales/template/TEMPLATERelativeDateFormatParser.vala
@@ -1,0 +1,122 @@
+/*
+ * Copyright © 2025 Alain M. (https://github.com/alainm23/planify)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA
+ *
+ * Authored by: Alain M. <alainmh23@gmail.com>
+ */
+ 
+namespace Chrono {
+    /**
+     * [LANGUAGE_NAME] relative date format parser
+     * 
+     * TODO: Update patterns to support your language
+     * Examples: "next week", "last month", "this year"
+     */
+    public class TEMPLATERelativeDateFormatParser : Object {
+        private Regex relative_regex;
+        
+        public TEMPLATERelativeDateFormatParser () {
+            try {
+                // TODO: Update this regex pattern for your language
+                // Current pattern is for English-like structure
+                relative_regex = new Regex (
+                    "(?:next|last|this)\\s+(second|seconds|minute|minutes|hour|hours|day|days|week|weeks|month|months|quarter|quarters|year|years)",
+                    RegexCompileFlags.CASELESS
+                );
+            } catch (Error e) {
+                warning ("Error creating relative date regex: %s", e.message);
+            }
+        }
+        
+        public ParseResult? parse (string text) {
+            try {
+                MatchInfo match;
+                if (!relative_regex.match (text, 0, out match)) {
+                    return null;
+                }
+                
+                string full_match = match.fetch (0).down ();
+                string? unit_str = match.fetch (1);
+                
+                if (unit_str == null) {
+                    return null;
+                }
+                
+                TimeUnit? time_unit = TEMPLATEConstants.get_time_unit (unit_str);
+                if (time_unit == null) {
+                    return null;
+                }
+                
+                int amount = 0;
+                
+                // TODO: Update these keywords for your language
+                if (full_match.contains ("next")) {
+                    amount = 1;
+                } else if (full_match.contains ("last")) {
+                    amount = -1;
+                } else if (full_match.contains ("this")) {
+                    amount = 0;
+                }
+                
+                var now = new DateTime.now_local ();
+                DateTime date = add_time_unit (now, time_unit, amount);
+                
+                var result = new ParseResult ();
+                result.date = date;
+                
+                int start_pos, end_pos;
+                match.fetch_pos (0, out start_pos, out end_pos);
+                result.start_index = start_pos;
+                result.end_index = end_pos;
+                result.matched_text = match.fetch (0);
+                
+                return result;
+            } catch (Error e) {
+                return null;
+            }
+        }
+        
+        private DateTime add_time_unit (DateTime date, TimeUnit unit, int amount) {
+            DateTime result;
+            switch (unit) {
+                case TimeUnit.SECOND:
+                    return date.add_seconds (amount);
+                case TimeUnit.MINUTE:
+                    return date.add_minutes (amount);
+                case TimeUnit.HOUR:
+                    return date.add_hours (amount);
+                case TimeUnit.DAY:
+                    result = date.add_days (amount);
+                    return new DateTime.local (result.get_year (), result.get_month (), result.get_day_of_month (), 0, 0, 0);
+                case TimeUnit.WEEK:
+                    result = date.add_weeks (amount);
+                    return new DateTime.local (result.get_year (), result.get_month (), result.get_day_of_month (), 0, 0, 0);
+                case TimeUnit.MONTH:
+                    result = date.add_months (amount);
+                    return new DateTime.local (result.get_year (), result.get_month (), result.get_day_of_month (), 0, 0, 0);
+                case TimeUnit.QUARTER:
+                    result = date.add_months (amount * 3);
+                    return new DateTime.local (result.get_year (), result.get_month (), result.get_day_of_month (), 0, 0, 0);
+                case TimeUnit.YEAR:
+                    result = date.add_years (amount);
+                    return new DateTime.local (result.get_year (), result.get_month (), result.get_day_of_month (), 0, 0, 0);
+                default:
+                    return date;
+            }
+        }
+    }
+}

--- a/core/Services/Chrono/Locales/template/TemplateParser.vala
+++ b/core/Services/Chrono/Locales/template/TemplateParser.vala
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2025 Alain M. (https://github.com/alainm23/planify)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA
+ *
+ * Authored by: Alain M. <alainmh23@gmail.com>
+ */
+ 
+namespace Chrono {
+    /**
+     * Main parser for [LANGUAGE_NAME] language
+     * 
+     * TODO: Replace "Template" with your language name
+     * TODO: Update language_code with your ISO language code
+     */
+    public class TemplateParser : LanguageParser {
+        private Gee.ArrayList<Object> parsers;
+        
+        public TemplateParser () {
+            // TODO: Update with your language code (e.g., "fr", "de", "it")
+            language_code = "template";
+            
+            parsers = new Gee.ArrayList<Object> ();
+            
+            // Add all parsers for this language
+            parsers.add (new TEMPLATECasualDateParser ());
+            parsers.add (new TEMPLATERelativeDateFormatParser ());
+            // TODO: Add other parsers as you implement them:
+            // parsers.add (new TEMPLATECasualTimeParser ());
+            // parsers.add (new TEMPLATEMonthNameParser ());
+            // parsers.add (new TEMPLATETimeExpressionParser ());
+            // parsers.add (new TEMPLATEDateTimeComboParser ());
+        }
+        
+        public override ParseResult? parse (string text) {
+            foreach (var parser in parsers) {
+                ParseResult? result = null;
+                
+                // Try each parser type
+                if (parser is TEMPLATECasualDateParser) {
+                    result = ((TEMPLATECasualDateParser) parser).parse (text);
+                } else if (parser is TEMPLATERelativeDateFormatParser) {
+                    result = ((TEMPLATERelativeDateFormatParser) parser).parse (text);
+                }
+                // TODO: Add other parser types as you implement them
+                
+                if (result != null) {
+                    return result;
+                }
+            }
+            
+            return null;
+        }
+        
+        public override bool can_parse (string text) {
+            return parse (text) != null;
+        }
+    }
+}

--- a/core/Services/Chrono/Parser.vala
+++ b/core/Services/Chrono/Parser.vala
@@ -26,6 +26,7 @@ namespace Chrono {
         public Parser () {
             language_parsers = new Gee.HashMap<string, LanguageParser> ();
             register_language ("en", new EnglishParser ());
+            register_language ("es", new SpanishParser ());
         }
         
         public void register_language (string code, LanguageParser parser) {

--- a/core/Utils/Util.vala
+++ b/core/Utils/Util.vala
@@ -232,6 +232,24 @@ public class Util : GLib.Object {
         return Intl.get_language_names ();
     }
 
+    public static string get_user_language () {
+        string[] languages = Intl.get_language_names ();
+        
+        if (languages.length > 0) {
+            string lang = languages[0];
+            
+            if ("_" in lang) {
+                lang = lang.split ("_")[0];
+            } else if ("." in lang) {
+                lang = lang.split (".")[0];
+            }
+            
+            return lang.down ();
+        }
+        
+        return "en";
+    }
+
     public string get_badge_name () {
         string returned = "";
         int badge_count = Services.Settings.get_default ().settings.get_enum ("badge-count");

--- a/core/meson.build
+++ b/core/meson.build
@@ -36,6 +36,14 @@ core_files = files(
     'Services/Chrono/Locales/en/ENMonthNameParser.vala',
     'Services/Chrono/Locales/en/ENRelativeDateFormatParser.vala',
     'Services/Chrono/Locales/en/ENTimeExpressionParser.vala',
+    'Services/Chrono/Locales/es/SpanishParser.vala',
+    'Services/Chrono/Locales/es/ESConstants.vala',
+    'Services/Chrono/Locales/es/ESCasualDateParser.vala',
+    'Services/Chrono/Locales/es/ESCasualTimeParser.vala',
+    'Services/Chrono/Locales/es/ESDateTimeComboParser.vala',
+    'Services/Chrono/Locales/es/ESMonthNameParser.vala',
+    'Services/Chrono/Locales/es/ESRelativeDateFormatParser.vala',
+    'Services/Chrono/Locales/es/ESTimeExpressionParser.vala',
 
     'Layouts/HeaderItem.vala',
 

--- a/src/Widgets/TranslationRow.vala
+++ b/src/Widgets/TranslationRow.vala
@@ -109,7 +109,7 @@ public class Widgets.TranslationRow : Adw.PreferencesRow {
     public async void load_translation_data () {
         try {
             var metrics = yield Services.Api.get_default ().get_translation_metrics ();
-            var languages = Util.get_default ().get_current_languages ();
+            var languages = Util.get_current_languages ();
 
             string user_lang = "";
             string full_lang = "";


### PR DESCRIPTION
This PR adds comprehensive Spanish language support to Planify's date parsing system.

### Features Added

- **Spanish date parsing** with natural language support
- **Casual dates**: "hoy", "mañana", "ayer", "pasado mañana"
- **Relative dates**: "próxima semana", "mes pasado", "este año"
- **Time expressions**: "por la mañana", "en la tarde", "por la noche"
- **Month names**: Full names and abbreviations in Spanish
- **Flexible patterns** supporting accented/unaccented text