### PR TITLE
Fix drag and drop after multi-select

### DIFF
--- a/src/Layouts/ItemRow.vala
+++ b/src/Layouts/ItemRow.vala
@@ -824,7 +824,10 @@ public class Layouts.ItemRow : Layouts.ItemBase {
             if (active) {
                 select_revealer.reveal_child = true;
                 checked_button.sensitive = false;
-                disable_drag_and_drop ();
+                if (drag_source != null) {
+                    itemrow_box.remove_controller (drag_source);
+                    drag_source = null;
+                }
             } else {
                 select_revealer.reveal_child = false;
                 checked_button.sensitive = true;


### PR DESCRIPTION
Fixes #2116 

Calling `disable_drag_and_drop()` sets `drag_enabled` to false, 
https://github.com/alainm23/planify/blob/0b4eb0ae6530adc6ac8d79cd4923126f0632614f/src/Layouts/ItemRow.vala?plain=1#L1883-L1884

so drag and drop will never be re-enabled again because of this check:
https://github.com/alainm23/planify/blob/0b4eb0ae6530adc6ac8d79cd4923126f0632614f/src/Layouts/ItemRow.vala?plain=1#L835-L837

To fix this, I copied the existing logic from the `edit` setter 
https://github.com/alainm23/planify/blob/0b4eb0ae6530adc6ac8d79cd4923126f0632614f/src/Layouts/ItemRow.vala?plain=1#L145-L148

