### PR TITLE
fix: add required DTSTAMP property to VTODO components

### DIFF
--- a/core/Objects/Item.vala
+++ b/core/Objects/Item.vala
@@ -1192,6 +1192,7 @@ public class Objects.Item : Objects.BaseObject {
         ICal.Component ical = new ICal.Component.vtodo ();
 
         ical.set_uid (id);
+        ical.set_dtstamp (new ICal.Time.current_with_zone (ICal.Timezone.get_utc_timezone ()));
         ical.set_summary (content);
         ical.set_description (description);
 


### PR DESCRIPTION
RFC 5545 Section 3.6.2 specifies that DTSTAMP is **required** for VTODO components:

> The following are REQUIRED, but MUST NOT occur more than once.
>
>   dtstamp / uid

Currently, `to_vtodo()` sets UID but not DTSTAMP. This can cause issues with:
- Strict CalDAV servers that validate RFC compliance
- Other calendar clients that expect DTSTAMP to be present

## Fix

Add DTSTAMP set to current UTC time (RFC 5545 requires UTC for DTSTAMP):

```vala
ical.set_dtstamp (new ICal.Time.current_with_zone (ICal.Timezone.get_utc_timezone ()));
```

This follows the same pattern used for the COMPLETED property at line 1303.

## Testing

1. Create a new task in Planify
2. Sync to CalDAV server
3. Verify the VTODO contains DTSTAMP property
4. Verify other CalDAV clients can read the task