### PR TITLE
Add PDF export for projects

### DIFF
--- a/core/Widgets/IconColorProject.vala
+++ b/core/Widgets/IconColorProject.vala
@@ -26,7 +26,6 @@ public class Widgets.IconColorProject : Adw.Bin {
     private Widgets.CircularProgressBar circular_progress_bar;
     public Gtk.Image inbox_icon;
     private Gtk.Label emoji_label;
-    private Gtk.Stack color_emoji_stack;
     private Gtk.Stack stack;
 
     private Gee.HashMap<ulong, weak GLib.Object> signal_map = new Gee.HashMap<ulong, weak GLib.Object> ();

--- a/po/POTFILES
+++ b/po/POTFILES
@@ -180,6 +180,7 @@ src/Services/ActionManager.vala
 src/Services/Api.vala
 src/Services/Backups.vala
 src/Services/DBusServer.vala
+src/Services/ExportService.vala
 src/Services/MigrateFromPlanner.vala
 src/Services/Notification.vala
 src/Services/TimeMonitor.vala

--- a/po/af.po
+++ b/po/af.po
@@ -1274,7 +1274,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr ""
 
@@ -2789,6 +2789,14 @@ msgstr ""
 msgid "Send by E-Mail"
 msgstr ""
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 msgid "Add tasks"
 msgstr ""
@@ -2922,6 +2930,10 @@ msgstr ""
 
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
+msgstr ""
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
 msgstr ""
 
 #: src/Services/Notification.vala:99

--- a/po/ak.po
+++ b/po/ak.po
@@ -1274,7 +1274,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr ""
 
@@ -2789,6 +2789,14 @@ msgstr ""
 msgid "Send by E-Mail"
 msgstr ""
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 msgid "Add tasks"
 msgstr ""
@@ -2922,6 +2930,10 @@ msgstr ""
 
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
+msgstr ""
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
 msgstr ""
 
 #: src/Services/Notification.vala:99

--- a/po/ar.po
+++ b/po/ar.po
@@ -1309,7 +1309,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr ""
 
@@ -2832,6 +2832,14 @@ msgstr ""
 msgid "Send by E-Mail"
 msgstr ""
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 msgid "Add tasks"
 msgstr ""
@@ -2965,6 +2973,10 @@ msgstr ""
 
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
+msgstr ""
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
 msgstr ""
 
 #: src/Services/Notification.vala:99

--- a/po/az.po
+++ b/po/az.po
@@ -1274,7 +1274,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr ""
 
@@ -2789,6 +2789,14 @@ msgstr ""
 msgid "Send by E-Mail"
 msgstr ""
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 msgid "Add tasks"
 msgstr ""
@@ -2922,6 +2930,10 @@ msgstr ""
 
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
+msgstr ""
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
 msgstr ""
 
 #: src/Services/Notification.vala:99

--- a/po/be.po
+++ b/po/be.po
@@ -1283,7 +1283,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr ""
 
@@ -2800,6 +2800,14 @@ msgstr ""
 msgid "Send by E-Mail"
 msgstr ""
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 msgid "Add tasks"
 msgstr ""
@@ -2933,6 +2941,10 @@ msgstr ""
 
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
+msgstr ""
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
 msgstr ""
 
 #: src/Services/Notification.vala:99

--- a/po/bg.po
+++ b/po/bg.po
@@ -1339,7 +1339,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr ""
 
@@ -2917,6 +2917,14 @@ msgstr "Споделяне"
 msgid "Send by E-Mail"
 msgstr "Изпращане като писмо"
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 #, fuzzy
 msgid "Add tasks"
@@ -3062,6 +3070,10 @@ msgstr ""
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
 msgstr "Резервни „Planify“ файлове"
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
+msgstr ""
 
 # # c-format
 #: src/Services/Notification.vala:99

--- a/po/bn.po
+++ b/po/bn.po
@@ -1274,7 +1274,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr ""
 
@@ -2789,6 +2789,14 @@ msgstr ""
 msgid "Send by E-Mail"
 msgstr ""
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 msgid "Add tasks"
 msgstr ""
@@ -2922,6 +2930,10 @@ msgstr ""
 
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
+msgstr ""
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
 msgstr ""
 
 #: src/Services/Notification.vala:99

--- a/po/bs.po
+++ b/po/bs.po
@@ -1283,7 +1283,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr ""
 
@@ -2800,6 +2800,14 @@ msgstr ""
 msgid "Send by E-Mail"
 msgstr ""
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 msgid "Add tasks"
 msgstr ""
@@ -2933,6 +2941,10 @@ msgstr ""
 
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
+msgstr ""
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
 msgstr ""
 
 #: src/Services/Notification.vala:99

--- a/po/ca.po
+++ b/po/ca.po
@@ -1289,7 +1289,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr "Termini"
 
@@ -2818,6 +2818,14 @@ msgstr "Comparteix"
 msgid "Send by E-Mail"
 msgstr "Envia per e-mail"
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 msgid "Add tasks"
 msgstr "Afegeix tasques"
@@ -2951,6 +2959,10 @@ msgstr "Reinicia ara"
 
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
+msgstr ""
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
 msgstr ""
 
 #: src/Services/Notification.vala:99

--- a/po/ckb.po
+++ b/po/ckb.po
@@ -1274,7 +1274,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr ""
 
@@ -2789,6 +2789,14 @@ msgstr ""
 msgid "Send by E-Mail"
 msgstr ""
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 msgid "Add tasks"
 msgstr ""
@@ -2922,6 +2930,10 @@ msgstr ""
 
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
+msgstr ""
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
 msgstr ""
 
 #: src/Services/Notification.vala:99

--- a/po/cs.po
+++ b/po/cs.po
@@ -1282,7 +1282,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr ""
 
@@ -2799,6 +2799,14 @@ msgstr ""
 msgid "Send by E-Mail"
 msgstr ""
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 msgid "Add tasks"
 msgstr ""
@@ -2932,6 +2940,10 @@ msgstr ""
 
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
+msgstr ""
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
 msgstr ""
 
 #: src/Services/Notification.vala:99

--- a/po/cv.po
+++ b/po/cv.po
@@ -1274,7 +1274,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr ""
 
@@ -2789,6 +2789,14 @@ msgstr ""
 msgid "Send by E-Mail"
 msgstr ""
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 msgid "Add tasks"
 msgstr ""
@@ -2922,6 +2930,10 @@ msgstr ""
 
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
+msgstr ""
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
 msgstr ""
 
 #: src/Services/Notification.vala:99

--- a/po/da.po
+++ b/po/da.po
@@ -1274,7 +1274,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr ""
 
@@ -2789,6 +2789,14 @@ msgstr ""
 msgid "Send by E-Mail"
 msgstr ""
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 msgid "Add tasks"
 msgstr ""
@@ -2922,6 +2930,10 @@ msgstr ""
 
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
+msgstr ""
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
 msgstr ""
 
 #: src/Services/Notification.vala:99

--- a/po/de.po
+++ b/po/de.po
@@ -1322,7 +1322,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr "Frist"
 
@@ -2915,6 +2915,14 @@ msgstr "Teilen"
 msgid "Send by E-Mail"
 msgstr "Per E-Mail senden"
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 msgid "Add tasks"
 msgstr "Füge Aufgaben hinzu"
@@ -3063,6 +3071,10 @@ msgstr "Jetzt neustarten"
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
 msgstr "Planify Sicherungsdateien"
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
+msgstr ""
 
 #: src/Services/Notification.vala:99
 msgid "Snooze for 10 minutes"

--- a/po/dum.po
+++ b/po/dum.po
@@ -1272,7 +1272,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr ""
 
@@ -2787,6 +2787,14 @@ msgstr ""
 msgid "Send by E-Mail"
 msgstr ""
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 msgid "Add tasks"
 msgstr ""
@@ -2920,6 +2928,10 @@ msgstr ""
 
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
+msgstr ""
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
 msgstr ""
 
 #: src/Services/Notification.vala:99

--- a/po/el.po
+++ b/po/el.po
@@ -1275,7 +1275,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr ""
 
@@ -2790,6 +2790,14 @@ msgstr ""
 msgid "Send by E-Mail"
 msgstr ""
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 msgid "Add tasks"
 msgstr ""
@@ -2923,6 +2931,10 @@ msgstr ""
 
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
+msgstr ""
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
 msgstr ""
 
 #: src/Services/Notification.vala:99

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -1315,7 +1315,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr ""
 
@@ -2858,6 +2858,14 @@ msgstr "Share"
 msgid "Send by E-Mail"
 msgstr "Send by E-Mail"
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 msgid "Add tasks"
 msgstr "Add tasks"
@@ -3003,6 +3011,10 @@ msgstr ""
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
 msgstr "Planify Backup Files"
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
+msgstr ""
 
 #: src/Services/Notification.vala:99
 #, fuzzy

--- a/po/eo.po
+++ b/po/eo.po
@@ -1274,7 +1274,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr ""
 
@@ -2789,6 +2789,14 @@ msgstr ""
 msgid "Send by E-Mail"
 msgstr ""
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 msgid "Add tasks"
 msgstr ""
@@ -2922,6 +2930,10 @@ msgstr ""
 
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
+msgstr ""
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
 msgstr ""
 
 #: src/Services/Notification.vala:99

--- a/po/es.po
+++ b/po/es.po
@@ -1317,7 +1317,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr "Fecha límite"
 
@@ -2908,6 +2908,14 @@ msgstr "Compartir"
 msgid "Send by E-Mail"
 msgstr "Enviar por correo electrónico"
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 msgid "Add tasks"
 msgstr "Añadir tareas"
@@ -3053,6 +3061,10 @@ msgstr "Reiniciar ahora"
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
 msgstr "Archivos de copia de seguridad de Planify"
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
+msgstr ""
 
 #: src/Services/Notification.vala:99
 msgid "Snooze for 10 minutes"

--- a/po/et.po
+++ b/po/et.po
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr "Tähtaeg"
 
@@ -2793,6 +2793,14 @@ msgstr "Jaga"
 msgid "Send by E-Mail"
 msgstr "Saada e-postiga"
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 msgid "Add tasks"
 msgstr "Lisa ülesandeid"
@@ -2929,6 +2937,10 @@ msgstr "Taaskäivita kohe"
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
 msgstr "Planify varukoopiad"
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
+msgstr ""
 
 #: src/Services/Notification.vala:99
 msgid "Snooze for 10 minutes"

--- a/po/eu.po
+++ b/po/eu.po
@@ -1274,7 +1274,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr ""
 
@@ -2789,6 +2789,14 @@ msgstr ""
 msgid "Send by E-Mail"
 msgstr ""
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 msgid "Add tasks"
 msgstr ""
@@ -2922,6 +2930,10 @@ msgstr ""
 
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
+msgstr ""
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
 msgstr ""
 
 #: src/Services/Notification.vala:99

--- a/po/fa.po
+++ b/po/fa.po
@@ -1274,7 +1274,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr ""
 
@@ -2789,6 +2789,14 @@ msgstr ""
 msgid "Send by E-Mail"
 msgstr ""
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 msgid "Add tasks"
 msgstr ""
@@ -2922,6 +2930,10 @@ msgstr ""
 
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
+msgstr ""
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
 msgstr ""
 
 #: src/Services/Notification.vala:99

--- a/po/fi.po
+++ b/po/fi.po
@@ -1274,7 +1274,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr ""
 
@@ -2789,6 +2789,14 @@ msgstr ""
 msgid "Send by E-Mail"
 msgstr ""
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 msgid "Add tasks"
 msgstr ""
@@ -2922,6 +2930,10 @@ msgstr ""
 
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
+msgstr ""
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
 msgstr ""
 
 #: src/Services/Notification.vala:99

--- a/po/fr.po
+++ b/po/fr.po
@@ -1319,7 +1319,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr "Échéance"
 
@@ -2916,6 +2916,14 @@ msgstr "Partager"
 msgid "Send by E-Mail"
 msgstr "Envoyer par courriel"
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 msgid "Add tasks"
 msgstr "Ajouter des tâches"
@@ -3062,6 +3070,10 @@ msgstr "Redémarrer maintenant"
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
 msgstr "Fichiers de sauvegarde Planify"
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
+msgstr ""
 
 # # c-format
 #: src/Services/Notification.vala:99

--- a/po/ga.po
+++ b/po/ga.po
@@ -1282,7 +1282,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr ""
 
@@ -2799,6 +2799,14 @@ msgstr ""
 msgid "Send by E-Mail"
 msgstr ""
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 msgid "Add tasks"
 msgstr ""
@@ -2932,6 +2940,10 @@ msgstr ""
 
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
+msgstr ""
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
 msgstr ""
 
 #: src/Services/Notification.vala:99

--- a/po/gl.po
+++ b/po/gl.po
@@ -1274,7 +1274,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr ""
 
@@ -2789,6 +2789,14 @@ msgstr ""
 msgid "Send by E-Mail"
 msgstr ""
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 msgid "Add tasks"
 msgstr ""
@@ -2922,6 +2930,10 @@ msgstr ""
 
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
+msgstr ""
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
 msgstr ""
 
 #: src/Services/Notification.vala:99

--- a/po/he.po
+++ b/po/he.po
@@ -1275,7 +1275,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr ""
 
@@ -2790,6 +2790,14 @@ msgstr ""
 msgid "Send by E-Mail"
 msgstr ""
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 msgid "Add tasks"
 msgstr ""
@@ -2923,6 +2931,10 @@ msgstr ""
 
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
+msgstr ""
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
 msgstr ""
 
 #: src/Services/Notification.vala:99

--- a/po/hi.po
+++ b/po/hi.po
@@ -1327,7 +1327,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr ""
 
@@ -2896,6 +2896,14 @@ msgstr "साझा करें"
 msgid "Send by E-Mail"
 msgstr "ई-मेल द्वारा भेजें"
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 #, fuzzy
 msgid "Add tasks"
@@ -3035,6 +3043,10 @@ msgstr ""
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
 msgstr "प्लॅानिफाई की बैकअप फाइलें"
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
+msgstr ""
 
 #: src/Services/Notification.vala:99
 #, fuzzy

--- a/po/hr.po
+++ b/po/hr.po
@@ -1313,7 +1313,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr "Rok"
 
@@ -2886,6 +2886,14 @@ msgstr "Dijeli"
 msgid "Send by E-Mail"
 msgstr "Pošalji e-poštom"
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 msgid "Add tasks"
 msgstr "Dodaj zadatke"
@@ -3030,6 +3038,10 @@ msgstr "Ponovo pokreni sada"
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
 msgstr "Datoteke sigurnosnih kopija aplikacije Planify"
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
+msgstr ""
 
 #: src/Services/Notification.vala:99
 msgid "Snooze for 10 minutes"

--- a/po/hu.po
+++ b/po/hu.po
@@ -1274,7 +1274,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr ""
 
@@ -2789,6 +2789,14 @@ msgstr ""
 msgid "Send by E-Mail"
 msgstr ""
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 msgid "Add tasks"
 msgstr ""
@@ -2922,6 +2930,10 @@ msgstr ""
 
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
+msgstr ""
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
 msgstr ""
 
 #: src/Services/Notification.vala:99

--- a/po/hy.po
+++ b/po/hy.po
@@ -1274,7 +1274,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr ""
 
@@ -2789,6 +2789,14 @@ msgstr ""
 msgid "Send by E-Mail"
 msgstr ""
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 msgid "Add tasks"
 msgstr ""
@@ -2922,6 +2930,10 @@ msgstr ""
 
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
+msgstr ""
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
 msgstr ""
 
 #: src/Services/Notification.vala:99

--- a/po/id.po
+++ b/po/id.po
@@ -1297,7 +1297,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr "Tenggat"
 
@@ -2869,6 +2869,14 @@ msgstr "Bagikan"
 msgid "Send by E-Mail"
 msgstr "Kirim melalui E-mail"
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 msgid "Add tasks"
 msgstr "Tambahkan tugas"
@@ -3013,6 +3021,10 @@ msgstr "Mulai Ulang Sekarang"
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
 msgstr "Berkas Cadangan Planify"
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
+msgstr ""
 
 #: src/Services/Notification.vala:99
 msgid "Snooze for 10 minutes"

--- a/po/io.github.alainm23.planify.pot
+++ b/po/io.github.alainm23.planify.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: io.github.alainm23.planify\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-03-26 11:32+0000\n"
+"POT-Creation-Date: 2026-03-27 11:00+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1278,7 +1278,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr ""
 
@@ -2793,6 +2793,14 @@ msgstr ""
 msgid "Send by E-Mail"
 msgstr ""
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 msgid "Add tasks"
 msgstr ""
@@ -2926,6 +2934,10 @@ msgstr ""
 
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
+msgstr ""
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
 msgstr ""
 
 #: src/Services/Notification.vala:99

--- a/po/is.po
+++ b/po/is.po
@@ -1274,7 +1274,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr ""
 
@@ -2789,6 +2789,14 @@ msgstr ""
 msgid "Send by E-Mail"
 msgstr ""
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 msgid "Add tasks"
 msgstr ""
@@ -2922,6 +2930,10 @@ msgstr ""
 
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
+msgstr ""
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
 msgstr ""
 
 #: src/Services/Notification.vala:99

--- a/po/it.po
+++ b/po/it.po
@@ -1304,7 +1304,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr "Scadenza"
 
@@ -2844,6 +2844,14 @@ msgstr "Condividi"
 msgid "Send by E-Mail"
 msgstr "Invia tramite E-Mail"
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 msgid "Add tasks"
 msgstr "Aggiungi Attività"
@@ -2977,6 +2985,10 @@ msgstr ""
 
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
+msgstr ""
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
 msgstr ""
 
 #: src/Services/Notification.vala:99

--- a/po/ja.po
+++ b/po/ja.po
@@ -1266,7 +1266,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr ""
 
@@ -2779,6 +2779,14 @@ msgstr ""
 msgid "Send by E-Mail"
 msgstr ""
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 msgid "Add tasks"
 msgstr ""
@@ -2912,6 +2920,10 @@ msgstr ""
 
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
+msgstr ""
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
 msgstr ""
 
 #: src/Services/Notification.vala:99

--- a/po/jv.po
+++ b/po/jv.po
@@ -1266,7 +1266,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr ""
 
@@ -2779,6 +2779,14 @@ msgstr ""
 msgid "Send by E-Mail"
 msgstr ""
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 msgid "Add tasks"
 msgstr ""
@@ -2912,6 +2920,10 @@ msgstr ""
 
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
+msgstr ""
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
 msgstr ""
 
 #: src/Services/Notification.vala:99

--- a/po/ka.po
+++ b/po/ka.po
@@ -1301,7 +1301,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr ""
 
@@ -2840,6 +2840,14 @@ msgstr "გაზიარება"
 msgid "Send by E-Mail"
 msgstr "ელფოსტით გაგზავნა"
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 #, fuzzy
 msgid "Add tasks"
@@ -2978,6 +2986,10 @@ msgstr ""
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
 msgstr "Planify-ის მარქაფის ფაილები"
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
+msgstr ""
 
 #: src/Services/Notification.vala:99
 #, fuzzy

--- a/po/kab.po
+++ b/po/kab.po
@@ -1274,7 +1274,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr ""
 
@@ -2789,6 +2789,14 @@ msgstr ""
 msgid "Send by E-Mail"
 msgstr ""
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 msgid "Add tasks"
 msgstr ""
@@ -2922,6 +2930,10 @@ msgstr ""
 
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
+msgstr ""
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
 msgstr ""
 
 #: src/Services/Notification.vala:99

--- a/po/kk.po
+++ b/po/kk.po
@@ -1328,7 +1328,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr ""
 
@@ -2896,6 +2896,14 @@ msgstr "Бөлісу"
 msgid "Send by E-Mail"
 msgstr "Эл. пошта арқылы жіберу"
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 #, fuzzy
 msgid "Add tasks"
@@ -3042,6 +3050,10 @@ msgstr ""
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
 msgstr "Planify сақтық көшірме файлдары"
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
+msgstr ""
 
 #: src/Services/Notification.vala:99
 #, fuzzy

--- a/po/kn.po
+++ b/po/kn.po
@@ -1274,7 +1274,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr ""
 
@@ -2789,6 +2789,14 @@ msgstr ""
 msgid "Send by E-Mail"
 msgstr ""
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 msgid "Add tasks"
 msgstr ""
@@ -2922,6 +2930,10 @@ msgstr ""
 
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
+msgstr ""
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
 msgstr ""
 
 #: src/Services/Notification.vala:99

--- a/po/ko.po
+++ b/po/ko.po
@@ -1320,7 +1320,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr ""
 
@@ -2882,6 +2882,14 @@ msgstr "공유"
 msgid "Send by E-Mail"
 msgstr "이메일로 보내기"
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 #, fuzzy
 msgid "Add tasks"
@@ -3022,6 +3030,10 @@ msgstr ""
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
 msgstr "Planify 백업 파일"
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
+msgstr ""
 
 # # c-format
 #: src/Services/Notification.vala:99

--- a/po/ku.po
+++ b/po/ku.po
@@ -1274,7 +1274,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr ""
 
@@ -2789,6 +2789,14 @@ msgstr ""
 msgid "Send by E-Mail"
 msgstr ""
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 msgid "Add tasks"
 msgstr ""
@@ -2922,6 +2930,10 @@ msgstr ""
 
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
+msgstr ""
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
 msgstr ""
 
 #: src/Services/Notification.vala:99

--- a/po/kw.po
+++ b/po/kw.po
@@ -1278,7 +1278,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr ""
 
@@ -2793,6 +2793,14 @@ msgstr ""
 msgid "Send by E-Mail"
 msgstr ""
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 msgid "Add tasks"
 msgstr ""
@@ -2926,6 +2934,10 @@ msgstr ""
 
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
+msgstr ""
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
 msgstr ""
 
 #: src/Services/Notification.vala:99

--- a/po/lb.po
+++ b/po/lb.po
@@ -1274,7 +1274,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr ""
 
@@ -2789,6 +2789,14 @@ msgstr ""
 msgid "Send by E-Mail"
 msgstr ""
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 msgid "Add tasks"
 msgstr ""
@@ -2922,6 +2930,10 @@ msgstr ""
 
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
+msgstr ""
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
 msgstr ""
 
 #: src/Services/Notification.vala:99

--- a/po/lg.po
+++ b/po/lg.po
@@ -1274,7 +1274,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr ""
 
@@ -2789,6 +2789,14 @@ msgstr ""
 msgid "Send by E-Mail"
 msgstr ""
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 msgid "Add tasks"
 msgstr ""
@@ -2922,6 +2930,10 @@ msgstr ""
 
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
+msgstr ""
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
 msgstr ""
 
 #: src/Services/Notification.vala:99

--- a/po/lt.po
+++ b/po/lt.po
@@ -1283,7 +1283,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr ""
 
@@ -2800,6 +2800,14 @@ msgstr ""
 msgid "Send by E-Mail"
 msgstr ""
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 msgid "Add tasks"
 msgstr ""
@@ -2933,6 +2941,10 @@ msgstr ""
 
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
+msgstr ""
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
 msgstr ""
 
 #: src/Services/Notification.vala:99

--- a/po/lv.po
+++ b/po/lv.po
@@ -1310,7 +1310,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr ""
 
@@ -2866,6 +2866,14 @@ msgstr "Dalīties"
 msgid "Send by E-Mail"
 msgstr "Sūtīt pa e-pastu"
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 msgid "Add tasks"
 msgstr "Pievienot uzdevumus"
@@ -3009,6 +3017,10 @@ msgstr ""
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
 msgstr "Planify dublējumkopijas datnes"
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
+msgstr ""
 
 #: src/Services/Notification.vala:99
 msgid "Snooze for 10 minutes"

--- a/po/mg.po
+++ b/po/mg.po
@@ -1274,7 +1274,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr ""
 
@@ -2789,6 +2789,14 @@ msgstr ""
 msgid "Send by E-Mail"
 msgstr ""
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 msgid "Add tasks"
 msgstr ""
@@ -2922,6 +2930,10 @@ msgstr ""
 
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
+msgstr ""
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
 msgstr ""
 
 #: src/Services/Notification.vala:99

--- a/po/mk.po
+++ b/po/mk.po
@@ -1274,7 +1274,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr ""
 
@@ -2789,6 +2789,14 @@ msgstr ""
 msgid "Send by E-Mail"
 msgstr ""
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 msgid "Add tasks"
 msgstr ""
@@ -2922,6 +2930,10 @@ msgstr ""
 
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
+msgstr ""
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
 msgstr ""
 
 #: src/Services/Notification.vala:99

--- a/po/mn.po
+++ b/po/mn.po
@@ -1274,7 +1274,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr ""
 
@@ -2789,6 +2789,14 @@ msgstr ""
 msgid "Send by E-Mail"
 msgstr ""
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 msgid "Add tasks"
 msgstr ""
@@ -2922,6 +2930,10 @@ msgstr ""
 
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
+msgstr ""
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
 msgstr ""
 
 #: src/Services/Notification.vala:99

--- a/po/mr.po
+++ b/po/mr.po
@@ -1274,7 +1274,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr ""
 
@@ -2789,6 +2789,14 @@ msgstr ""
 msgid "Send by E-Mail"
 msgstr ""
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 msgid "Add tasks"
 msgstr ""
@@ -2922,6 +2930,10 @@ msgstr ""
 
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
+msgstr ""
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
 msgstr ""
 
 #: src/Services/Notification.vala:99

--- a/po/ms.po
+++ b/po/ms.po
@@ -1266,7 +1266,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr ""
 
@@ -2779,6 +2779,14 @@ msgstr ""
 msgid "Send by E-Mail"
 msgstr ""
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 msgid "Add tasks"
 msgstr ""
@@ -2912,6 +2920,10 @@ msgstr ""
 
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
+msgstr ""
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
 msgstr ""
 
 #: src/Services/Notification.vala:99

--- a/po/my.po
+++ b/po/my.po
@@ -1266,7 +1266,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr ""
 
@@ -2779,6 +2779,14 @@ msgstr ""
 msgid "Send by E-Mail"
 msgstr ""
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 msgid "Add tasks"
 msgstr ""
@@ -2912,6 +2920,10 @@ msgstr ""
 
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
+msgstr ""
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
 msgstr ""
 
 #: src/Services/Notification.vala:99

--- a/po/nb.po
+++ b/po/nb.po
@@ -1308,7 +1308,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr "Frist"
 
@@ -2874,6 +2874,14 @@ msgstr "Del"
 msgid "Send by E-Mail"
 msgstr "Send med e-post"
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 msgid "Add tasks"
 msgstr "Legg til oppgaver"
@@ -3018,6 +3026,10 @@ msgstr "Omstart nå"
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
 msgstr "Planify sikkerhetskopi-filer"
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
+msgstr ""
 
 #: src/Services/Notification.vala:99
 msgid "Snooze for 10 minutes"

--- a/po/nl.po
+++ b/po/nl.po
@@ -1325,7 +1325,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr "Deadline"
 
@@ -2904,6 +2904,14 @@ msgstr "Delen"
 msgid "Send by E-Mail"
 msgstr "Per e-mail verzenden"
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 msgid "Add tasks"
 msgstr "Taken toevoegen"
@@ -3049,6 +3057,10 @@ msgstr "Nu herstarten"
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
 msgstr "Back-up-bestanden van Planify"
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
+msgstr ""
 
 #: src/Services/Notification.vala:99
 msgid "Snooze for 10 minutes"

--- a/po/nn.po
+++ b/po/nn.po
@@ -1274,7 +1274,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr ""
 
@@ -2789,6 +2789,14 @@ msgstr ""
 msgid "Send by E-Mail"
 msgstr ""
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 msgid "Add tasks"
 msgstr ""
@@ -2922,6 +2930,10 @@ msgstr ""
 
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
+msgstr ""
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
 msgstr ""
 
 #: src/Services/Notification.vala:99

--- a/po/pa.po
+++ b/po/pa.po
@@ -1274,7 +1274,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr ""
 
@@ -2789,6 +2789,14 @@ msgstr ""
 msgid "Send by E-Mail"
 msgstr ""
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 msgid "Add tasks"
 msgstr ""
@@ -2922,6 +2930,10 @@ msgstr ""
 
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
+msgstr ""
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
 msgstr ""
 
 #: src/Services/Notification.vala:99

--- a/po/pl.po
+++ b/po/pl.po
@@ -1287,7 +1287,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr ""
 
@@ -2804,6 +2804,14 @@ msgstr ""
 msgid "Send by E-Mail"
 msgstr ""
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 msgid "Add tasks"
 msgstr ""
@@ -2937,6 +2945,10 @@ msgstr ""
 
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
+msgstr ""
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
 msgstr ""
 
 #: src/Services/Notification.vala:99

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -1326,7 +1326,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr "Prazo"
 
@@ -2909,6 +2909,14 @@ msgstr "Compartilhar"
 msgid "Send by E-Mail"
 msgstr "Enviar por E-Mail"
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 #, fuzzy
 msgid "Add tasks"
@@ -3056,6 +3064,10 @@ msgstr ""
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
 msgstr "Planeje Arquivos de Backup"
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
+msgstr ""
 
 # # c-format
 #: src/Services/Notification.vala:99

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -1308,7 +1308,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr "Data limite"
 
@@ -2902,6 +2902,14 @@ msgstr "Partilhar"
 msgid "Send by E-Mail"
 msgstr "Enviar por e-mail"
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 msgid "Add tasks"
 msgstr "Adicionar tarefas"
@@ -3046,6 +3054,10 @@ msgstr "Reiniciar agora"
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
 msgstr "Ficheiros da cópia de segurança do Planify"
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
+msgstr ""
 
 #: src/Services/Notification.vala:99
 msgid "Snooze for 10 minutes"

--- a/po/ro.po
+++ b/po/ro.po
@@ -1283,7 +1283,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr ""
 
@@ -2800,6 +2800,14 @@ msgstr ""
 msgid "Send by E-Mail"
 msgstr ""
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 msgid "Add tasks"
 msgstr ""
@@ -2933,6 +2941,10 @@ msgstr ""
 
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
+msgstr ""
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
 msgstr ""
 
 #: src/Services/Notification.vala:99

--- a/po/ru.po
+++ b/po/ru.po
@@ -1314,7 +1314,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr "Крайний срок"
 
@@ -2893,6 +2893,14 @@ msgstr "Поделиться"
 msgid "Send by E-Mail"
 msgstr "Отправить по E-Mail"
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 msgid "Add tasks"
 msgstr "Добавить задачи"
@@ -3037,6 +3045,10 @@ msgstr "Перезапустить сейчас"
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
 msgstr "Резервные копии Planify"
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
+msgstr ""
 
 #: src/Services/Notification.vala:99
 msgid "Snooze for 10 minutes"

--- a/po/sa.po
+++ b/po/sa.po
@@ -1282,7 +1282,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr ""
 
@@ -2799,6 +2799,14 @@ msgstr ""
 msgid "Send by E-Mail"
 msgstr ""
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 msgid "Add tasks"
 msgstr ""
@@ -2932,6 +2940,10 @@ msgstr ""
 
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
+msgstr ""
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
 msgstr ""
 
 #: src/Services/Notification.vala:99

--- a/po/si.po
+++ b/po/si.po
@@ -1274,7 +1274,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr ""
 
@@ -2789,6 +2789,14 @@ msgstr ""
 msgid "Send by E-Mail"
 msgstr ""
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 msgid "Add tasks"
 msgstr ""
@@ -2922,6 +2930,10 @@ msgstr ""
 
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
+msgstr ""
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
 msgstr ""
 
 #: src/Services/Notification.vala:99

--- a/po/sk.po
+++ b/po/sk.po
@@ -1340,7 +1340,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr ""
 
@@ -2900,6 +2900,14 @@ msgstr "Zdieľať"
 msgid "Send by E-Mail"
 msgstr "Poslať e-mailom"
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 #, fuzzy
 msgid "Add tasks"
@@ -3047,6 +3055,10 @@ msgstr ""
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
 msgstr "Zálohovacie súbory Planify"
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
+msgstr ""
 
 #: src/Services/Notification.vala:99
 #, fuzzy

--- a/po/sl.po
+++ b/po/sl.po
@@ -1317,7 +1317,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr ""
 
@@ -2836,6 +2836,14 @@ msgstr ""
 msgid "Send by E-Mail"
 msgstr ""
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 msgid "Add tasks"
 msgstr ""
@@ -2969,6 +2977,10 @@ msgstr ""
 
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
+msgstr ""
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
 msgstr ""
 
 #: src/Services/Notification.vala:99

--- a/po/sma.po
+++ b/po/sma.po
@@ -1282,7 +1282,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr ""
 
@@ -2799,6 +2799,14 @@ msgstr ""
 msgid "Send by E-Mail"
 msgstr ""
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 msgid "Add tasks"
 msgstr ""
@@ -2932,6 +2940,10 @@ msgstr ""
 
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
+msgstr ""
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
 msgstr ""
 
 #: src/Services/Notification.vala:99

--- a/po/sq.po
+++ b/po/sq.po
@@ -1274,7 +1274,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr ""
 
@@ -2789,6 +2789,14 @@ msgstr ""
 msgid "Send by E-Mail"
 msgstr ""
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 msgid "Add tasks"
 msgstr ""
@@ -2922,6 +2930,10 @@ msgstr ""
 
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
+msgstr ""
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
 msgstr ""
 
 #: src/Services/Notification.vala:99

--- a/po/sr.po
+++ b/po/sr.po
@@ -1283,7 +1283,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr ""
 
@@ -2800,6 +2800,14 @@ msgstr ""
 msgid "Send by E-Mail"
 msgstr ""
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 msgid "Add tasks"
 msgstr ""
@@ -2933,6 +2941,10 @@ msgstr ""
 
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
+msgstr ""
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
 msgstr ""
 
 #: src/Services/Notification.vala:99

--- a/po/sv.po
+++ b/po/sv.po
@@ -1300,7 +1300,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr ""
 
@@ -2815,6 +2815,14 @@ msgstr ""
 msgid "Send by E-Mail"
 msgstr ""
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 msgid "Add tasks"
 msgstr ""
@@ -2948,6 +2956,10 @@ msgstr ""
 
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
+msgstr ""
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
 msgstr ""
 
 #: src/Services/Notification.vala:99

--- a/po/szl.po
+++ b/po/szl.po
@@ -1283,7 +1283,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr ""
 
@@ -2800,6 +2800,14 @@ msgstr ""
 msgid "Send by E-Mail"
 msgstr ""
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 msgid "Add tasks"
 msgstr ""
@@ -2933,6 +2941,10 @@ msgstr ""
 
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
+msgstr ""
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
 msgstr ""
 
 #: src/Services/Notification.vala:99

--- a/po/ta.po
+++ b/po/ta.po
@@ -1274,7 +1274,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr ""
 
@@ -2789,6 +2789,14 @@ msgstr ""
 msgid "Send by E-Mail"
 msgstr ""
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 msgid "Add tasks"
 msgstr ""
@@ -2922,6 +2930,10 @@ msgstr ""
 
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
+msgstr ""
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
 msgstr ""
 
 #: src/Services/Notification.vala:99

--- a/po/te.po
+++ b/po/te.po
@@ -1274,7 +1274,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr ""
 
@@ -2789,6 +2789,14 @@ msgstr ""
 msgid "Send by E-Mail"
 msgstr ""
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 msgid "Add tasks"
 msgstr ""
@@ -2922,6 +2930,10 @@ msgstr ""
 
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
+msgstr ""
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
 msgstr ""
 
 #: src/Services/Notification.vala:99

--- a/po/th.po
+++ b/po/th.po
@@ -1266,7 +1266,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr ""
 
@@ -2779,6 +2779,14 @@ msgstr ""
 msgid "Send by E-Mail"
 msgstr ""
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 msgid "Add tasks"
 msgstr ""
@@ -2912,6 +2920,10 @@ msgstr ""
 
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
+msgstr ""
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
 msgstr ""
 
 #: src/Services/Notification.vala:99

--- a/po/tl.po
+++ b/po/tl.po
@@ -1275,7 +1275,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr ""
 
@@ -2790,6 +2790,14 @@ msgstr ""
 msgid "Send by E-Mail"
 msgstr ""
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 msgid "Add tasks"
 msgstr ""
@@ -2923,6 +2931,10 @@ msgstr ""
 
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
+msgstr ""
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
 msgstr ""
 
 #: src/Services/Notification.vala:99

--- a/po/tr.po
+++ b/po/tr.po
@@ -1314,7 +1314,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr ""
 
@@ -2888,6 +2888,14 @@ msgstr "Paylaş"
 msgid "Send by E-Mail"
 msgstr "E-posta İle Gönder"
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 #, fuzzy
 msgid "Add tasks"
@@ -3029,6 +3037,10 @@ msgstr ""
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
 msgstr "Planify Yedek Dosyaları"
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
+msgstr ""
 
 # c-format
 #: src/Services/Notification.vala:99

--- a/po/ug.po
+++ b/po/ug.po
@@ -1274,7 +1274,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr ""
 
@@ -2789,6 +2789,14 @@ msgstr ""
 msgid "Send by E-Mail"
 msgstr ""
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 msgid "Add tasks"
 msgstr ""
@@ -2922,6 +2930,10 @@ msgstr ""
 
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
+msgstr ""
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
 msgstr ""
 
 #: src/Services/Notification.vala:99

--- a/po/uk.po
+++ b/po/uk.po
@@ -1315,7 +1315,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr "Кінцевий термін"
 
@@ -2896,6 +2896,14 @@ msgstr "Поділитися"
 msgid "Send by E-Mail"
 msgstr "Надіслати електронною поштою"
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 msgid "Add tasks"
 msgstr "Додати завдання"
@@ -3039,6 +3047,10 @@ msgstr "Перезавантажити зараз"
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
 msgstr "Планування резервних копій файлів"
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
+msgstr ""
 
 #: src/Services/Notification.vala:99
 msgid "Snooze for 10 minutes"

--- a/po/ur.po
+++ b/po/ur.po
@@ -1274,7 +1274,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr ""
 
@@ -2789,6 +2789,14 @@ msgstr ""
 msgid "Send by E-Mail"
 msgstr ""
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 msgid "Add tasks"
 msgstr ""
@@ -2922,6 +2930,10 @@ msgstr ""
 
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
+msgstr ""
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
 msgstr ""
 
 #: src/Services/Notification.vala:99

--- a/po/uz.po
+++ b/po/uz.po
@@ -1274,7 +1274,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr ""
 
@@ -2789,6 +2789,14 @@ msgstr ""
 msgid "Send by E-Mail"
 msgstr ""
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 msgid "Add tasks"
 msgstr ""
@@ -2922,6 +2930,10 @@ msgstr ""
 
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
+msgstr ""
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
 msgstr ""
 
 #: src/Services/Notification.vala:99

--- a/po/vi.po
+++ b/po/vi.po
@@ -1291,7 +1291,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr "Thời hạn"
 
@@ -2864,6 +2864,14 @@ msgstr "Chia Sẻ"
 msgid "Send by E-Mail"
 msgstr "Gửi qua Email"
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 msgid "Add tasks"
 msgstr "Thêm nhiệm vụ"
@@ -3007,6 +3015,10 @@ msgstr "Khởi Động Lại Ngay"
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
 msgstr "Tệp Sao Lưu Planify"
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
+msgstr ""
 
 #: src/Services/Notification.vala:99
 msgid "Snooze for 10 minutes"

--- a/po/zh.po
+++ b/po/zh.po
@@ -1269,7 +1269,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr ""
 
@@ -2782,6 +2782,14 @@ msgstr ""
 msgid "Send by E-Mail"
 msgstr ""
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 msgid "Add tasks"
 msgstr ""
@@ -2915,6 +2923,10 @@ msgstr ""
 
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
+msgstr ""
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
 msgstr ""
 
 #: src/Services/Notification.vala:99

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -1281,7 +1281,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr "截止日期"
 
@@ -2817,6 +2817,14 @@ msgstr "分享"
 msgid "Send by E-Mail"
 msgstr "寄出電子郵件"
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 msgid "Add tasks"
 msgstr "添加任務"
@@ -2957,6 +2965,10 @@ msgstr "立即重新啟動"
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
 msgstr "Planify 備份檔案"
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
+msgstr ""
 
 #: src/Services/Notification.vala:99
 msgid "Snooze for 10 minutes"

--- a/po/zu.po
+++ b/po/zu.po
@@ -1274,7 +1274,7 @@ msgstr ""
 msgid "What is the latest date to complete this?"
 msgstr ""
 
-#: core/Widgets/DeadlineButton.vala:148
+#: core/Widgets/DeadlineButton.vala:148 src/Services/ExportService.vala:73
 msgid "Deadline"
 msgstr ""
 
@@ -2789,6 +2789,14 @@ msgstr ""
 msgid "Send by E-Mail"
 msgstr ""
 
+#: src/Layouts/ProjectRow.vala:714
+msgid "Export as PDF"
+msgstr ""
+
+#: src/Layouts/ProjectRow.vala:791
+msgid "Project exported as PDF"
+msgstr ""
+
 #: src/Layouts/SectionBoard.vala:157 src/Layouts/SectionRow.vala:224
 msgid "Add tasks"
 msgstr ""
@@ -2922,6 +2930,10 @@ msgstr ""
 
 #: src/Services/Backups.vala:565
 msgid "Planify Backup Files"
+msgstr ""
+
+#: src/Services/ExportService.vala:187
+msgid "Deadline:"
 msgstr ""
 
 #: src/Services/Notification.vala:99

--- a/src/Layouts/ProjectRow.vala
+++ b/src/Layouts/ProjectRow.vala
@@ -711,6 +711,7 @@ public class Layouts.ProjectRow : Gtk.ListBoxRow {
 
         var share_markdown_item = new Widgets.ContextMenu.MenuItem (_("Share"), "share-alt-symbolic");
         var share_email_item = new Widgets.ContextMenu.MenuItem (_("Send by E-Mail"), "mail-symbolic");
+        var export_pdf_item = new Widgets.ContextMenu.MenuItem (_("Export as PDF"), "paper-symbolic");
 
         var menu_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 0);
         menu_box.margin_top = menu_box.margin_bottom = 3;
@@ -730,6 +731,7 @@ public class Layouts.ProjectRow : Gtk.ListBoxRow {
 
         menu_box.append (share_markdown_item);
         menu_box.append (share_email_item);
+        menu_box.append (export_pdf_item);
 
         if (!project.is_deck && !project.inbox_project) {
             menu_box.append (new Widgets.ContextMenu.MenuSeparator ());
@@ -774,6 +776,26 @@ public class Layouts.ProjectRow : Gtk.ListBoxRow {
 
         share_email_item.clicked.connect (() => {
             project.share_mail ();
+        });
+
+        export_pdf_item.clicked.connect (() => {
+            var file_dialog = new Gtk.FileDialog () {
+                initial_name = "%s.pdf".printf (project.name)
+            };
+
+            file_dialog.save.begin (Planify._instance.main_window, null, (obj, res) => {
+                try {
+                    var file = file_dialog.save.end (res);
+                    Services.ExportService.get_default ().export_project_pdf (project, file.get_path ());
+                    Services.EventBus.get_default ().send_toast (
+                        Util.get_default ().create_toast (_("Project exported as PDF"))
+                    );
+                } catch (Error e) {
+                    if (!(e is IOError.CANCELLED)) {
+                        warning ("Error exporting PDF: %s", e.message);
+                    }
+                }
+            });
         });
 
         duplicate_item.clicked.connect (() => {

--- a/src/Services/ExportService.vala
+++ b/src/Services/ExportService.vala
@@ -1,0 +1,255 @@
+/*
+ * Copyright © 2023 Alain M. (https://github.com/alainm23/planify)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA
+ *
+ * Authored by: Alain M. <alainmh23@gmail.com>
+ */
+
+public class Services.ExportService : GLib.Object {
+    private const double PAGE_WIDTH = 595.0;  // A4 width in points
+    private const double PAGE_HEIGHT = 842.0; // A4 height in points
+    private const double MARGIN = 50.0;
+
+    private static ExportService ? _instance;
+    public static ExportService get_default () {
+        if (_instance == null) {
+            _instance = new ExportService ();
+        }
+
+        return _instance;
+    }
+
+    public void export_project_pdf (Objects.Project project, string output_path) {
+        var surface = new Cairo.PdfSurface (output_path, PAGE_WIDTH, PAGE_HEIGHT);
+        var cr = new Cairo.Context (surface);
+        double y = MARGIN;
+
+        // Project name
+        cr.select_font_face ("Sans", Cairo.FontSlant.NORMAL, Cairo.FontWeight.BOLD);
+        cr.set_font_size (24);
+        cr.set_source_rgb (0, 0, 0);
+        y += 24;
+        cr.move_to (MARGIN, y);
+        cr.show_text (project.name);
+
+        // Description
+        if (project.description != "") {
+            y += 24;
+            cr.select_font_face ("Sans", Cairo.FontSlant.NORMAL, Cairo.FontWeight.NORMAL);
+            cr.set_font_size (11);
+            cr.set_source_rgb (0.4, 0.4, 0.4);
+
+            foreach (string line in wrap_text (cr, project.description, PAGE_WIDTH - MARGIN * 2)) {
+                cr.move_to (MARGIN, y);
+                cr.show_text (line);
+                y += 16;
+            }
+        }
+
+        // Due date
+        if (project.due_date != "") {
+            y += 6;
+            cr.select_font_face ("Sans", Cairo.FontSlant.NORMAL, Cairo.FontWeight.NORMAL);
+            cr.set_font_size (10);
+            cr.set_source_rgb (0.3, 0.3, 0.3);
+            cr.move_to (MARGIN, y);
+
+            var datetime = Utils.Datetime.get_date_from_string (project.due_date);
+            if (datetime != null) {
+                cr.show_text ("%s: %s".printf (_("Deadline"), Utils.Datetime.get_short_date_format_from_date (datetime)));
+            }
+        }
+
+        // Tasks without section
+        if (project.items.size > 0) {
+            y += 12;
+            y = draw_items (cr, surface, project.items, y, MARGIN);
+        }
+
+        // Sections
+        var sorted_sections = new Gee.ArrayList<Objects.Section> ();
+        sorted_sections.add_all (project.sections);
+        sorted_sections.sort ((a, b) => {
+            return a.section_order - b.section_order;
+        });
+
+        bool is_first_section = true;
+        foreach (Objects.Section section in sorted_sections) {
+            if (y > PAGE_HEIGHT - MARGIN - 30) {
+                surface.show_page ();
+                y = MARGIN;
+            }
+
+            if (is_first_section && project.items.size <= 0) {
+                y += 24;
+            } else {
+                y += 12;
+            }
+
+            is_first_section = false;
+            cr.select_font_face ("Sans", Cairo.FontSlant.NORMAL, Cairo.FontWeight.BOLD);
+            cr.set_font_size (11);
+            cr.set_source_rgb (0, 0, 0);
+            cr.move_to (MARGIN, y);
+            cr.show_text (section.name);
+            y += 24;
+
+            if (section.items.size > 0) {
+                y = draw_items (cr, surface, section.items, y, MARGIN);
+            }
+        }
+
+        surface.show_page ();
+        surface.finish ();
+    }
+
+    private double draw_items (Cairo.Context cr, Cairo.PdfSurface surface, Gee.ArrayList<Objects.Item> items, double start_y, double x) {
+        double y = start_y;
+
+        foreach (Objects.Item item in items) {
+            if (y > PAGE_HEIGHT - MARGIN) {
+                surface.show_page ();
+                y = MARGIN;
+            }
+
+            string checkbox = item.checked ? "- [x]" : "- [ ]";
+
+            cr.select_font_face ("Sans", Cairo.FontSlant.NORMAL, Cairo.FontWeight.NORMAL);
+            cr.set_font_size (11);
+            cr.set_source_rgb (0.3, 0.3, 0.3);
+            cr.move_to (x, y);
+            cr.show_text (checkbox);
+
+            Cairo.TextExtents extents;
+            cr.text_extents (checkbox + " ", out extents);
+            double text_x = x + extents.x_advance;
+
+            // Due date
+            if (item.has_due) {
+                string date_str = "[%s] ".printf (Utils.Datetime.get_relative_date_from_date (item.due.datetime));
+                cr.set_source_rgb (0.4, 0.4, 0.4);
+                cr.set_font_size (9);
+                cr.move_to (text_x, y);
+                cr.show_text (date_str);
+
+                Cairo.TextExtents date_extents;
+                cr.text_extents (date_str, out date_extents);
+                text_x += date_extents.x_advance;
+            }
+
+            // Title
+            cr.set_font_size (11);
+            if (item.checked) {
+                cr.set_source_rgb (0.5, 0.5, 0.5);
+            } else {
+                cr.set_source_rgb (0, 0, 0);
+            }
+
+            cr.move_to (text_x, y);
+            cr.show_text (item.content);
+
+            // Priority
+            if (item.priority != Constants.PRIORITY_4) {
+                string priority_str = " (P%d)".printf (4 - item.priority + 1);
+                Cairo.TextExtents content_extents;
+                cr.text_extents (item.content, out content_extents);
+
+                cr.set_font_size (9);
+                set_priority_color (cr, item.priority);
+                cr.move_to (text_x + content_extents.x_advance, y);
+                cr.show_text (priority_str);
+
+                Cairo.TextExtents priority_extents;
+                cr.text_extents (priority_str, out priority_extents);
+                text_x += content_extents.x_advance + priority_extents.x_advance;
+            } else {
+                Cairo.TextExtents content_extents;
+                cr.text_extents (item.content, out content_extents);
+                text_x += content_extents.x_advance;
+            }
+
+            // Deadline
+            if (item.has_deadline) {
+                string deadline_str = " · %s %s".printf (_("Deadline:"), Utils.Datetime.get_relative_time_from_date (item.deadline_datetime));
+                cr.set_font_size (9);
+                cr.set_source_rgb (0.5, 0.5, 0.5);
+                cr.move_to (text_x, y);
+                cr.show_text (deadline_str);
+            }
+
+            y += 20;
+
+            // Sub-items
+            if (item.items.size > 0) {
+                y = draw_items (cr, surface, item.items, y, x + 20);
+            }
+        }
+
+        return y;
+    }
+
+    private Gee.ArrayList<string> wrap_text (Cairo.Context cr, string text, double max_width) {
+        var lines = new Gee.ArrayList<string> ();
+        string[] paragraphs = text.split ("\n");
+
+        foreach (string paragraph in paragraphs) {
+            if (paragraph.strip () == "") {
+                lines.add ("");
+                continue;
+            }
+
+            string[] words = paragraph.split (" ");
+            string current_line = "";
+
+            foreach (string word in words) {
+                string test_line = current_line == "" ? word : current_line + " " + word;
+                Cairo.TextExtents extents;
+                cr.text_extents (test_line, out extents);
+
+                if (extents.width > max_width && current_line != "") {
+                    lines.add (current_line);
+                    current_line = word;
+                } else {
+                    current_line = test_line;
+                }
+            }
+
+            if (current_line != "") {
+                lines.add (current_line);
+            }
+        }
+
+        return lines;
+    }
+
+    private void set_priority_color (Cairo.Context cr, int priority) {
+        switch (priority) {
+            case Constants.PRIORITY_1: // P1 - red
+                cr.set_source_rgb (1.0, 0.44, 0.40);
+                break;
+            case Constants.PRIORITY_2: // P2 - orange
+                cr.set_source_rgb (1.0, 0.60, 0.08);
+                break;
+            case Constants.PRIORITY_3: // P3 - blue
+                cr.set_source_rgb (0.32, 0.59, 1.0);
+                break;
+            default:
+                cr.set_source_rgb (0.4, 0.4, 0.4);
+                break;
+        }
+    }
+}

--- a/src/meson.build
+++ b/src/meson.build
@@ -40,6 +40,7 @@ sources = files(
   'Services/DBusServer.vala',
   'Services/Backups.vala',
   'Services/MigrateFromPlanner.vala',
+  'Services/ExportService.vala',
 
   'Utils/TaskUtils.vala',
 


### PR DESCRIPTION
Adds the ability to export a project as a PDF file from the project context menu ("Export as PDF").

The generated PDF includes:

- Project name, description, and deadline
- Tasks with status, due date, priority (colored), and deadline
- Sections ordered by position with their tasks
- Sub-tasks with indentation
- Automatic page breaks

Uses Cairo.PdfSurface directly, no extra dependencies needed.

Fixes: #552