### PR TITLE
fix: sync server toggle not persisting

### DIFF
--- a/src/Dialogs/Preferences/Pages/Accounts/SourceView.vala
+++ b/src/Dialogs/Preferences/Pages/Accounts/SourceView.vala
@@ -158,8 +158,8 @@ public class Dialogs.Preferences.Pages.SourceView : Dialogs.Preferences.Pages.Ba
 
         child = toolbar_view;
 
-        signal_map[sync_server_row.activated.connect (() => {
-            source.sync_server = !source.sync_server;
+        signal_map[sync_server_row.notify["active"].connect (() => {
+            source.sync_server = sync_server_row.active;
             source.save ();
 
             if (source.sync_server) {


### PR DESCRIPTION
The "Sync Server" toggle in account settings (Settings → Sources → [account] → Sync Server) does not persist when toggled. Users can turn it on, but it reverts to off.

## Root Cause

In `SourceView.vala`, the toggle handler uses `activated.connect()`:

```vala
signal_map[sync_server_row.activated.connect (() => {
    source.sync_server = !source.sync_server;
    // ...
})] = sync_server_row;
```

For `Adw.SwitchRow`, the `activated` signal fires when the row is activated (clicking the row area or pressing Enter), but not when the switch itself is toggled. The switch state change is signaled via `notify["active"]`.

## Fix

Use `notify["active"]` and read the actual switch state:

```vala
signal_map[sync_server_row.notify["active"].connect (() => {
    source.sync_server = sync_server_row.active;
    // ...
})] = sync_server_row;
```

## Testing

1. Open Settings → Sources → [CalDAV account]
2. Toggle "Sync Server" on
3. Close settings, reopen
4. Verify toggle is still on
5. Verify auto-sync runs every 15 minutes