### PR TITLE
fix: Allow editing project description when no tasks exist

### DIFF
--- a/src/Layouts/SectionRow.vala
+++ b/src/Layouts/SectionRow.vala
@@ -225,7 +225,7 @@ public class Layouts.SectionRow : Gtk.ListBoxRow {
 
         var add_button = new Gtk.Button () {
             child = add_button_box,
-            margin_start = 16,
+            margin_start = 24,
             margin_bottom = 6,
             margin_top = 3,
             halign = START,

--- a/src/Views/Project/List.vala
+++ b/src/Views/Project/List.vala
@@ -73,16 +73,16 @@ public class Views.List : Adw.Bin {
 
         var title_box = new Gtk.Box (HORIZONTAL, 6) {
             valign = CENTER,
-            margin_start = 22,
+            margin_start = 30,
         };
 
         title_box.append (icon_project);
         title_box.append (title_label);
 
-        var description_widget = new Widgets.EditableTextView (_ ("Note")) {
+        var description_widget = new Widgets.EditableTextView (_("Note")) {
             text = project.description,
             margin_top = 12,
-            margin_start = 24,
+            margin_start = 32,
             margin_end = 24
         };
 
@@ -115,7 +115,7 @@ public class Views.List : Adw.Bin {
             icon_name = "check-round-outline-symbolic",
             title = _ ("Add Some Tasks"),
             description = _ ("Press 'a' to create a new task"),
-            can_focus = true
+            can_focus = false
         };
         listbox_placeholder.update_property (Gtk.AccessibleProperty.LABEL, 
             _ ("Add Some Tasks. Press 'a' to create a new task"), -1);
@@ -263,7 +263,6 @@ public class Views.List : Adw.Bin {
             filters.sensitive = !active;
             pinned_items_flowbox.sensitive = !active;
 
-            description_widget.sensitive = !active;
             if (active) {
                 description_widget.add_css_class ("dimmed");
             } else {
@@ -284,7 +283,6 @@ public class Views.List : Adw.Bin {
         }
 
         listbox_placeholder_stack.visible_child_name = count > 0 ? "listbox" : "placeholder";
-        scrolled_window.can_focus = count > 0;
     }
 
     private void add_sections () {


### PR DESCRIPTION
Fixes a focus issue where the project description field couldn't be edited when the project had no tasks.

Changes:
- Removed the line that disabled focus on the scrolled window when task count was zero
- Set `listbox_placeholder.can_focus` to `false` to prevent unnecessary focus capture


<img width="450" height="547" alt="image" src="https://github.com/user-attachments/assets/468c69f0-e8c7-4952-ba63-3d78c9f8aee0" />


Fixes: #2109