### PR TITLE
Fix calendar day alignment and show 3 weeks ahead

### DIFF
--- a/core/Widgets/Calendar/CalendarDay.vala
+++ b/core/Widgets/Calendar/CalendarDay.vala
@@ -20,11 +20,16 @@
  */
 
 public class Widgets.Calendar.CalendarDay : Adw.Bin {
+    private Gtk.Label day_label;
+    private Gtk.Label month_label;
+    private Gtk.Button button;
+    private ulong button_clicked_id = 0;
+
     int _day;
     public int day {
         set {
             _day = value;
-            button.label = _day.to_string ();
+            day_label.label = _day.to_string ();
             update_accessible_label ();
         }
         get {
@@ -43,8 +48,14 @@ public class Widgets.Calendar.CalendarDay : Adw.Bin {
         }
     }
 
-    private Gtk.Button button;
-    private ulong button_clicked_id = 0;
+    public bool show_month {
+        set {
+            month_label.visible = value;
+            if (value && _date != null) {
+                month_label.label = _date.format ("%b");
+            }
+        }
+    }
 
     public signal void day_selected ();
 
@@ -56,7 +67,22 @@ public class Widgets.Calendar.CalendarDay : Adw.Bin {
     }
 
     construct {
+        month_label = new Gtk.Label (null) {
+            css_classes = { "caption", "dimmed" },
+            visible = false
+        };
+
+        day_label = new Gtk.Label (null);
+
+        var box = new Gtk.Box (Gtk.Orientation.VERTICAL, 0) {
+            halign = CENTER,
+            valign = CENTER
+        };
+        box.append (month_label);
+        box.append (day_label);
+
         button = new Gtk.Button () {
+            child = box,
             css_classes = { "flat", "calendar-day" }
         };
 
@@ -66,6 +92,10 @@ public class Widgets.Calendar.CalendarDay : Adw.Bin {
             day_selected ();
             button.add_css_class ("selected");
         });
+    }
+
+    public void add_day_css_class (string css_class) {
+        day_label.add_css_class (css_class);
     }
 
     private void update_accessible_label () {

--- a/core/Widgets/Calendar/CalendarMonth.vala
+++ b/core/Widgets/Calendar/CalendarMonth.vala
@@ -25,6 +25,8 @@ public class Widgets.Calendar.CalendarMonth : Gtk.Box {
     private Gee.ArrayList<Widgets.Calendar.CalendarDay> days_arraylist;
     private Widgets.ContextMenu.MenuItem date_item;
 
+    private const int TOTAL_DAYS = 21; // 3 weeks
+
     private GLib.DateTime _current_date;
     public GLib.DateTime current_date {
         get {
@@ -118,38 +120,35 @@ public class Widgets.Calendar.CalendarMonth : Gtk.Box {
         days_arraylist.clear ();
 
         var today = current_date;
-        int current_day = today.get_day_of_month ();
-        int max_days = Utils.Datetime.get_days_of_month (today.get_month (), today.get_year ());
-        
         int start_week = Services.Settings.get_default ().settings.get_enum ("start-week");
-        int day_of_week = today.get_day_of_week () - start_week;
-        if (day_of_week < 0) {
-            day_of_week += 7;
-        }
-        day_of_week = (day_of_week + 7) % 7;
 
-        int col = day_of_week;
+        // Calculate starting column for today
+        // get_day_of_week(): 1=Monday...7=Sunday
+        // start_week: 0=Sunday, 1=Monday...6=Saturday
+        int today_dow = today.get_day_of_week () % 7; // Sunday=0, Monday=1...Saturday=6
+        int col = (today_dow - start_week + 7) % 7;
         int row = 0;
 
-        for (int day = current_day; day <= max_days; day++) {
-            var calendar_day = new Widgets.Calendar.CalendarDay ();
-            var day_datetime = new DateTime.local (
-                today.get_year (),
-                today.get_month (),
-                day,
-                0, 0, 0
-            );
+        for (int i = 0; i < TOTAL_DAYS; i++) {
+            var day_datetime = today.add_days (i);
 
-            calendar_day.day = day;
+            var calendar_day = new Widgets.Calendar.CalendarDay ();
+            calendar_day.day = day_datetime.get_day_of_month ();
             calendar_day.date = day_datetime;
             calendar_day.tooltip_text = Utils.Datetime.get_relative_date_from_date (day_datetime);
 
-            if (day_datetime.compare (current_date) == 0) {
+            if (i == 0) {
                 calendar_day.child.add_css_class ("today");
             }
 
+            // Show short month name on first day of next month
+            if (day_datetime.get_day_of_month () == 1 && day_datetime.get_month () != today.get_month ()) {
+                calendar_day.show_month = true;
+                calendar_day.add_day_css_class ("caption");
+            }
+
             signals_map[calendar_day.day_selected.connect (() => {
-                day_selected_style (calendar_day.day, day_datetime);
+                day_selected_style (calendar_day);
             })] = calendar_day;
 
             days_grid.attach (calendar_day, col, row, 1, 1);
@@ -163,37 +162,30 @@ public class Widgets.Calendar.CalendarMonth : Gtk.Box {
         }
     }
 
-    private void day_selected_style (int day, GLib.DateTime date) {
-        _date = date;
+    private void day_selected_style (Widgets.Calendar.CalendarDay selected_day) {
+        _date = selected_day.date;
         day_selected ();
 
         foreach (var day_item in days_arraylist) {
             day_item.child.remove_css_class ("selected");
         }
-        
-        foreach (var day_item in days_arraylist) {
-            if (day_item.day == day) {
-                day_item.child.add_css_class ("selected");
-                break;
-            }
-        }
+
+        selected_day.child.add_css_class ("selected");
     }
 
     private void select_date (GLib.DateTime date) {
         var today = current_date;
-        bool is_in_range = false;
-        
-        if (date.get_year () == today.get_year () && date.get_month () == today.get_month ()) {
-            if (date.get_day_of_month () >= today.get_day_of_month ()) {
-                is_in_range = true;
-            }
-        }
+        var max_date = today.add_days (TOTAL_DAYS - 1);
+
+        bool is_in_range = date.compare (today) >= 0 && date.compare (max_date) <= 0;
 
         if (is_in_range) {
             date_item.title = _("Choose a date");
             foreach (var day_item in days_arraylist) {
                 day_item.child.remove_css_class ("selected");
-                if (day_item.day == date.get_day_of_month ()) {
+                if (day_item.date.get_year () == date.get_year () &&
+                    day_item.date.get_month () == date.get_month () &&
+                    day_item.date.get_day_of_month () == date.get_day_of_month ()) {
                     day_item.child.add_css_class ("selected");
                 }
             }

--- a/core/Widgets/Calendar/CalendarScroll.vala
+++ b/core/Widgets/Calendar/CalendarScroll.vala
@@ -180,7 +180,7 @@ public class Widgets.Calendar.CalendarScroll : Adw.Bin {
             month_label = new Gtk.Label (null) {
                 halign = Gtk.Align.START,
                 css_classes = { "font-bold" },
-                margin_start = 6
+                margin_start = 9
             };
 
             calendar_week = new Widgets.Calendar.CalendarWeek () {
@@ -201,6 +201,10 @@ public class Widgets.Calendar.CalendarScroll : Adw.Bin {
             main_box.append (month_label);
             main_box.append (calendar_week);
             main_box.append (days_grid);
+            main_box.append (new Gtk.Separator (Gtk.Orientation.HORIZONTAL) {
+                margin_start = 6,
+                margin_end = 6
+            });
 
             child = main_box;
 
@@ -228,14 +232,13 @@ public class Widgets.Calendar.CalendarScroll : Adw.Bin {
                 0, 0, 0
             );
 
-            int day_of_week = first_day_date.get_day_of_week () - start_week;
-            if (day_of_week < 0) {
-                day_of_week += 7;
-            }
-            day_of_week = (day_of_week + 7) % 7;
-
-            int col = day_of_week;
+            int day_of_week = first_day_date.get_day_of_week () % 7; // Sunday=0, Monday=1...Saturday=6
+            int col = (day_of_week - start_week + 7) % 7;
             int row = 0;
+
+            for (int i = 0; i < col; i++) {
+                days_grid.attach (new Gtk.Label (null), i, 0, 1, 1);
+            }
 
             for (int day = start_day; day <= max_days; day++) {
                 var day_datetime = new DateTime.local (

--- a/po/af.po
+++ b/po/af.po
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "3 hours before"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr ""
 
@@ -1055,9 +1055,9 @@ msgstr ""
 msgid "Next month, %s"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr ""
 

--- a/po/ak.po
+++ b/po/ak.po
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "3 hours before"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr ""
 
@@ -1055,9 +1055,9 @@ msgstr ""
 msgid "Next month, %s"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr ""
 

--- a/po/ar.po
+++ b/po/ar.po
@@ -1050,7 +1050,7 @@ msgstr ""
 msgid "3 hours before"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr ""
 
@@ -1090,9 +1090,9 @@ msgstr ""
 msgid "Next month, %s"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr ""
 

--- a/po/az.po
+++ b/po/az.po
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "3 hours before"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr ""
 
@@ -1055,9 +1055,9 @@ msgstr ""
 msgid "Next month, %s"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr ""
 

--- a/po/be.po
+++ b/po/be.po
@@ -1024,7 +1024,7 @@ msgstr ""
 msgid "3 hours before"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr ""
 
@@ -1064,9 +1064,9 @@ msgstr ""
 msgid "Next month, %s"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr ""
 

--- a/po/bg.po
+++ b/po/bg.po
@@ -1077,7 +1077,7 @@ msgstr "2 часа преди крайния срок"
 msgid "3 hours before"
 msgstr "3 часа преди крайния срок"
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr ""
 
@@ -1117,9 +1117,9 @@ msgstr ""
 msgid "Next month, %s"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr "Избиране на дата"
 

--- a/po/bn.po
+++ b/po/bn.po
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "3 hours before"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr ""
 
@@ -1055,9 +1055,9 @@ msgstr ""
 msgid "Next month, %s"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr ""
 

--- a/po/bs.po
+++ b/po/bs.po
@@ -1024,7 +1024,7 @@ msgstr ""
 msgid "3 hours before"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr ""
 
@@ -1064,9 +1064,9 @@ msgstr ""
 msgid "Next month, %s"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr ""
 

--- a/po/ca.po
+++ b/po/ca.po
@@ -1030,7 +1030,7 @@ msgstr "2 hores abans"
 msgid "3 hours before"
 msgstr "3 hores abans"
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr ""
 
@@ -1070,9 +1070,9 @@ msgstr ""
 msgid "Next month, %s"
 msgstr "Mes següent, %s"
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr "Tria una data"
 

--- a/po/ckb.po
+++ b/po/ckb.po
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "3 hours before"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr ""
 
@@ -1055,9 +1055,9 @@ msgstr ""
 msgid "Next month, %s"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr ""
 

--- a/po/cs.po
+++ b/po/cs.po
@@ -1023,7 +1023,7 @@ msgstr ""
 msgid "3 hours before"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr ""
 
@@ -1063,9 +1063,9 @@ msgstr ""
 msgid "Next month, %s"
 msgstr "Následující měsíc, %s"
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr "Vyberte datum"
 

--- a/po/cv.po
+++ b/po/cv.po
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "3 hours before"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr ""
 
@@ -1055,9 +1055,9 @@ msgstr ""
 msgid "Next month, %s"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr ""
 

--- a/po/da.po
+++ b/po/da.po
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "3 hours before"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr ""
 
@@ -1055,9 +1055,9 @@ msgstr ""
 msgid "Next month, %s"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr ""
 

--- a/po/de.po
+++ b/po/de.po
@@ -1063,7 +1063,7 @@ msgstr "2 Stunden davor"
 msgid "3 hours before"
 msgstr "3 Stunden davor"
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr "%A, %e. %B %Y"
 
@@ -1103,9 +1103,9 @@ msgstr "%B %Y"
 msgid "Next month, %s"
 msgstr "Nächster Monat, %s"
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr "Datum auswählen"
 

--- a/po/dum.po
+++ b/po/dum.po
@@ -1013,7 +1013,7 @@ msgstr ""
 msgid "3 hours before"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr ""
 
@@ -1053,9 +1053,9 @@ msgstr ""
 msgid "Next month, %s"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr ""
 

--- a/po/el.po
+++ b/po/el.po
@@ -1016,7 +1016,7 @@ msgstr ""
 msgid "3 hours before"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr ""
 
@@ -1056,9 +1056,9 @@ msgstr ""
 msgid "Next month, %s"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr ""
 

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -1056,7 +1056,7 @@ msgstr "2 hours before"
 msgid "3 hours before"
 msgstr "3 hours before"
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr ""
 
@@ -1096,9 +1096,9 @@ msgstr ""
 msgid "Next month, %s"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr "Choose a date"
 

--- a/po/eo.po
+++ b/po/eo.po
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "3 hours before"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr ""
 
@@ -1055,9 +1055,9 @@ msgstr ""
 msgid "Next month, %s"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr ""
 

--- a/po/es.po
+++ b/po/es.po
@@ -1057,7 +1057,7 @@ msgstr "2 horas antes"
 msgid "3 hours before"
 msgstr "3 horas antes"
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr "%A, %B %e, %Y"
 
@@ -1097,9 +1097,9 @@ msgstr "%B %Y"
 msgid "Next month, %s"
 msgstr "El próximo mes, %s"
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr "Elija una fecha"
 

--- a/po/et.po
+++ b/po/et.po
@@ -1017,7 +1017,7 @@ msgstr ""
 msgid "3 hours before"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr ""
 
@@ -1057,9 +1057,9 @@ msgstr ""
 msgid "Next month, %s"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr "Vali kuupäev"
 

--- a/po/eu.po
+++ b/po/eu.po
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "3 hours before"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr ""
 
@@ -1055,9 +1055,9 @@ msgstr ""
 msgid "Next month, %s"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr ""
 

--- a/po/fa.po
+++ b/po/fa.po
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "3 hours before"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr ""
 
@@ -1055,9 +1055,9 @@ msgstr ""
 msgid "Next month, %s"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr ""
 

--- a/po/fi.po
+++ b/po/fi.po
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "3 hours before"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr ""
 
@@ -1055,9 +1055,9 @@ msgstr ""
 msgid "Next month, %s"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -1060,7 +1060,7 @@ msgstr "2 heures avant"
 msgid "3 hours before"
 msgstr "3 heures avant"
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr "%A, %B %e, %Y"
 
@@ -1100,9 +1100,9 @@ msgstr "%B %Y"
 msgid "Next month, %s"
 msgstr "Mois prochain, %s"
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr "Choisir une date"
 

--- a/po/ga.po
+++ b/po/ga.po
@@ -1023,7 +1023,7 @@ msgstr ""
 msgid "3 hours before"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr ""
 
@@ -1063,9 +1063,9 @@ msgstr ""
 msgid "Next month, %s"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr ""
 

--- a/po/gl.po
+++ b/po/gl.po
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "3 hours before"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr ""
 
@@ -1055,9 +1055,9 @@ msgstr ""
 msgid "Next month, %s"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr ""
 

--- a/po/he.po
+++ b/po/he.po
@@ -1016,7 +1016,7 @@ msgstr "שעתיים קודם"
 msgid "3 hours before"
 msgstr "3 שעות קודם"
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr ""
 
@@ -1056,9 +1056,9 @@ msgstr ""
 msgid "Next month, %s"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr ""
 

--- a/po/hi.po
+++ b/po/hi.po
@@ -1065,7 +1065,7 @@ msgstr "2 घंटे पहले"
 msgid "3 hours before"
 msgstr "3 घंटे पहले"
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr ""
 
@@ -1105,9 +1105,9 @@ msgstr ""
 msgid "Next month, %s"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr "कोई तारीख चुनें"
 

--- a/po/hr.po
+++ b/po/hr.po
@@ -1054,7 +1054,7 @@ msgstr "2 sata prije"
 msgid "3 hours before"
 msgstr "3 sata prije"
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr "%A, %e. %d. %Y."
 
@@ -1094,9 +1094,9 @@ msgstr "%B %Y."
 msgid "Next month, %s"
 msgstr "Sljedeći mjesec, %s"
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr "Odaberi datum"
 

--- a/po/hu.po
+++ b/po/hu.po
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "3 hours before"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr ""
 
@@ -1055,9 +1055,9 @@ msgstr ""
 msgid "Next month, %s"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr ""
 

--- a/po/hy.po
+++ b/po/hy.po
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "3 hours before"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr ""
 
@@ -1055,9 +1055,9 @@ msgstr ""
 msgid "Next month, %s"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr ""
 

--- a/po/id.po
+++ b/po/id.po
@@ -1038,7 +1038,7 @@ msgstr "2 jam sebelumnya"
 msgid "3 hours before"
 msgstr "3 jam sebelumnya"
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr "%A, %B %e, %Y"
 
@@ -1078,9 +1078,9 @@ msgstr "%B %Y"
 msgid "Next month, %s"
 msgstr "Bulan berikutnya, %s"
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr "Pilih tanggal"
 

--- a/po/io.github.alainm23.planify.pot
+++ b/po/io.github.alainm23.planify.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: io.github.alainm23.planify\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-03-27 11:00+0000\n"
+"POT-Creation-Date: 2026-03-27 11:25+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "3 hours before"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr ""
 
@@ -1059,9 +1059,9 @@ msgstr ""
 msgid "Next month, %s"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr ""
 

--- a/po/is.po
+++ b/po/is.po
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "3 hours before"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr ""
 
@@ -1055,9 +1055,9 @@ msgstr ""
 msgid "Next month, %s"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr ""
 

--- a/po/it.po
+++ b/po/it.po
@@ -1045,7 +1045,7 @@ msgstr "2 ore prima"
 msgid "3 hours before"
 msgstr "3 ore prima"
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr "%A, %B %e, %Y"
 
@@ -1085,9 +1085,9 @@ msgstr "%B %Y"
 msgid "Next month, %s"
 msgstr "Il prossimo mese, %s"
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr "Scegli una data"
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -1007,7 +1007,7 @@ msgstr ""
 msgid "3 hours before"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr ""
 
@@ -1047,9 +1047,9 @@ msgstr ""
 msgid "Next month, %s"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr ""
 

--- a/po/jv.po
+++ b/po/jv.po
@@ -1007,7 +1007,7 @@ msgstr ""
 msgid "3 hours before"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr ""
 
@@ -1047,9 +1047,9 @@ msgstr ""
 msgid "Next month, %s"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr ""
 

--- a/po/ka.po
+++ b/po/ka.po
@@ -1038,7 +1038,7 @@ msgstr "2 საათით ადრე"
 msgid "3 hours before"
 msgstr "3 საათით ადრე"
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr ""
 
@@ -1078,9 +1078,9 @@ msgstr ""
 msgid "Next month, %s"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr "აირჩიეთ თარიღი"
 

--- a/po/kab.po
+++ b/po/kab.po
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "3 hours before"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr ""
 
@@ -1055,9 +1055,9 @@ msgstr ""
 msgid "Next month, %s"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr ""
 

--- a/po/kk.po
+++ b/po/kk.po
@@ -1066,7 +1066,7 @@ msgstr "2 сағат бұрын"
 msgid "3 hours before"
 msgstr "3 сағат бұрын"
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr ""
 
@@ -1106,9 +1106,9 @@ msgstr ""
 msgid "Next month, %s"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr "Күнді таңдау"
 

--- a/po/kn.po
+++ b/po/kn.po
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "3 hours before"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr ""
 
@@ -1055,9 +1055,9 @@ msgstr ""
 msgid "Next month, %s"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr ""
 

--- a/po/ko.po
+++ b/po/ko.po
@@ -1058,7 +1058,7 @@ msgstr ""
 msgid "3 hours before"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr ""
 
@@ -1098,9 +1098,9 @@ msgstr ""
 msgid "Next month, %s"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr "날짜 선택"
 

--- a/po/ku.po
+++ b/po/ku.po
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "3 hours before"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr ""
 
@@ -1055,9 +1055,9 @@ msgstr ""
 msgid "Next month, %s"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr ""
 

--- a/po/kw.po
+++ b/po/kw.po
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "3 hours before"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr ""
 
@@ -1059,9 +1059,9 @@ msgstr ""
 msgid "Next month, %s"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr ""
 

--- a/po/lb.po
+++ b/po/lb.po
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "3 hours before"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr ""
 
@@ -1055,9 +1055,9 @@ msgstr ""
 msgid "Next month, %s"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr ""
 

--- a/po/lg.po
+++ b/po/lg.po
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "3 hours before"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr ""
 
@@ -1055,9 +1055,9 @@ msgstr ""
 msgid "Next month, %s"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr ""
 

--- a/po/lt.po
+++ b/po/lt.po
@@ -1024,7 +1024,7 @@ msgstr ""
 msgid "3 hours before"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr ""
 
@@ -1064,9 +1064,9 @@ msgstr ""
 msgid "Next month, %s"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr ""
 

--- a/po/lv.po
+++ b/po/lv.po
@@ -1051,7 +1051,7 @@ msgstr "2 stundas pirms"
 msgid "3 hours before"
 msgstr "3 stundas pirms"
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr "%A, %B %e, %Y"
 
@@ -1091,9 +1091,9 @@ msgstr "%B %Y"
 msgid "Next month, %s"
 msgstr "Nākamais mēnesis, %s"
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr "Izvēlēties datumu"
 

--- a/po/mg.po
+++ b/po/mg.po
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "3 hours before"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr ""
 
@@ -1055,9 +1055,9 @@ msgstr ""
 msgid "Next month, %s"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr ""
 

--- a/po/mk.po
+++ b/po/mk.po
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "3 hours before"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr ""
 
@@ -1055,9 +1055,9 @@ msgstr ""
 msgid "Next month, %s"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr ""
 

--- a/po/mn.po
+++ b/po/mn.po
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "3 hours before"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr ""
 
@@ -1055,9 +1055,9 @@ msgstr ""
 msgid "Next month, %s"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr ""
 

--- a/po/mr.po
+++ b/po/mr.po
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "3 hours before"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr ""
 
@@ -1055,9 +1055,9 @@ msgstr ""
 msgid "Next month, %s"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr ""
 

--- a/po/ms.po
+++ b/po/ms.po
@@ -1007,7 +1007,7 @@ msgstr ""
 msgid "3 hours before"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr ""
 
@@ -1047,9 +1047,9 @@ msgstr ""
 msgid "Next month, %s"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr ""
 

--- a/po/my.po
+++ b/po/my.po
@@ -1007,7 +1007,7 @@ msgstr ""
 msgid "3 hours before"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr ""
 
@@ -1047,9 +1047,9 @@ msgstr ""
 msgid "Next month, %s"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr ""
 

--- a/po/nb.po
+++ b/po/nb.po
@@ -1049,7 +1049,7 @@ msgstr "2 timer før"
 msgid "3 hours before"
 msgstr "3 timer før"
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr "%A, %B %e, %Y"
 
@@ -1089,9 +1089,9 @@ msgstr "%B %Y"
 msgid "Next month, %s"
 msgstr "Neste måned, %s"
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr "Velg en dato"
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -1064,7 +1064,7 @@ msgstr "2 uren ervoor"
 msgid "3 hours before"
 msgstr "3 uren ervoor"
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 #, fuzzy
 msgid "%A, %B %e, %Y"
 msgstr "%A, %B %e, %Y"
@@ -1106,9 +1106,9 @@ msgstr "%B %Y"
 msgid "Next month, %s"
 msgstr "Volgende maand, %s"
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr "Datum kiezen"
 

--- a/po/nn.po
+++ b/po/nn.po
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "3 hours before"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr ""
 
@@ -1055,9 +1055,9 @@ msgstr ""
 msgid "Next month, %s"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr ""
 

--- a/po/pa.po
+++ b/po/pa.po
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "3 hours before"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr ""
 
@@ -1055,9 +1055,9 @@ msgstr ""
 msgid "Next month, %s"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr ""
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -1028,7 +1028,7 @@ msgstr ""
 msgid "3 hours before"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr ""
 
@@ -1068,9 +1068,9 @@ msgstr ""
 msgid "Next month, %s"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -1064,7 +1064,7 @@ msgstr "2 horas antes"
 msgid "3 hours before"
 msgstr "3 horas antes"
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr ""
 
@@ -1104,9 +1104,9 @@ msgstr ""
 msgid "Next month, %s"
 msgstr "Próximo mês, %s"
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr "Escolha uma data"
 

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -1049,7 +1049,7 @@ msgstr "2 horas antes"
 msgid "3 hours before"
 msgstr "3 horas antes"
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr "%A, %B %e, %Y"
 
@@ -1089,9 +1089,9 @@ msgstr "%B %Y"
 msgid "Next month, %s"
 msgstr "Mês seguinte, %s"
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr "Escolha a data"
 

--- a/po/ro.po
+++ b/po/ro.po
@@ -1024,7 +1024,7 @@ msgstr ""
 msgid "3 hours before"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr ""
 
@@ -1064,9 +1064,9 @@ msgstr ""
 msgid "Next month, %s"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr ""
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -1055,7 +1055,7 @@ msgstr "За 2 часа"
 msgid "3 hours before"
 msgstr "За 3 часа"
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr "%A, %B %e, %Y"
 
@@ -1095,9 +1095,9 @@ msgstr "%B %Y"
 msgid "Next month, %s"
 msgstr "Следующий месяц, %s"
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr "Выбрать дату"
 

--- a/po/sa.po
+++ b/po/sa.po
@@ -1023,7 +1023,7 @@ msgstr ""
 msgid "3 hours before"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr ""
 
@@ -1063,9 +1063,9 @@ msgstr ""
 msgid "Next month, %s"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr ""
 

--- a/po/si.po
+++ b/po/si.po
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "3 hours before"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr ""
 
@@ -1055,9 +1055,9 @@ msgstr ""
 msgid "Next month, %s"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr ""
 

--- a/po/sk.po
+++ b/po/sk.po
@@ -1074,7 +1074,7 @@ msgstr "2 hodiny pred"
 msgid "3 hours before"
 msgstr "3 hodiny pred"
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr ""
 
@@ -1114,9 +1114,9 @@ msgstr ""
 msgid "Next month, %s"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr "Vyberte dátum"
 

--- a/po/sl.po
+++ b/po/sl.po
@@ -1058,7 +1058,7 @@ msgstr "2 uri prej"
 msgid "3 hours before"
 msgstr "3 ure prej"
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr ""
 
@@ -1098,9 +1098,9 @@ msgstr ""
 msgid "Next month, %s"
 msgstr "Nasledni mesec,%s"
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr "Izberite datum"
 

--- a/po/sma.po
+++ b/po/sma.po
@@ -1023,7 +1023,7 @@ msgstr ""
 msgid "3 hours before"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr ""
 
@@ -1063,9 +1063,9 @@ msgstr ""
 msgid "Next month, %s"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr ""
 

--- a/po/sq.po
+++ b/po/sq.po
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "3 hours before"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr ""
 
@@ -1055,9 +1055,9 @@ msgstr ""
 msgid "Next month, %s"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr ""
 

--- a/po/sr.po
+++ b/po/sr.po
@@ -1024,7 +1024,7 @@ msgstr ""
 msgid "3 hours before"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr ""
 
@@ -1064,9 +1064,9 @@ msgstr ""
 msgid "Next month, %s"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr ""
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -1041,7 +1041,7 @@ msgstr ""
 msgid "3 hours before"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr ""
 
@@ -1081,9 +1081,9 @@ msgstr ""
 msgid "Next month, %s"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr ""
 

--- a/po/szl.po
+++ b/po/szl.po
@@ -1024,7 +1024,7 @@ msgstr ""
 msgid "3 hours before"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr ""
 
@@ -1064,9 +1064,9 @@ msgstr ""
 msgid "Next month, %s"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr ""
 

--- a/po/ta.po
+++ b/po/ta.po
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "3 hours before"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr ""
 
@@ -1055,9 +1055,9 @@ msgstr ""
 msgid "Next month, %s"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr ""
 

--- a/po/te.po
+++ b/po/te.po
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "3 hours before"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr ""
 
@@ -1055,9 +1055,9 @@ msgstr ""
 msgid "Next month, %s"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr ""
 

--- a/po/th.po
+++ b/po/th.po
@@ -1007,7 +1007,7 @@ msgstr ""
 msgid "3 hours before"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr ""
 
@@ -1047,9 +1047,9 @@ msgstr ""
 msgid "Next month, %s"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr ""
 

--- a/po/tl.po
+++ b/po/tl.po
@@ -1016,7 +1016,7 @@ msgstr ""
 msgid "3 hours before"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr ""
 
@@ -1056,9 +1056,9 @@ msgstr ""
 msgid "Next month, %s"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr ""
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -1054,7 +1054,7 @@ msgstr "2 saat önce"
 msgid "3 hours before"
 msgstr "3 saat önce"
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr ""
 
@@ -1094,9 +1094,9 @@ msgstr ""
 msgid "Next month, %s"
 msgstr "Sonraki ay, %s"
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr "Tarih seçiniz"
 

--- a/po/ug.po
+++ b/po/ug.po
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "3 hours before"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr ""
 
@@ -1055,9 +1055,9 @@ msgstr ""
 msgid "Next month, %s"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr ""
 

--- a/po/uk.po
+++ b/po/uk.po
@@ -1056,7 +1056,7 @@ msgstr "За 2 години до"
 msgid "3 hours before"
 msgstr "За 3 години до"
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr "%A, %B %e, %Y"
 
@@ -1096,9 +1096,9 @@ msgstr "%B %Y"
 msgid "Next month, %s"
 msgstr "Наступного місяця, %s"
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr "Виберіть дату"
 

--- a/po/ur.po
+++ b/po/ur.po
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "3 hours before"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr ""
 
@@ -1055,9 +1055,9 @@ msgstr ""
 msgid "Next month, %s"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr ""
 

--- a/po/uz.po
+++ b/po/uz.po
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "3 hours before"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr ""
 
@@ -1055,9 +1055,9 @@ msgstr ""
 msgid "Next month, %s"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr ""
 

--- a/po/vi.po
+++ b/po/vi.po
@@ -1032,7 +1032,7 @@ msgstr "2 giờ trước"
 msgid "3 hours before"
 msgstr "3 giờ trước"
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr "%A, %B %e, %Y"
 
@@ -1072,9 +1072,9 @@ msgstr "%B %Y"
 msgid "Next month, %s"
 msgstr "Tháng tới. %s"
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr "Chọn ngày"
 

--- a/po/zh.po
+++ b/po/zh.po
@@ -1010,7 +1010,7 @@ msgstr ""
 msgid "3 hours before"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr ""
 
@@ -1050,9 +1050,9 @@ msgstr ""
 msgid "Next month, %s"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr ""
 

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -1022,7 +1022,7 @@ msgstr "2 小時之前"
 msgid "3 hours before"
 msgstr "3 小時之前"
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr "%A, %B %e, %Y"
 
@@ -1062,9 +1062,9 @@ msgstr "%B %Y"
 msgid "Next month, %s"
 msgstr "下個月份， %s"
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr "選擇日期"
 

--- a/po/zu.po
+++ b/po/zu.po
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "3 hours before"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarDay.vala:73
+#: core/Widgets/Calendar/CalendarDay.vala:103
 msgid "%A, %B %e, %Y"
 msgstr ""
 
@@ -1055,9 +1055,9 @@ msgstr ""
 msgid "Next month, %s"
 msgstr ""
 
-#: core/Widgets/Calendar/CalendarMonth.vala:80
-#: core/Widgets/Calendar/CalendarMonth.vala:193
-#: core/Widgets/Calendar/CalendarMonth.vala:209
+#: core/Widgets/Calendar/CalendarMonth.vala:82
+#: core/Widgets/Calendar/CalendarMonth.vala:183
+#: core/Widgets/Calendar/CalendarMonth.vala:201
 msgid "Choose a date"
 msgstr ""
 


### PR DESCRIPTION
Fixes day-of-week alignment in CalendarMonth and CalendarScroll where days were misaligned with the week header due to incorrect Sunday handling in the column calculation.

Also improves CalendarMonth to show 3 weeks from today instead of only the remaining days of the current month. Days from the next month are shown dimmed, with a short month label on the 1st day for clarity.

Fixes: #2326 #2329

<img width="324" height="495" alt="image" src="https://github.com/user-attachments/assets/b69ef637-e4a0-4e19-8e50-29e9dedd8860" />
