### PR TITLE
Add GNOME Shell search provider

### DIFF
--- a/build-aux/io.github.alainm23.planify.Devel.json
+++ b/build-aux/io.github.alainm23.planify.Devel.json
@@ -23,12 +23,10 @@
     ],
     "cleanup" : [
         "/include",
+        "/lib/girepository-1.0",
         "/lib/pkgconfig",
-        "/man",
-        "/share/doc",
-        "/share/gtk-doc",
-        "/share/man",
-        "/share/pkgconfig",
+        "/share/gir-1.0",
+        "/share/vala",
         "*.la",
         "*.a"
     ],

--- a/data/io.github.alainm23.planify.metainfo.xml.in.in
+++ b/data/io.github.alainm23.planify.metainfo.xml.in.in
@@ -50,6 +50,7 @@
   <kudos>
     <kudo>ModernToolkit</kudo>
     <kudo>HiDpiIcon</kudo>
+    <kudo>SearchProvider</kudo>
   </kudos>
   <developer_name translate="no">Alain</developer_name>
   <update_contact>alainmh23@gmail.com</update_contact>

--- a/meson.build
+++ b/meson.build
@@ -129,7 +129,7 @@ subdir('core')
 subdir('src')
 subdir('quick-add')
 subdir('data')
-# subdir('search-provider')
+subdir('search-provider')
 subdir('po')
 
 # Testing

