### PR TITLE
Add preference to preserve task properties in "Keep Adding" mode

### DIFF
--- a/core/Objects/Item.vala
+++ b/core/Objects/Item.vala
@@ -62,7 +62,7 @@ public class Objects.Item : Objects.BaseObject {
     public Objects.DueDate due { get; set; default = new Objects.DueDate (); }
     public Gee.ArrayList<Objects.Label> labels { get; set; default = new Gee.ArrayList<Objects.Label> (); }
 
-    public Gee.ArrayList<Objects.Label> _get_labels () {
+    public Gee.ArrayList<Objects.Label> get_labels_list () {
         Gee.ArrayList<Objects.Label> return_value = new Gee.ArrayList<Objects.Label> ();
 
         foreach (Objects.Label label in labels) {
@@ -605,7 +605,7 @@ public class Objects.Item : Objects.BaseObject {
             }
         }
 
-        foreach (var label in _get_labels ()) {
+        foreach (var label in get_labels_list ()) {
             if (!new_labels.has_key (label.id)) {
                 delete_item_label (label.id);
             }
@@ -947,6 +947,10 @@ public class Objects.Item : Objects.BaseObject {
 
         labels.add (label);
         item_label_added (label);
+    }
+
+    public void clean_labels () {
+        labels.clear ();
     }
 
     public Objects.Label ? delete_item_label (string id) {
@@ -1852,7 +1856,7 @@ public class Objects.Item : Objects.BaseObject {
             }
         }
 
-        foreach (var label in _get_labels ()) {
+        foreach (var label in get_labels_list ()) {
             if (!new_labels.has_key (label.id)) {
                 delete_item_label (label.id);
                 update = true;

--- a/data/io.github.alainm23.planify.gschema.xml
+++ b/data/io.github.alainm23.planify.gschema.xml
@@ -340,5 +340,11 @@
             <summary>Smart Date Recognition</summary>
             <description>Automatically detect and parse natural language dates like "tomorrow" or "next week" when creating tasks</description>
         </key>
+
+        <key name="quick-add-keep-properties" type="b">
+            <default>false</default>
+            <summary>Keep task properties when adding multiple tasks</summary>
+            <description>When "Keep adding" is enabled, preserve date, labels, and pinned status for the next task</description>
+        </key>
     </schema>
 </schemalist>

--- a/src/Dialogs/Preferences/Pages/QuickAdd.vala
+++ b/src/Dialogs/Preferences/Pages/QuickAdd.vala
@@ -94,7 +94,19 @@ public class Dialogs.Preferences.Pages.QuickAdd : Dialogs.Preferences.Pages.Base
         save_last_row.set_activatable_widget (save_last_switch);
         save_last_row.add_suffix (save_last_switch);
 
+        var keep_properties_switch = new Gtk.Switch () {
+            valign = Gtk.Align.CENTER,
+            active = Services.Settings.get_default ().settings.get_boolean ("quick-add-keep-properties")
+        };
+
+        var keep_properties_row = new Adw.ActionRow ();
+        keep_properties_row.title = _("Keep Task Properties");
+        keep_properties_row.subtitle = _("When 'Keep adding' is enabled, preserve date, labels, and pinned status");
+        keep_properties_row.set_activatable_widget (keep_properties_switch);
+        keep_properties_row.add_suffix (keep_properties_switch);
+
         settings_group.add (save_last_row);
+        settings_group.add (keep_properties_row);
 
         var content_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 12) {
             vexpand = true,
@@ -125,6 +137,11 @@ public class Dialogs.Preferences.Pages.QuickAdd : Dialogs.Preferences.Pages.Base
             Services.Settings.get_default ().settings.set_boolean ("quick-add-save-last-project",
                                                                    save_last_switch.active);
         })] = save_last_switch;
+
+        signal_map[keep_properties_switch.notify["active"].connect (() => {
+            Services.Settings.get_default ().settings.set_boolean ("quick-add-keep-properties",
+                                                                   keep_properties_switch.active);
+        })] = keep_properties_switch;
 
         destroy.connect (() => {
             clean_up ();

--- a/src/Layouts/ItemRow.vala
+++ b/src/Layouts/ItemRow.vala
@@ -462,9 +462,10 @@ public class Layouts.ItemRow : Layouts.ItemBase {
 
         markdown_revealer = new Gtk.Revealer ();
 
-        item_labels = new Widgets.ItemLabels (item) {
+        item_labels = new Widgets.ItemLabels () {
             margin_start = 24,
-            sensitive = !item.completed
+            sensitive = !item.completed,
+            item = item
         };
 
         schedule_button = null;
@@ -1027,7 +1028,7 @@ public class Layouts.ItemRow : Layouts.ItemBase {
 
         labels_summary.update_request ();
         if (label_button != null) {
-            label_button.labels = item._get_labels ();
+            label_button.labels = item.get_labels_list ();
         }
         if (schedule_button != null) {
             schedule_button.update_from_item (item);
@@ -1997,7 +1998,7 @@ public class Layouts.ItemRow : Layouts.ItemBase {
             sensitive = !item.completed
         };
         label_button.source = item.project.source;
-        label_button.labels = item._get_labels ();
+        label_button.labels = item.get_labels_list ();
 
         reminder_button = new Widgets.ReminderPicker.ReminderButton () {
             sensitive = !item.completed

--- a/src/Layouts/ItemSidebarView.vala
+++ b/src/Layouts/ItemSidebarView.vala
@@ -415,7 +415,7 @@ public class Layouts.ItemSidebarView : Adw.Bin {
         priority_button.update_from_item (item);
         status_button.update_from_item (item);
 
-        label_button.labels = item._get_labels ();
+        label_button.labels = item.get_labels_list ();
         label_button.update_tooltip_from_item (item);
 
         pin_button.update_from_item (item);
@@ -468,7 +468,7 @@ public class Layouts.ItemSidebarView : Adw.Bin {
             }
         }
 
-        foreach (var label in item._get_labels ()) {
+        foreach (var label in item.get_labels_list ()) {
             if (!new_labels.has_key (label.id)) {
                 item.delete_item_label (label.id);
                 update = true;

--- a/src/Widgets/LabelsSummary.vala
+++ b/src/Widgets/LabelsSummary.vala
@@ -110,7 +110,7 @@ public class Widgets.LabelsSummary : Adw.Bin {
     public void update_request () {
         more_label_revealer.reveal_child = false;
         
-        var item_labels = item._get_labels ();
+        var item_labels = item.get_labels_list ();
         var overflow_labels = new Gee.ArrayList<Objects.Label> ();
         int current_visible = labels.size;
         

--- a/src/Widgets/MultiSelectToolbar.vala
+++ b/src/Widgets/MultiSelectToolbar.vala
@@ -333,13 +333,13 @@ public class Widgets.MultiSelectToolbar : Adw.Bin {
 
     private void check_labels (Objects.Item item, bool active) {
         if (active) {
-            foreach (Objects.Label label in item._get_labels ()) {
+            foreach (Objects.Label label in item.get_labels_list ()) {
                 if (!labels.has_key (label.id)) {
                     labels[label.id] = label;
                 }
             }
         } else {
-            foreach (Objects.Label label in item._get_labels ()) {
+            foreach (Objects.Label label in item.get_labels_list ()) {
                 if (labels.has_key (label.id)) {
                     labels.unset (label.id);
                 }


### PR DESCRIPTION
Added optional preference to preserve task properties (date, labels, priority, pinned status, deadline) when using "Keep Adding" mode in Quick Add.

- New preference: quick-add-keep-properties (default: false)
- UI: Added "Keep Task Properties" switch in Quick Add preferences
- Fixed label preservation and signal loop issues
- Refactored ItemLabels widget to properly handle item changes

Fixes: #2160