### PR TITLE
Fix file filter in backup import dialog

### DIFF
--- a/src/Services/Backups.vala
+++ b/src/Services/Backups.vala
@@ -561,9 +561,13 @@ public class Services.Backups : Object {
     }
 
     private void add_filters (Gtk.FileDialog file_dialog) {
-        Gtk.FileFilter filter = new Gtk.FileFilter ();
-        filter.add_pattern ("*.json");
+        var filter = new Gtk.FileFilter ();
         filter.set_filter_name (_("Planify Backup Files"));
+        filter.add_pattern ("*.json");
+        
+        var filters = new ListStore (typeof (Gtk.FileFilter));
+        filters.append (filter);
+        file_dialog.filters = filters;
         file_dialog.default_filter = filter;
     }
 }


### PR DESCRIPTION
Fixes file filter not accepting .json files in some desktop environments (e.g., Deepin).

The issue was caused by not properly setting the filters property on Gtk.FileDialog. Now using ListStore to correctly register file filters, ensuring compatibility across different file portals and desktop environments.

FIxes: #2141