--- a/search-provider/main.vala
+++ b/search-provider/main.vala
@@ -1,3 +1,24 @@
+/*
+ * Copyright © 2026 Alain M. (https://github.com/alainm23/planify)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA
+ *
+ * Authored by: Alain M. <alainmh23@gmail.com>
+ */
+
 int main (string[] args) {
     Intl.bindtextdomain (Build.GETTEXT_PACKAGE, Build.GNOMELOCALEDIR);
     Intl.bind_textdomain_codeset (Build.GETTEXT_PACKAGE, "UTF-8");

--- a/search-provider/main.vala
+++ b/search-provider/main.vala
@@ -1,11 +1,8 @@
-// This file is part of Highscore. License: GPL-3.0-or-later
-
 int main (string[] args) {
     Intl.bindtextdomain (Build.GETTEXT_PACKAGE, Build.GNOMELOCALEDIR);
     Intl.bind_textdomain_codeset (Build.GETTEXT_PACKAGE, "UTF-8");
     Intl.textdomain (Build.GETTEXT_PACKAGE);
 
     var app = new Planify.SearchProvider ();
-
     return app.run (args);
 }

--- a/search-provider/meson.build
+++ b/search-provider/meson.build
@@ -1,25 +1,19 @@
-search_provider_c_args = [
-  '-DGETTEXT_PACKAGE="' + meson.project_name () + '"',
-  '-DG_LOG_DOMAIN="PlanifySearchProvider"',
-]
-
 search_provider_sources = [
   'main.vala',
-  'search-provider.vala'
+  'search-provider.vala',
+  'search-repository.vala'
 ]
 
 search_provider_deps = [
   gio_dep,
-  gtk_dep,
   sqlite3_dep,
 ]
 
 executable (
-  'io.github.alainmh23.planify-search-provider',
+  application_id + '-search-provider',
   search_provider_sources,
   config_file,
   dependencies: search_provider_deps,
-  c_args: search_provider_c_args,
   install: true,
   install_dir: libexecdir
 )

--- a/search-provider/search-provider.vala
+++ b/search-provider/search-provider.vala
@@ -1,3 +1,24 @@
+/*
+ * Copyright © 2026 Alain M. (https://github.com/alainm23/planify)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA
+ *
+ * Authored by: Alain M. <alainmh23@gmail.com>
+ */
+ 
 [DBus (name = "org.gnome.Shell.SearchProvider2")]
 public class Planify.SearchProvider : GLib.Application {
 

--- a/search-provider/search-provider.vala
+++ b/search-provider/search-provider.vala
@@ -1,7 +1,8 @@
-// This file is part of Highscore. License: GPL-3.0+.
-
 [DBus (name = "org.gnome.Shell.SearchProvider2")]
-public class Planify.SearchProvider : Gtk.Application {
+public class Planify.SearchProvider : GLib.Application {
+
+    private SearchRepository repository;
+
     internal SearchProvider () {
         Object (
             application_id: Build.APPLICATION_ID + ".SearchProvider",
@@ -11,10 +12,12 @@ public class Planify.SearchProvider : Gtk.Application {
     }
 
     construct {
-
+        repository = new SearchRepository ();
     }
 
-    protected override bool dbus_register (DBusConnection connection, string object_path) {
+    protected override bool dbus_register (DBusConnection connection, string object_path) throws Error {
+        base.dbus_register (connection, object_path);
+
         try {
             connection.register_object (object_path, this);
         } catch (IOError e) {
@@ -23,5 +26,58 @@ public class Planify.SearchProvider : Gtk.Application {
         }
 
         return true;
+    }
+
+    public string[] get_initial_result_set (string[] terms) throws Error {
+        return repository.search (string.joinv (" ", terms));
+    }
+
+    public string[] get_subsearch_result_set (string[] previous_results, string[] terms) throws Error {
+        return repository.search (string.joinv (" ", terms));
+    }
+
+    public HashTable<string, Variant>[] get_result_metas (string[] identifiers) throws Error {
+        var results = new GenericArray<HashTable<string, Variant>> ();
+
+        foreach (var id in identifiers) {
+            var meta_data = repository.get_meta (id);
+            if (meta_data == null) {
+                continue;
+            }
+
+            var meta = new HashTable<string, Variant> (str_hash, str_equal);
+            meta.insert ("id", new Variant.string (id));
+            meta.insert ("name", new Variant.string (meta_data.name));
+            meta.insert ("description", new Variant.string (meta_data.description));
+            results.add (meta);
+        }
+
+        return results.data;
+    }
+
+    public void activate_result (string identifier, string[] terms, uint32 timestamp) throws Error {
+        if (identifier.has_prefix ("project-")) {
+            launch_planify ("planify://project/" + identifier.substring (8));
+        } else if (identifier.has_prefix ("item-")) {
+            launch_planify ("planify://item/" + identifier.substring (5));
+        } else {
+            launch_planify ("planify://");
+        }
+    }
+
+    public void launch_search (string[] terms, uint32 timestamp) throws Error {
+        launch_planify ("planify://");
+    }
+
+    private void launch_planify (string uri = "planify://") {
+        try {
+            AppInfo.launch_default_for_uri (uri, null);
+        } catch (Error e) {
+            try {
+                Process.spawn_command_line_async ("flatpak run " + Build.APPLICATION_ID);
+            } catch (SpawnError se) {
+                warning ("Could not launch Planify: %s", se.message);
+            }
+        }
     }
 }

--- a/search-provider/search-repository.vala
+++ b/search-provider/search-repository.vala
@@ -1,5 +1,25 @@
-public class Planify.SearchRepository : Object {
+/*
+ * Copyright © 2026 Alain M. (https://github.com/alainm23/planify)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA
+ *
+ * Authored by: Alain M. <alainmh23@gmail.com>
+ */
 
+public class Planify.SearchRepository : Object {
     private Sqlite.Database db;
     private bool db_open = false;
 

--- a/search-provider/search-repository.vala
+++ b/search-provider/search-repository.vala
@@ -1,0 +1,139 @@
+public class Planify.SearchRepository : Object {
+
+    private Sqlite.Database db;
+    private bool db_open = false;
+
+    public struct ResultMeta {
+        public string name;
+        public string description;
+    }
+
+    construct {
+        var db_path = Path.build_filename (
+            Environment.get_user_data_dir (),
+            "io.github.alainm23.planify", "database.db"
+        );
+
+        if (FileUtils.test (db_path, FileTest.EXISTS)) {
+            if (Sqlite.Database.open_v2 (db_path, out db, Sqlite.OPEN_READONLY) == Sqlite.OK) {
+                db_open = true;
+            }
+        }
+
+        if (!db_open) {
+            warning ("Could not open database: %s", db_path);
+        }
+    }
+
+    public string[] search (string query) {
+        if (!db_open) {
+            return {};
+        }
+
+        var results = new GenericArray<string> ();
+        string term = "%" + query.down () + "%";
+
+        search_projects (term, results);
+        search_items (term, results);
+
+        return results.data;
+    }
+
+    public ResultMeta? get_meta (string identifier) {
+        if (!db_open) {
+            return null;
+        }
+
+        if (identifier.has_prefix ("project-")) {
+            return get_project_meta (identifier.substring (8));
+        } else if (identifier.has_prefix ("item-")) {
+            return get_item_meta (identifier.substring (5));
+        }
+
+        return null;
+    }
+
+    private void search_projects (string term, GenericArray<string> results) {
+        Sqlite.Statement stmt;
+
+        var sql = """
+            SELECT id FROM Projects
+            WHERE is_deleted = 0 AND is_archived = 0
+            AND LOWER(name) LIKE $term
+            LIMIT 5;
+        """;
+
+        if (db.prepare_v2 (sql, sql.length, out stmt) == Sqlite.OK) {
+            stmt.bind_text (stmt.bind_parameter_index ("$term"), term);
+            while (stmt.step () == Sqlite.ROW) {
+                results.add ("project-" + stmt.column_text (0));
+            }
+        }
+    }
+
+    private void search_items (string term, GenericArray<string> results) {
+        Sqlite.Statement stmt;
+
+        var sql = """
+            SELECT i.id FROM Items i
+            LEFT JOIN Projects p ON i.project_id = p.id
+            WHERE i.is_deleted = 0 AND i.checked = 0
+            AND (p.is_archived = 0 OR p.is_archived IS NULL)
+            AND (LOWER(i.content) LIKE $term OR LOWER(i.description) LIKE $term)
+            LIMIT 5;
+        """;
+
+        if (db.prepare_v2 (sql, sql.length, out stmt) == Sqlite.OK) {
+            stmt.bind_text (stmt.bind_parameter_index ("$term"), term);
+            while (stmt.step () == Sqlite.ROW) {
+                results.add ("item-" + stmt.column_text (0));
+            }
+        }
+    }
+
+    private ResultMeta? get_project_meta (string project_id) {
+        Sqlite.Statement stmt;
+
+        var sql = """
+            SELECT p.name,
+                (SELECT COUNT(*) FROM Items i
+                 WHERE i.project_id = p.id AND i.checked = 0 AND i.is_deleted = 0)
+            FROM Projects p WHERE p.id = $id;
+        """;
+
+        if (db.prepare_v2 (sql, sql.length, out stmt) == Sqlite.OK) {
+            stmt.bind_text (stmt.bind_parameter_index ("$id"), project_id);
+            if (stmt.step () == Sqlite.ROW) {
+                int count = stmt.column_int (1);
+                return ResultMeta () {
+                    name = stmt.column_text (0),
+                    description = "%d %s".printf (count, count == 1 ? "task" : "tasks")
+                };
+            }
+        }
+
+        return null;
+    }
+
+    private ResultMeta? get_item_meta (string item_id) {
+        Sqlite.Statement stmt;
+
+        var sql = """
+            SELECT i.content, p.name FROM Items i
+            LEFT JOIN Projects p ON i.project_id = p.id
+            WHERE i.id = $id;
+        """;
+
+        if (db.prepare_v2 (sql, sql.length, out stmt) == Sqlite.OK) {
+            stmt.bind_text (stmt.bind_parameter_index ("$id"), item_id);
+            if (stmt.step () == Sqlite.ROW) {
+                return ResultMeta () {
+                    name = stmt.column_text (0),
+                    description = stmt.column_text (1) ?? ""
+                };
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/App.vala
+++ b/src/App.vala
@@ -86,10 +86,23 @@ public class Planify : Adw.Application {
 
     private void handle_uri (string uri) {
         var parts = uri.replace ("planify://", "").split ("?", 2);
-        string path = parts[0].replace ("/", "");
+        string path = parts[0];
 
-        if (path == "auth") {
+        if (path.has_prefix ("auth")) {
             Services.EventBus.get_default ().oauth_callback (uri);
+        } else if (path.has_prefix ("project/")) {
+            string project_id = path.substring (8);
+            Services.EventBus.get_default ().pane_selected (PaneType.PROJECT, project_id);
+        } else if (path.has_prefix ("item/")) {
+            string item_id = path.substring (5);
+            var item = Services.Store.instance ().get_item (item_id);
+            if (item != null) {
+                Services.EventBus.get_default ().pane_selected (PaneType.PROJECT, item.project_id);
+                Timeout.add (275, () => {
+                    Services.EventBus.get_default ().open_item (item);
+                    return GLib.Source.REMOVE;
+                });
+            }
         }
     }
 

--- a/src/Dialogs/Preferences/Pages/General.vala
+++ b/src/Dialogs/Preferences/Pages/General.vala
@@ -99,6 +99,12 @@ public class Dialogs.Preferences.Pages.General : Dialogs.Preferences.Pages.BaseP
 
         de_group.add (calendar_events_row);
 
+        var search_provider_row = new Adw.ActionRow ();
+        search_provider_row.title = _("GNOME Shell Search");
+        search_provider_row.subtitle = _("Search tasks and projects directly from GNOME Shell. Enable it in Settings → Search");
+
+        de_group.add (search_provider_row);
+
         var datetime_group = new Adw.PreferencesGroup ();
         datetime_group.title = _("Date and Time");
 


### PR DESCRIPTION
Integrate Planify with GNOME Shell search. Users can search for tasks and projects by pressing Super without opening the app.

- Implements `org.gnome.Shell.SearchProvider2` DBus interface
- Searches tasks (by content/description) and projects (by name)
- Shows project name for tasks and task count for projects
- Clicking a result opens Planify and navigates to the project/item
- Reads database directly in read-only mode (lightweight, no GTK dependency)
- Supports both Flatpak and local installations

Fixes: #1128

<img width="1919" height="796" alt="image" src="https://github.com/user-attachments/assets/a09548af-62be-4de0-a182-f9b6d1629637" />
