### PR TITLE
handle negative child_order

### DIFF
--- a/core/QuickAddCore.vala
+++ b/core/QuickAddCore.vala
@@ -1475,18 +1475,15 @@ public class Layouts.QuickAddCore : Adw.Bin {
 
         if (position == -1) {
             if (new_task_position == NewTaskPosition.START) {
-                new_order = items[0].child_order / 2;
+                position = 0;
             } else {
-                new_order = items[items.size - 1].child_order + 1000;
+                position = items.size;
             }
-        } else if (position == 0) {
-            var first = items[0];
-            new_order = first.child_order / 2;
+        }
 
-            if (new_order == first.child_order) {
-                normalize_orders (items);
-                return generate_child_order ();
-            }
+        if (position == 0) {
+            var first = items[0];
+            new_order = first.child_order - 1000;
         } else if (position > 0 && position < items.size) {
             var prev = items[position - 1];
             var next = items[position];

--- a/src/Utils/TaskUtils.vala
+++ b/src/Utils/TaskUtils.vala
@@ -40,7 +40,7 @@ public class Utils.TaskUtils {
         }
 
         if (prev == null && next != null) {
-            moved_row.item.child_order = (int) (next.item.child_order / 2);
+            moved_row.item.child_order = (int) (next.item.child_order - 1000);
         } else if (prev != null && next == null) {
             moved_row.item.child_order = prev.item.child_order + 1000;
         } else if (prev != null && next != null) {


### PR DESCRIPTION
Currently, when adding a new task at the start, its `child_order` is set to `first.child_order / 2`.

This breaks if there are negative values (happened for me, not sure where they came from)

E.g.: `-2 / 2 = -1` -> inserted after, not before.

The diff is a bit hard to read bc I also removed some code duplication. The interesting change is the `child_order / 2` -> `child_order - 1000` 

If we want to avoid negative `child_order` values, the existing `normalize_orders` logic could be run if the value is negative. I don't see a reason atm why that's necessary, so I'm not doing that here.