### PR TITLE
CalendarEvents: Avoid Posix.NLTime if not available

### DIFF
--- a/core/Services/CalendarEvents/CalendarEvents.vala
+++ b/core/Services/CalendarEvents/CalendarEvents.vala
@@ -65,7 +65,11 @@ public class Services.CalendarEvents : Object {
         source_components = new HashTable<E.Source, Gee.TreeMultiMap<string, ECal.Component>> (CalendarEventsUtil.source_hash_func, CalendarEventsUtil.source_equal_func);
         source_view = new HashTable<string, ECal.ClientView> (str_hash, str_equal);
 
+#if HAVE__NL_TIME_FIRST_WEEKDAY
         int week_start = Posix.NLTime.FIRST_WEEKDAY.to_string ().data[0];
+#else
+        int week_start = 0;
+#endif
         if (week_start >= 1 && week_start <= 7) {
             week_starts_on = (GLib.DateWeekday) (week_start - 1);
         }

--- a/meson.build
+++ b/meson.build
@@ -4,6 +4,8 @@ project(
   version: '4.18.0'
 )
 
+cc = meson.get_compiler('c')
+
 gnome = import('gnome')
 i18n = import('i18n')
 pkgconfig = import('pkgconfig')
@@ -101,6 +103,17 @@ libexecdir = prefix / get_option('libexecdir')
 grep = find_program('grep')
 total_strings_res = run_command(grep, '-c', 'msgid', meson.project_source_root() + '/po/io.github.alainm23.planify.pot', check : true)
 total_strings = total_strings_res.stdout().strip().to_int() - 1
+
+# _NL_TIME_FIRST_WEEKDAY is a glibc-ism
+nl_time_first_weekday_src = '''
+  #include <langinfo.h>
+  int main() {
+    nl_langinfo(_NL_TIME_FIRST_WEEKDAY);
+  };
+'''
+if cc.compiles(nl_time_first_weekday_src)
+    add_project_arguments('-D', 'HAVE__NL_TIME_FIRST_WEEKDAY', language: 'vala')
+endif
 
 conf_data = configuration_data()
 conf_data.set('TOTAL_STRINGS', total_strings)


### PR DESCRIPTION
_NL_TIME_FIRST_WEEKDAY and similar are glibc-ism's and don't exist on other libc implementations like musl libc.

So if it's not available, set first weekday to 0 instead.