### PR TITLE
Fix child_order when moving a task to the very bottom

### DIFF
--- a/src/Layouts/SectionBoard.vala
+++ b/src/Layouts/SectionBoard.vala
@@ -737,7 +737,7 @@ public class Layouts.SectionBoard : Gtk.FlowBoxChild {
             source_list.remove (picked_widget);
 
             listbox.append (picked_widget);
-            Utils.TaskUtils.update_single_item_order (listbox, picked_widget, picked_widget.get_index () + 1);
+            Utils.TaskUtils.update_single_item_order (listbox, picked_widget, picked_widget.get_index ());
 
             Services.EventBus.get_default ().update_inserted_item_map (picked_widget, old_section_id, old_parent_id);
             

--- a/src/Layouts/SectionRow.vala
+++ b/src/Layouts/SectionRow.vala
@@ -784,7 +784,7 @@ public class Layouts.SectionRow : Gtk.ListBoxRow {
             source_list.remove (picked_widget);
 
             listbox.append (picked_widget);
-            Utils.TaskUtils.update_single_item_order (listbox, picked_widget, picked_widget.get_index () + 1);
+            Utils.TaskUtils.update_single_item_order (listbox, picked_widget, picked_widget.get_index ());
 
             Services.EventBus.get_default ().update_inserted_item_map (picked_widget, old_section_id, old_parent_id);
 


### PR DESCRIPTION
When moving a task via drag'n'drop to the very bottom, `update_single_item_order` was called not with the index of the moved item but with that index + 1.

This caused the child_order logic to effectively compute `item.child_order += 1000`, i.e., the item was moved a bit further downwards but not actually to the very end. Hence, the order would be wrong after the next sync with the server.