### PR TITLE
Fix Radicale CalDAV compatibility for PUT requests

### DIFF
--- a/core/Services/CalDAV/CalDAVClient.vala
+++ b/core/Services/CalDAV/CalDAVClient.vala
@@ -597,7 +597,7 @@ public class Services.CalDAV.CalDAVClient : Services.CalDAV.WebDAVClient {
         var url = update ? item.ical_url : GLib.Path.build_path ("/", item.project.calendar_url, "%s.ics".printf (item.id));
         var body = item.to_vtodo ();
 
-        var expected = update ? new Soup.Status[]{ Soup.Status.NO_CONTENT }
+        var expected = update ? new Soup.Status[]{ Soup.Status.NO_CONTENT, Soup.Status.CREATED }
                               : new Soup.Status[]{ Soup.Status.CREATED };
 
         HttpResponse response = new HttpResponse ();
@@ -620,7 +620,7 @@ public class Services.CalDAV.CalDAVClient : Services.CalDAV.WebDAVClient {
         HttpResponse response = new HttpResponse ();
 
         try {
-            yield send_request ("PUT", item.ical_url, "", body, null, null, { Soup.Status.NO_CONTENT });
+            yield send_request ("PUT", item.ical_url, "", body, null, null, { Soup.Status.NO_CONTENT, Soup.Status.CREATED });
             item.extra_data = Util.generate_extra_data (item.ical_url, "", body);
 
             response.status = true;


### PR DESCRIPTION
Radicale responds with 201 Created HTTP status codes for PUT operations. Accept these instead of showing an error message. Fixes updating/checking/unchecking/setting priority on tasks synced to Radicale (3.4.1) for me.

Might fix #2029 and possibly #2018.

Signed-off-by: Lucie Hartmann (lucie@mntre.com)