### PR TITLE
Fix false date detection in month name parsers

### DIFF
--- a/core/Services/Chrono/Locales/en/ENMonthNameParser.vala
+++ b/core/Services/Chrono/Locales/en/ENMonthNameParser.vala
@@ -31,10 +31,10 @@ namespace Chrono {
         public ENMonthNameParser () {
             try {
                 month_regex = new Regex (
-                    "(\\d{1,2})\\s+(january|february|march|april|may|june|july|august|september|october|november|december|jan|feb|mar|apr|jun|jul|aug|sep|sept|oct|nov|dec)(?:\\s+(\\d{2,4}))?|" +
-                    "(january|february|march|april|may|june|july|august|september|october|november|december|jan|feb|mar|apr|jun|jul|aug|sep|sept|oct|nov|dec)(?:,?\\s+(\\d{4}))|" +
-                    "(january|february|march|april|may|june|july|august|september|october|november|december|jan|feb|mar|apr|jun|jul|aug|sep|sept|oct|nov|dec)\\s+(\\d{1,2})(?:,?\\s+(\\d{2,4}))?|" +
-                    "(january|february|march|april|may|june|july|august|september|october|november|december|jan|feb|mar|apr|jun|jul|aug|sep|sept|oct|nov|dec)",
+                    "\\b(\\d{1,2})\\s+(january|february|march|april|may|june|july|august|september|october|november|december|jan|feb|mar|apr|jun|jul|aug|sep|sept|oct|nov|dec)\\b(?:\\s+(\\d{2,4}))?|" +
+                    "\\b(january|february|march|april|may|june|july|august|september|october|november|december|jan|feb|mar|apr|jun|jul|aug|sep|sept|oct|nov|dec)\\b(?:,?\\s+(\\d{4}))|" +
+                    "\\b(january|february|march|april|may|june|july|august|september|october|november|december|jan|feb|mar|apr|jun|jul|aug|sep|sept|oct|nov|dec)\\b\\s+(\\d{1,2})(?:,?\\s+(\\d{2,4}))?|" +
+                    "\\b(january|february|march|april|may|june|july|august|september|october|november|december|jan|feb|mar|apr|jun|jul|aug|sep|sept|oct|nov|dec)\\b",
                     RegexCompileFlags.CASELESS
                 );
             } catch (Error e) {

--- a/core/Services/Chrono/Locales/es/ESMonthNameParser.vala
+++ b/core/Services/Chrono/Locales/es/ESMonthNameParser.vala
@@ -31,10 +31,10 @@ namespace Chrono {
         public ESMonthNameParser () {
             try {
                 month_regex = new Regex (
-                    "(?:el\\s+)?(\\d{1,2})\\s+(?:de\\s+)?(enero|febrero|marzo|abril|mayo|junio|julio|agosto|septiembre|octubre|noviembre|diciembre|ene|feb|mar|abr|may|jun|jul|ago|sep|sept|oct|nov|dic)(?:\\s+(?:de|del)\\s+(\\d{2,4}))?|" +
-                    "(?:el\\s+)?(enero|febrero|marzo|abril|mayo|junio|julio|agosto|septiembre|octubre|noviembre|diciembre|ene|feb|mar|abr|may|jun|jul|ago|sep|sept|oct|nov|dic)(?:,?\\s+(?:de|del)\\s+(\\d{4}))|" +
-                    "(?:el\\s+)?(enero|febrero|marzo|abril|mayo|junio|julio|agosto|septiembre|octubre|noviembre|diciembre|ene|feb|mar|abr|may|jun|jul|ago|sep|sept|oct|nov|dic)\\s+(\\d{1,2})(?:,?\\s+(?:de|del)\\s+(\\d{2,4}))?|" +
-                    "(?:el\\s+)?(enero|febrero|marzo|abril|mayo|junio|julio|agosto|septiembre|octubre|noviembre|diciembre|ene|feb|mar|abr|may|jun|jul|ago|sep|sept|oct|nov|dic)",
+                    "\\b(?:el\\s+)?(\\d{1,2})\\s+(?:de\\s+)?(enero|febrero|marzo|abril|mayo|junio|julio|agosto|septiembre|octubre|noviembre|diciembre|ene|feb|mar|abr|may|jun|jul|ago|sep|sept|oct|nov|dic)\\b(?:\\s+(?:de|del)\\s+(\\d{2,4}))?|" +
+                    "\\b(?:el\\s+)?(enero|febrero|marzo|abril|mayo|junio|julio|agosto|septiembre|octubre|noviembre|diciembre|ene|feb|mar|abr|may|jun|jul|ago|sep|sept|oct|nov|dic)\\b(?:,?\\s+(?:de|del)\\s+(\\d{4}))|" +
+                    "\\b(?:el\\s+)?(enero|febrero|marzo|abril|mayo|junio|julio|agosto|septiembre|octubre|noviembre|diciembre|ene|feb|mar|abr|may|jun|jul|ago|sep|sept|oct|nov|dic)\\b\\s+(\\d{1,2})(?:,?\\s+(?:de|del)\\s+(\\d{2,4}))?|" +
+                    "\\b(?:el\\s+)?(enero|febrero|marzo|abril|mayo|junio|julio|agosto|septiembre|octubre|noviembre|diciembre|ene|feb|mar|abr|may|jun|jul|ago|sep|sept|oct|nov|dic)\\b",
                     RegexCompileFlags.CASELESS
                 );
             } catch (Error e) {


### PR DESCRIPTION
Fixes issue where words containing month abbreviations were incorrectly detected as dates (e.g., "Mark" → Mar, "Jane" → Jan, "Decide" → Dec, "paprika" → Apr).

Added word boundary anchors (\b) to month name regex patterns in both English and Spanish parsers to ensure only complete words are matched.

FIxes: #2110 #2089