### PR TITLE
Improve behavior for small windows

### DIFF
--- a/src/Layouts/HeaderBar.vala
+++ b/src/Layouts/HeaderBar.vala
@@ -81,11 +81,6 @@ public class Layouts.HeaderBar : Adw.Bin {
 
         update_sidebar_icon ();
 
-        var sidebar_button_revealer = new Gtk.Revealer () {
-            transition_type = SLIDE_LEFT,
-            child = sidebar_button
-        };
-
         // Back Button
         back_button = new Gtk.Button.from_icon_name ("go-previous-symbolic") {
             valign = Gtk.Align.CENTER,
@@ -133,7 +128,7 @@ public class Layouts.HeaderBar : Adw.Bin {
             title_widget = title_box_revealer,
         };
 
-        headerbar.pack_start (sidebar_button_revealer);
+        headerbar.pack_start (sidebar_button);
         headerbar.pack_start (back_button_revealer);
 
         child = headerbar;
@@ -148,7 +143,6 @@ public class Layouts.HeaderBar : Adw.Bin {
         })] = back_button;
 
         signal_map[Services.Settings.get_default ().settings.changed["slim-mode"].connect (() => {
-            sidebar_button_revealer.reveal_child = !Services.Settings.get_default ().settings.get_boolean ("slim-mode");
             update_sidebar_icon ();
         })] = Services.Settings.get_default ();
     }

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -135,7 +135,7 @@ public class MainWindow : Adw.ApplicationWindow {
             sidebar = sidebar_view
         };
 
-        var breakpoint = new Adw.Breakpoint (Adw.BreakpointCondition.parse ("max-width: 500sp"));
+        var breakpoint = new Adw.Breakpoint (Adw.BreakpointCondition.parse ("max-width: 675sp"));
         breakpoint.add_setter (overlay_split_view, "collapsed", true);
         add_breakpoint (breakpoint);
 


### PR DESCRIPTION
This is a suggestion to resolve #2128 via two small changes:

1. Increase the already existing auto-hide threshold to 675. 
    - Why 675? Thats the value below which the close button no longer fits into the window if the sidebar remains open.
2. Make the button to "Open/Close sidebar" always visible. 
    - Currently, the only way to find this super useful feature is if you stumble over it in the keybindings dialog

They are a separate commit each so you can cherry-pick if necessary :)