### PR TITLE
fix: backfill Todoist labels when incremental sync returns empty

### DIFF
--- a/core/Objects/Item.vala
+++ b/core/Objects/Item.vala
@@ -615,8 +615,10 @@ public class Objects.Item : Objects.BaseObject {
     public Gee.ArrayList<Objects.Label> get_labels_from_json (Json.Node node) {
         Gee.ArrayList<Objects.Label> return_value = new Gee.ArrayList<Objects.Label> ();
         foreach (unowned Json.Node element in node.get_object ().get_array_member ("labels").get_elements ()) {
-            Objects.Label label = Services.Store.instance ().get_label_by_name (element.get_string (), true, project.source_id);
-            return_value.add (label);
+            Objects.Label ? label = resolve_label_from_sync_value (element.get_string ());
+            if (label != null) {
+                return_value.add (label);
+            }
         }
         return return_value;
     }
@@ -643,10 +645,35 @@ public class Objects.Item : Objects.BaseObject {
     public Gee.HashMap<string, Objects.Label> get_labels_maps_from_json (Json.Node node) {
         Gee.HashMap<string, Objects.Label> return_value = new Gee.HashMap<string, Objects.Label> ();
         foreach (unowned Json.Node element in node.get_object ().get_array_member ("labels").get_elements ()) {
-            Objects.Label label = Services.Store.instance ().get_label_by_name (element.get_string (), true, project.source_id);
-            return_value[label.id] = label;
+            Objects.Label ? label = resolve_label_from_sync_value (element.get_string ());
+            if (label != null) {
+                return_value[label.id] = label;
+            }
         }
         return return_value;
+    }
+
+    private Objects.Label ? resolve_label_from_sync_value (string value) {
+        Objects.Label ? label = Services.Store.instance ().get_label (value);
+        string source_id = get_item_source_id ();
+        if (label != null && source_id != "" && label.source_id == source_id) {
+            return label;
+        }
+
+        if (source_id != "") {
+            return Services.Store.instance ().get_label_by_name (value, true, source_id);
+        }
+
+        return null;
+    }
+
+    private string get_item_source_id () {
+        Objects.Project ? item_project = project;
+        if (item_project != null) {
+            return item_project.source_id;
+        }
+
+        return "";
     }
 
     public Gee.HashMap<string, Objects.Label> get_labels_maps_from_caldav (GLib.SList<string> categories_list) {

--- a/core/Services/Todoist.vala
+++ b/core/Services/Todoist.vala
@@ -31,6 +31,9 @@ public class Services.Todoist : GLib.Object {
     private const string LABELS_COLLECTION = "labels";
     private const string REMINDERS_COLLECTION = "reminders";
     private const string MIGRATE_MESSAGE = _("Todoist has updated their API. Please reconnect your account in Preferences to continue syncing.");
+    private const string LABELS_RESOURCE_TYPES = "[\"labels\"]";
+
+    private Gee.HashSet<string> labels_backfill_attempted;
 
     private static Todoist ? _instance;
     public static Todoist get_default () {
@@ -44,6 +47,7 @@ public class Services.Todoist : GLib.Object {
     public Todoist () {
         session = new Soup.Session ();
         parser = new Json.Parser ();
+        labels_backfill_attempted = new Gee.HashSet<string> ();
     }
 
     public async HttpResponse login (string _url, Objects.Source? migrate_source = null) {
@@ -279,6 +283,9 @@ public class Services.Todoist : GLib.Object {
                 foreach (unowned Json.Node _node in _labels.get_elements ()) {
                     string _id = _node.get_object ().get_string_member ("id");
                     Objects.Label ? label = Services.Store.instance ().get_label (_id);
+                    if (label != null && label.source_id != source.id) {
+                        label = null;
+                    }
                     if (label != null) {
                         if (_node.get_object ().get_boolean_member ("is_deleted")) {
                             Services.Store.instance ().delete_label (label);
@@ -291,6 +298,13 @@ public class Services.Todoist : GLib.Object {
                         _label.source_id = source.id;
 
                         Services.Store.instance ().insert_label (_label);
+                    }
+                }
+
+                if (_labels.get_length () == 0) {
+                    if (!labels_backfill_attempted.contains (source.id)) {
+                        labels_backfill_attempted.add (source.id);
+                        yield backfill_labels_snapshot (source);
                     }
                 }
 
@@ -408,6 +422,46 @@ public class Services.Todoist : GLib.Object {
         }
 
         source.sync_finished ();
+    }
+
+    private async void backfill_labels_snapshot (Objects.Source source) {
+        var message = new Soup.Message ("POST", TODOIST_SYNC_URL);
+        message.request_headers.append ("Authorization", "Bearer %s".printf (source.todoist_data.access_token));
+
+        string form_data = "sync_token=*&resource_types=%s".printf (LABELS_RESOURCE_TYPES);
+        message.set_request_body_from_bytes ("application/x-www-form-urlencoded", new GLib.Bytes (form_data.data));
+
+        var labels_parser = new Json.Parser ();
+
+        try {
+            GLib.Bytes stream = yield session.send_and_read_async (message, GLib.Priority.LOW, null);
+            labels_parser.load_from_data ((string) stream.get_data ());
+
+            if (!labels_parser.get_root ().get_object ().has_member (LABELS_COLLECTION)) {
+                return;
+            }
+
+            unowned Json.Array labels = labels_parser.get_root ().get_object ().get_array_member (LABELS_COLLECTION);
+
+            foreach (unowned Json.Node _node in labels.get_elements ()) {
+                string _id = _node.get_object ().get_string_member ("id");
+                Objects.Label ? label = Services.Store.instance ().get_label (_id);
+                if (label != null && label.source_id == source.id) {
+                    if (_node.get_object ().get_boolean_member ("is_deleted")) {
+                        Services.Store.instance ().delete_label (label);
+                    } else {
+                        label.update_from_json (_node);
+                        Services.Store.instance ().update_label (label);
+                    }
+                } else if (!_node.get_object ().get_boolean_member ("is_deleted")) {
+                    Objects.Label _label = new Objects.Label.from_json (_node);
+                    _label.source_id = source.id;
+                    Services.Store.instance ().insert_label (_label);
+                }
+            }
+        } catch (Error e) {
+            debug ("Labels backfill failed: %s".printf (e.message));
+        }
     }
 
     /*


### PR DESCRIPTION
## Summary

Fixes an issue where Todoist labels could be missing in Planify if incremental sync returned an empty `labels` payload.

## What changed

- Added a one-time labels backfill in `Services.Todoist.sync()`:
  - If delta sync has no labels, fetch labels with:
    - `sync_token=*`
    - `resource_types=["labels"]`
  - Upsert returned labels into local store.
- Improved item label parsing in `Objects.Item`:
  - Resolve label values by id first, then by name.
  - Skip unresolved labels safely.

## Why

On some accounts, incremental sync can omit label entries even when labels exist server-side. Without a full labels refresh, Planify never repopulates missing labels.

## Validation

- Reproduced issue with labels created outside Planify not appearing.
- After fix:
  - labels are fetched via backfill,
  - labels appear in Labels view and task assignments,
  - label changes continue syncing normally.
- Build/test:
  - `ninja -C build`
  - `ninja -C build test` (all passing)

## Testing

Manual end-to-end validation against a real Todoist account:

- Modified existing labels in Planify and verified changes synced to Todoist.
- Modified existing labels in Todoist and verified changes synced to Planify.
- Created labels in Planify and verified they appeared in Todoist.
- Created labels in Todoist and verified they appeared in Planify.
- Deleted labels in Planify and verified deletion synced to Todoist.
- Deleted labels in Todoist and verified deletion synced to Planify.
- Verified task label assignments remained correct after each operation.

Result: all label create/update/delete flows worked as expected in both directions.


## Related

- Closes #2279
