### PR TITLE
fix: handle null sync-token and set Content-Type on PUT updates

### DIFF
--- a/core/Services/CalDAV/CalDAVClient.vala
+++ b/core/Services/CalDAV/CalDAVClient.vala
@@ -378,7 +378,7 @@ public class Services.CalDAV.CalDAVClient : Services.CalDAV.WebDAVClient {
 
         yield fetch_project_details (project, cancellable);
 
-        if (project.sync_id == "") {
+        if (project.sync_id == null || project.sync_id == "") {
             project.loading = false;
             return;
         }
@@ -620,7 +620,7 @@ public class Services.CalDAV.CalDAVClient : Services.CalDAV.WebDAVClient {
         HttpResponse response = new HttpResponse ();
 
         try {
-            yield send_request ("PUT", item.ical_url, "", body, null, null, { Soup.Status.NO_CONTENT, Soup.Status.CREATED });
+            yield send_request ("PUT", item.ical_url, "text/calendar", body, null, null, { Soup.Status.NO_CONTENT, Soup.Status.CREATED });
             item.extra_data = Util.generate_extra_data (item.ical_url, "", body);
 
             response.status = true;


### PR DESCRIPTION
Two fixes for CalDAV request handling:

## 1. Handle null sync_id before sync-collection REPORT

When `sync_id` is null (not empty string), Vala's `printf` outputs the literal string "(null)". This causes servers to receive:

```xml
<d:sync-token>(null)</d:sync-token>
```

The check at line 381 only tested for empty string `""`, not null. Now checks for both.

## 2. Set Content-Type header on item update PUT requests

`update_item()` was passing empty string for Content-Type, while `add_item()` correctly uses `"text/calendar"`. Now both use `"text/calendar"` consistently.

## Testing

1. Create a new CalDAV account
2. Add tasks and verify sync works
3. Update existing tasks and verify sync works
4. Check server logs for proper Content-Type headers