### PR TITLE
Robustly detect Ctrl key on mouse click events

### DIFF
--- a/core/Services/EventBus.vala
+++ b/core/Services/EventBus.vala
@@ -83,7 +83,6 @@ public class Services.EventBus : Object {
 
     // Multi Select
     public bool multi_select_enabled = false;
-    public bool ctrl_key_pressed = false;
     public signal void show_multi_select (bool enabled);
     public signal void select_item (Gtk.Widget itemrow);
     public signal void unselect_item (Gtk.Widget itemrow);

--- a/src/Layouts/ItemBoard.vala
+++ b/src/Layouts/ItemBoard.vala
@@ -396,7 +396,8 @@ public class Layouts.ItemBoard : Layouts.ItemBase {
         var detail_gesture_click = new Gtk.GestureClick ();
         card_widget.add_controller (detail_gesture_click);
         signals_map[detail_gesture_click.released.connect ((n_press, x, y) => {
-            if (Services.EventBus.get_default ().ctrl_key_pressed) {
+            var modifier = detail_gesture_click.get_current_event_state ();
+            if ((modifier & Gdk.ModifierType.CONTROL_MASK) != 0) {
                 Idle.add (() => {
                     if (item.project == null) {
                         return GLib.Source.REMOVE;

--- a/src/Layouts/ItemRow.vala
+++ b/src/Layouts/ItemRow.vala
@@ -678,7 +678,8 @@ public class Layouts.ItemRow : Layouts.ItemBase {
         })] = handle_gesture_click;
         
         signals_map[handle_gesture_click.released.connect ((n_press, x, y) => {
-            if (Services.EventBus.get_default ().ctrl_key_pressed) {
+            var modifier = handle_gesture_click.get_current_event_state ();
+            if ((modifier & Gdk.ModifierType.CONTROL_MASK) != 0) {
                 Idle.add (() => {
                     if (item.project == null) {
                         return GLib.Source.REMOVE;

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -403,10 +403,6 @@ public class MainWindow : Adw.ApplicationWindow {
         var key_controller = new Gtk.EventControllerKey ();
         ((Gtk.Widget) this).add_controller (key_controller);
         key_controller.key_pressed.connect ((keyval, keycode, state) => {
-            if (keyval == Gdk.Key.Control_L || keyval == Gdk.Key.Control_R) {
-                Services.EventBus.get_default ().ctrl_key_pressed = true;
-            }
-            
             if (keyval == Gdk.Key.Escape) {
                 Services.EventBus.get_default ().escape_pressed ();
                 
@@ -428,12 +424,6 @@ public class MainWindow : Adw.ApplicationWindow {
             }
             
             return false;
-        });
-        
-        key_controller.key_released.connect ((keyval, keycode, state) => {
-            if (keyval == Gdk.Key.Control_L || keyval == Gdk.Key.Control_R) {
-                Services.EventBus.get_default ().ctrl_key_pressed = false;
-            }
         });
 
         var window_gesture = new Gtk.GestureClick ();


### PR DESCRIPTION
This fixes #2176 by using event modifiers to determine the state of ctrl during the mouse click event.