### PR TITLE
Fix radio buttons for color theme selection

### DIFF
--- a/data/io.github.alainm23.planify.gschema.xml
+++ b/data/io.github.alainm23.planify.gschema.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schemalist>
     <enum id="io.github.alainm23.planify.appearance">
+        <value nick="Light" value="0" />
         <value nick="Dark" value="1" />
         <value nick="Dark Blue" value="2" />
     </enum>

--- a/src/Dialogs/Preferences/Pages/Appearance.vala
+++ b/src/Dialogs/Preferences/Pages/Appearance.vala
@@ -184,17 +184,17 @@ public class Dialogs.Preferences.Pages.Appearance : Dialogs.Preferences.Pages.Ba
                                                                    system_appearance_switch.active);
         })] = system_appearance_switch;
 
-        signal_map[light_radio.activate.connect (() => {
+        signal_map[light_radio.toggled.connect (() => {
             Services.Settings.get_default ().settings.set_boolean ("dark-mode", false);
             Services.Settings.get_default ().settings.set_enum ("appearance", 0);
         })] = light_radio;
 
-        signal_map[dark_radio.activate.connect (() => {
+        signal_map[dark_radio.toggled.connect (() => {
             Services.Settings.get_default ().settings.set_boolean ("dark-mode", true);
             Services.Settings.get_default ().settings.set_enum ("appearance", 1);
         })] = dark_radio;
 
-        signal_map[blue_radio.activate.connect (() => {
+        signal_map[blue_radio.toggled.connect (() => {
             Services.Settings.get_default ().settings.set_boolean ("dark-mode", true);
             Services.Settings.get_default ().settings.set_enum ("appearance", 2);
         })] = blue_radio;


### PR DESCRIPTION
Currently, clicking the radio buttons to select a color theme does nothing. E.g., clicking the radio button next to "dark" while in "light" will remain in "light" mode:
<img width="524" height="228" alt="image" src="https://github.com/user-attachments/assets/8c02a309-6eda-42d0-8b82-a3f8fdc6510e" />

Changing the signal to `toggled` rather than `activate` fixes that. (idk why exactly, but the docs say "Applications should never connect to this signal, but use the GtkCheckButton::toggled signal" https://docs.gtk.org/gtk4/signal.CheckButton.activate.html so that's what I did 😉 )

Also, the schema was lacking an entry for the light mode "appearance" value. So whenever light mode is activated, this triggers a GTK error, which in turn seems to not really do anything other than cause weird behavior on the radio buttons^^
