### PR TITLE
Improve "Show Completed" menu item label and add tooltip

### DIFF
--- a/src/Views/Project/Project.vala
+++ b/src/Views/Project/Project.vala
@@ -552,7 +552,9 @@ public class Views.Project : Adw.Bin {
             arrow = true
         };
 
-        var show_completed_item = new Widgets.ContextMenu.MenuSwitch (_ ("Show Completed Tasks"), "check-round-outline-symbolic");
+        var show_completed_item = new Widgets.ContextMenu.MenuSwitch (_ ("Show Completed"), "check-round-outline-symbolic") {
+            tooltip_text = _("Display completed tasks in the list")
+        };
         show_completed_item.active = project.show_completed;
 
         var show_completed_item_button = new Gtk.Button.from_icon_name ("edit-find-symbolic") {


### PR DESCRIPTION
Changes

- Shortened menu item label from "Show Completed Tasks" to "Show Completed" to prevent text overflow in the view settings popover
- Added tooltip "Display completed tasks in the list" to provide clear context about the toggle functionality

Fixes: #2118
