### PR TITLE
Add logging service for CalDAV debugging

### DIFF
--- a/core/Services/CalDAV/CalDAVClient.vala
+++ b/core/Services/CalDAV/CalDAVClient.vala
@@ -28,6 +28,7 @@ public class Services.CalDAV.CalDAVClient : Services.CalDAV.WebDAVClient {
 
 
     public async string? get_principal_url (GLib.Cancellable cancellable) throws GLib.Error {
+        Services.LogService.get_default ().info ("CalDAV", "Fetching principal URL");
         var xml = """<?xml version="1.0" encoding="utf-8"?>
                         <propfind xmlns="DAV:">
                             <prop>
@@ -54,6 +55,7 @@ public class Services.CalDAV.CalDAVClient : Services.CalDAV.WebDAVClient {
     }
 
     public async string? get_calendar_home (string principal_url, GLib.Cancellable cancellable) throws GLib.Error {
+        Services.LogService.get_default ().info ("CalDAV", "Fetching calendar home");
         var xml = """<?xml version="1.0" encoding="utf-8"?>
                         <propfind xmlns="DAV:" xmlns:cal="urn:ietf:params:xml:ns:caldav">
                             <prop>
@@ -81,6 +83,7 @@ public class Services.CalDAV.CalDAVClient : Services.CalDAV.WebDAVClient {
 
 
     public async void update_userdata (string principal_url, Objects.Source source, GLib.Cancellable cancellable) throws GLib.Error {
+        Services.LogService.get_default ().info ("CalDAV", "Updating user data");
         var xml = """<?xml version="1.0" encoding="utf-8"?>
                     <d:propfind xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns">
                         <d:prop>
@@ -122,6 +125,7 @@ public class Services.CalDAV.CalDAVClient : Services.CalDAV.WebDAVClient {
     }
 
     public async Gee.ArrayList<Objects.Project> fetch_project_list (Objects.Source source, GLib.Cancellable cancellable) throws GLib.Error {
+        Services.LogService.get_default ().info ("CalDAV", "Fetching project list");
         var xml = """<?xml version='1.0' encoding='utf-8'?>
                     <d:propfind xmlns:d="DAV:" xmlns:ical="http://apple.com/ns/ical/" xmlns:cal="urn:ietf:params:xml:ns:caldav">
                         <d:prop>
@@ -162,6 +166,7 @@ public class Services.CalDAV.CalDAVClient : Services.CalDAV.WebDAVClient {
 
 
     public async void sync (Objects.Source source, GLib.Cancellable cancellable) throws GLib.Error {
+        Services.LogService.get_default ().info ("CalDAV", "Syncing project list");
         var xml = """<?xml version='1.0' encoding='utf-8'?>
                     <d:propfind xmlns:d="DAV:" xmlns:ical="http://apple.com/ns/ical/" xmlns:cal="urn:ietf:params:xml:ns:caldav" xmlns:nc="http://nextcloud.com/ns">
                         <d:prop>
@@ -205,6 +210,7 @@ public class Services.CalDAV.CalDAVClient : Services.CalDAV.WebDAVClient {
                 var supported_calendar = propstat.get_first_prop_with_tagname ("supported-calendar-component-set");
 
                 if (is_deleted_calendar (resourcetype)) {
+                    Services.LogService.get_default ().info ("CalDAV", "Removing deleted calendar from server");
                     Objects.Project ? project = Services.Store.instance ().get_project_via_url (get_absolute_url (href));
                     if (project != null) {
                         Services.Store.instance ().delete_project (project);
@@ -220,6 +226,7 @@ public class Services.CalDAV.CalDAVClient : Services.CalDAV.WebDAVClient {
                         Objects.Project ? project = Services.Store.instance ().get_project_via_url (get_absolute_url (href));
 
                         if (project == null) {
+                            Services.LogService.get_default ().info ("CalDAV", "Discovered new project, fetching items");
                             project = new Objects.Project.from_propstat (propstat, get_absolute_url (href));
                             project.source_id = source.id;
 
@@ -236,6 +243,7 @@ public class Services.CalDAV.CalDAVClient : Services.CalDAV.WebDAVClient {
     }
 
     public async void fetch_project_details (Objects.Project project, GLib.Cancellable cancellable) throws GLib.Error {
+        Services.LogService.get_default ().debug ("CalDAV", "Fetching project details");
         var xml = """<?xml version='1.0' encoding='utf-8'?>
                     <d:propfind xmlns:d="DAV:" xmlns:ical="http://apple.com/ns/ical/" xmlns:cal="urn:ietf:params:xml:ns:caldav">
                         <d:prop>
@@ -272,6 +280,7 @@ public class Services.CalDAV.CalDAVClient : Services.CalDAV.WebDAVClient {
     public delegate void ProgressCallback (int current, int total, string message);
 
     public async void fetch_items_for_project (Objects.Project project, GLib.Cancellable cancellable, owned ProgressCallback? progress_callback = null) throws GLib.Error {
+        Services.LogService.get_default ().info ("CalDAV", "Fetching items for project");
         SourceFunc callback = fetch_items_for_project.callback;
 
         var xml = """<?xml version="1.0" encoding="utf-8"?>
@@ -361,6 +370,8 @@ public class Services.CalDAV.CalDAVClient : Services.CalDAV.WebDAVClient {
         if (project.is_deck) {
             return;
         }
+
+        Services.LogService.get_default ().info ("CalDAV", "Syncing tasklist");
 
         var xml = """
         <d:sync-collection xmlns:d="DAV:">
@@ -460,7 +471,7 @@ public class Services.CalDAV.CalDAVClient : Services.CalDAV.WebDAVClient {
                                 vtodo_comp = vcalendar.get_next_component (ICal.ComponentKind.VTODO_COMPONENT);
                             }
                         } catch (Error e) {
-                            warning ("Error parsing VTODO from %s: %s", href, e.message);
+                            Services.LogService.get_default ().error ("CalDAV.Sync", "Error parsing VTODO from %s: %s".printf (href, e.message));
                         }
                     }
                 }
@@ -487,6 +498,7 @@ public class Services.CalDAV.CalDAVClient : Services.CalDAV.WebDAVClient {
     }
 
     public async void update_sync_token (Objects.Project project, GLib.Cancellable cancellable) throws GLib.Error {
+        Services.LogService.get_default ().debug ("CalDAV", "Updating sync token");
         var xml = """<?xml version="1.0" encoding="utf-8"?>
         <d:propfind xmlns:d="DAV:">
             <d:prop>
@@ -511,6 +523,7 @@ public class Services.CalDAV.CalDAVClient : Services.CalDAV.WebDAVClient {
     }
 
     public async HttpResponse create_project (Objects.Project project) {
+        Services.LogService.get_default ().info ("CalDAV", "Creating project");
         var xml = """<?xml version="1.0" encoding="utf-8"?>
             <d:mkcol xmlns:d="DAV:" xmlns:ical="http://apple.com/ns/ical/" xmlns:oc="http://owncloud.org/ns" xmlns:cal="urn:ietf:params:xml:ns:caldav">
             <d:set>
@@ -543,6 +556,7 @@ public class Services.CalDAV.CalDAVClient : Services.CalDAV.WebDAVClient {
             project.calendar_url = calendar_url;
             response.status = true;
         } catch (Error e) {
+            Services.LogService.get_default ().error ("CalDAV", "Failed to create project: %s".printf (e.message));
             response.error_code = e.code;
             response.error = e.message;
         }
@@ -551,6 +565,7 @@ public class Services.CalDAV.CalDAVClient : Services.CalDAV.WebDAVClient {
     }
 
     public async HttpResponse update_project (Objects.Project project) {
+        Services.LogService.get_default ().info ("CalDAV", "Updating project");
         var xml = """<?xml version="1.0" encoding="utf-8"?>
         <d:propertyupdate xmlns:d="DAV:" xmlns:ical="http://apple.com/ns/ical/">
             <d:set>
@@ -570,6 +585,7 @@ public class Services.CalDAV.CalDAVClient : Services.CalDAV.WebDAVClient {
 
             response.status = true;
         } catch (Error e) {
+            Services.LogService.get_default ().error ("CalDAV", "Failed to update project: %s".printf (e.message));
             response.error_code = e.code;
             response.error = e.message;
         }
@@ -578,6 +594,7 @@ public class Services.CalDAV.CalDAVClient : Services.CalDAV.WebDAVClient {
     }
 
     public async HttpResponse delete_project (Objects.Project project) {
+        Services.LogService.get_default ().info ("CalDAV", "Deleting project");
         HttpResponse response = new HttpResponse ();
 
         try {
@@ -586,6 +603,7 @@ public class Services.CalDAV.CalDAVClient : Services.CalDAV.WebDAVClient {
             // Radicale sends a Multi-Status with 200 OK -> TODO: Validate Response in Multi Status?
             response.status = true;
         } catch (Error e) {
+            Services.LogService.get_default ().error ("CalDAV", "Failed to delete project: %s".printf (e.message));
             response.error_code = e.code;
             response.error = e.message;
         }
@@ -594,6 +612,7 @@ public class Services.CalDAV.CalDAVClient : Services.CalDAV.WebDAVClient {
     }
 
     public async HttpResponse add_item (Objects.Item item, bool update = false) {
+        Services.LogService.get_default ().info ("CalDAV", update ? "Updating item" : "Adding item");
         var url = update ? item.ical_url : GLib.Path.build_path ("/", item.project.calendar_url, "%s.ics".printf (item.id));
         var body = item.to_vtodo ();
 
@@ -607,6 +626,7 @@ public class Services.CalDAV.CalDAVClient : Services.CalDAV.WebDAVClient {
             item.extra_data = Util.generate_extra_data (url, "", body);
             response.status = true;
         } catch (Error e) {
+            Services.LogService.get_default ().error ("CalDAV", "Failed to %s item: %s".printf (update ? "update" : "add", e.message));
             response.error_code = e.code;
             response.error = e.message;
         }
@@ -615,6 +635,7 @@ public class Services.CalDAV.CalDAVClient : Services.CalDAV.WebDAVClient {
     }
 
     public async HttpResponse complete_item (Objects.Item item) {
+        Services.LogService.get_default ().info ("CalDAV", "Completing item");
         var body = item.to_vtodo ();
 
         HttpResponse response = new HttpResponse ();
@@ -625,6 +646,7 @@ public class Services.CalDAV.CalDAVClient : Services.CalDAV.WebDAVClient {
 
             response.status = true;
         } catch (Error e) {
+            Services.LogService.get_default ().error ("CalDAV", "Failed to complete item: %s".printf (e.message));
             response.error_code = e.code;
             response.error = e.message;
         }
@@ -634,6 +656,7 @@ public class Services.CalDAV.CalDAVClient : Services.CalDAV.WebDAVClient {
 
 
     public async HttpResponse move_item (Objects.Item item, Objects.Project destination_project) {
+        Services.LogService.get_default ().info ("CalDAV", "Moving item to another project");
         var destination = GLib.Path.build_path ("/", destination_project.calendar_url, "%s.ics".printf (item.id));
 
         var headers = new HashTable<string,string> (str_hash, str_equal);
@@ -648,6 +671,7 @@ public class Services.CalDAV.CalDAVClient : Services.CalDAV.WebDAVClient {
 
             response.status = true;
         } catch (Error e) {
+            Services.LogService.get_default ().error ("CalDAV", "Failed to move item: %s".printf (e.message));
             response.error_code = e.code;
             response.error = e.message;
         }
@@ -657,6 +681,7 @@ public class Services.CalDAV.CalDAVClient : Services.CalDAV.WebDAVClient {
 
 
     public async HttpResponse delete_item (Objects.Item item) {
+        Services.LogService.get_default ().info ("CalDAV", "Deleting item");
         HttpResponse response = new HttpResponse ();
 
         try {
@@ -664,6 +689,7 @@ public class Services.CalDAV.CalDAVClient : Services.CalDAV.WebDAVClient {
 
             response.status = true;
         } catch (Error e) {
+            Services.LogService.get_default ().error ("CalDAV", "Failed to delete item: %s".printf (e.message));
             response.error_code = e.code;
             response.error = e.message;
         }

--- a/core/Services/CalDAV/Core.vala
+++ b/core/Services/CalDAV/Core.vala
@@ -41,6 +41,7 @@ public class Services.CalDAV.Core : GLib.Object {
 
     public Services.CalDAV.CalDAVClient get_client (Objects.Source source) {
         if (!clients.has_key (source.id)) {
+            Services.LogService.get_default ().info ("CalDAV.Core", "Creating new client for source");
             var client = new Services.CalDAV.CalDAVClient (
                 new Soup.Session (),
                 source.caldav_data.server_url,
@@ -61,6 +62,7 @@ public class Services.CalDAV.Core : GLib.Object {
     }
 
     public void remove_client (string source_id) {
+        Services.LogService.get_default ().info ("CalDAV.Core", "Removing client");
         clients.unset (source_id);
     }
 
@@ -74,12 +76,13 @@ public class Services.CalDAV.Core : GLib.Object {
         try {
             abs_url = GLib.Uri.resolve_relative (base_url, href, GLib.UriFlags.NONE).to_string ();
         } catch (Error e) {
-            critical ("Failed to resolve relative url: %s", e.message);
+            Services.LogService.get_default ().error ("CalDAV.Core", "Failed to resolve relative url: %s".printf (e.message));
         }
         return abs_url;
     }
 
     public async string resolve_well_known_caldav (Soup.Session session, string base_url, bool ignore_ssl = false) throws GLib.Error {
+        Services.LogService.get_default ().info ("CalDAV.Core", "Resolving .well-known/caldav");
         var well_known_url = make_absolute_url (base_url, "/.well-known/caldav");
         var msg = new Soup.Message ("GET", well_known_url);
         msg.request_headers.append ("User-Agent", Constants.SOUP_USER_AGENT);
@@ -111,10 +114,10 @@ public class Services.CalDAV.Core : GLib.Object {
 
                     if (base_scheme == "https" && location_scheme == "http") {
                         if (location.has_prefix ("http://")) {
-                            warning ("Resolving .well-known/caldav caused a redirect from https to http. Preventing downgrade.");
+                            Services.LogService.get_default ().warn ("CalDAV.Core", "Resolving .well-known/caldav caused a redirect from https to http. Preventing downgrade.");
                             location = "https" + location.substring (4); // removes http and puts https infront
                         } else {
-                            warning ("Redirect location has http scheme but unexpected format: %s", location);
+                            Services.LogService.get_default ().warn ("CalDAV.Core", "Redirect location has http scheme but unexpected format: %s".printf (location));
                             return base_url;
                         }
                     }
@@ -127,13 +130,14 @@ public class Services.CalDAV.Core : GLib.Object {
             if (e is GLib.IOError.CANCELLED) {
                 throw e;
             }
-            warning ("Failed to check .well-known/caldav: %s", e.message);
+            Services.LogService.get_default ().warn ("CalDAV.Core", "Failed to check .well-known/caldav: %s".printf (e.message));
             return base_url;
         }
     }
 
 
     public async string? resolve_calendar_home (CalDAVType caldav_type, string dav_url, string username, string password, GLib.Cancellable cancellable, bool ignore_ssl = false) throws GLib.Error {
+        Services.LogService.get_default ().info ("CalDAV.Core", "Resolving calendar home");
         var caldav_client = new Services.CalDAV.CalDAVClient (new Soup.Session (), dav_url, username, password, ignore_ssl);
 
         try {
@@ -150,14 +154,17 @@ public class Services.CalDAV.Core : GLib.Object {
             if (e is GLib.IOError.CANCELLED) {
                 throw e;
             }
+            Services.LogService.get_default ().error ("CalDAV.Core", "Failed to resolve calendar home: %s".printf (e.message));
             throw new GLib.IOError.FAILED ("Failed to resolve calendar home: %s".printf (e.message));
         }
     }
 
     public async HttpResponse login (CalDAVType caldav_type, string dav_url, string username, string password, string calendar_home, GLib.Cancellable cancellable, bool ignore_ssl = false) {
+        Services.LogService.get_default ().info ("CalDAV.Core", "Starting login");
         HttpResponse response = new HttpResponse ();
 
         if (Services.Store.instance ().source_caldav_exists (dav_url, username)) {
+            Services.LogService.get_default ().warn ("CalDAV.Core", "Source already exists, aborting login");
             response.error_code = 409;
             response.error = _("Source already exists");
             return response;
@@ -196,8 +203,9 @@ public class Services.CalDAV.Core : GLib.Object {
             response.status = true;
 
             clients[source.id] = caldav_client;
+            Services.LogService.get_default ().info ("CalDAV.Core", "Login successful");
         } catch (Error e) {
-            print ("login error: %s".printf (e.message));
+            Services.LogService.get_default ().error ("CalDAV.Core", "Login error: %s".printf (e.message));
             response.error_code = e.code;
             response.error = e.message;
         }
@@ -207,6 +215,7 @@ public class Services.CalDAV.Core : GLib.Object {
 
     // TODO: why is this a seperate method, can this be merged with login?
     public async HttpResponse add_caldav_account (Objects.Source source, GLib.Cancellable cancellable) {
+        Services.LogService.get_default ().info ("CalDAV.Core", "Adding CalDAV account");
         HttpResponse response = new HttpResponse ();
         var caldav_client = get_client (source);
 
@@ -249,11 +258,12 @@ public class Services.CalDAV.Core : GLib.Object {
             }
 
             sync_progress (projects.size, projects.size, _("Sync completed"));
+            Services.LogService.get_default ().info ("CalDAV.Core", "Account added successfully, %d projects synced".printf (projects.size));
             response.status = true;
         } catch (Error e) {
             response.error_code = e.code;
             response.error = e.message;
-            debug (e.message);
+            Services.LogService.get_default ().error ("CalDAV.Core", "Add account error: %s".printf (e.message));
         }
 
         return response;
@@ -261,6 +271,7 @@ public class Services.CalDAV.Core : GLib.Object {
 
 
     public async void sync (Objects.Source source) {
+        Services.LogService.get_default ().info ("CalDAV.Core", "Starting sync");
         var caldav_client = get_client (source);
 
         source.sync_started ();
@@ -275,8 +286,9 @@ public class Services.CalDAV.Core : GLib.Object {
 
             source.sync_finished ();
             source.last_sync = new GLib.DateTime.now_local ().to_string ();
+            Services.LogService.get_default ().info ("CalDAV.Core", "Sync completed successfully");
         } catch (Error e) {
-            warning ("Failed to sync: %s", e.message);
+            Services.LogService.get_default ().error ("CalDAV.Core", "Failed to sync source '%s': %s".printf (source.display_name, e.message));
             source.sync_failed ();
         }
     }

--- a/core/Services/CalDAV/Providers/Nextcloud.vala
+++ b/core/Services/CalDAV/Providers/Nextcloud.vala
@@ -30,6 +30,7 @@ public class Services.CalDAV.Providers.Nextcloud : Object {
     }
 
     private string validate_server_url (string url) {
+        Services.LogService.get_default ().info ("Nextcloud", "Validating server URL");
         string server_url = "";
 
         try {
@@ -47,13 +48,14 @@ public class Services.CalDAV.Providers.Nextcloud : Object {
 
             server_url += path;
         } catch (Error e) {
-            debug (e.message);
+            Services.LogService.get_default ().error ("Nextcloud", "Failed to validate server URL: %s".printf (e.message));
         }
 
         return server_url;
     }
 
     public async HttpResponse start_login_flow (string server_url, GLib.Cancellable cancellable, bool ignore_ssl = false) {
+        Services.LogService.get_default ().info ("Nextcloud", "Starting login flow");
         HttpResponse response = new HttpResponse ();
 
         string login_url = "%s/index.php/login/v2".printf (validate_server_url (server_url));
@@ -82,6 +84,8 @@ public class Services.CalDAV.Providers.Nextcloud : Object {
 
             AppInfo.launch_default_for_uri (login_link, null);
 
+            Services.LogService.get_default ().info ("Nextcloud", "Login page opened in browser, waiting for authentication");
+
             int timeout = 20 * 60;
             int interval = 5;
 
@@ -105,14 +109,17 @@ public class Services.CalDAV.Providers.Nextcloud : Object {
                         var poll_object = poll_root.get_object ();
 
                         if (poll_object.has_member ("loginName")) {
+                            Services.LogService.get_default ().info ("Nextcloud", "Authentication successful, resolving CalDAV endpoint");
 
                             var server = poll_object.get_string_member ("server");
                             var login_name = poll_object.get_string_member ("loginName");
                             var app_password = poll_object.get_string_member ("appPassword");
 
                             var dav_endpoint = yield Core.get_default ().resolve_well_known_caldav (session, server);
+                            Services.LogService.get_default ().info ("Nextcloud", "Resolved well-known CalDAV endpoint");
 
                             var calendar_home = yield Core.get_default ().resolve_calendar_home (CalDAVType.NEXTCLOUD, dav_endpoint, login_name, app_password, cancellable, ignore_ssl);
+                            Services.LogService.get_default ().info ("Nextcloud", "Resolved calendar home");
                             
                             var login_response = yield Core.get_default ().login (CalDAVType.NEXTCLOUD, dav_endpoint, login_name, app_password, calendar_home, cancellable, ignore_ssl);
 
@@ -120,6 +127,7 @@ public class Services.CalDAV.Providers.Nextcloud : Object {
                         }
                     }
                 } catch (Error err) {
+                    Services.LogService.get_default ().error ("Nextcloud", "Polling error: %s".printf (err.message));
                     response.error_code = err.code;
                     response.error = "Polling error: %s".printf (err.message);
                     break;
@@ -130,6 +138,7 @@ public class Services.CalDAV.Providers.Nextcloud : Object {
                 timeout -= interval;
             }
         } catch (Error e) {
+            Services.LogService.get_default ().error ("Nextcloud", "Login flow error: %s".printf (e.message));
             response.error_code = e.code;
             response.error = "login error: %s".printf (e.message);
         }

--- a/core/Services/CalDAV/WebDAVClient.vala
+++ b/core/Services/CalDAV/WebDAVClient.vala
@@ -38,6 +38,7 @@ public class Services.CalDAV.WebDAVClient : GLib.Object {
     }
 
     public void cleanup () {
+        Services.LogService.get_default ().info ("WebDAV", "Cleaning up session");
         if (session != null) {
             session.abort ();
         }
@@ -48,16 +49,18 @@ public class Services.CalDAV.WebDAVClient : GLib.Object {
         try {
             abs_url = GLib.Uri.resolve_relative (base_url, href, GLib.UriFlags.NONE).to_string ();
         } catch (Error e) {
-            critical ("Failed to resolve relative url: %s", e.message);
+            Services.LogService.get_default ().error ("WebDAV", "Failed to resolve relative url: %s".printf (e.message));
         }
         return abs_url;
     }
 
     public async WebDAVMultiStatus propfind (string url, string xml, string depth, GLib.Cancellable cancellable) throws GLib.Error {
+        Services.LogService.get_default ().debug ("WebDAV", "PROPFIND request (depth: %s)".printf (depth));
         return new WebDAVMultiStatus.from_string (yield send_request ("PROPFIND", url, "application/xml", xml, depth, cancellable, { Soup.Status.MULTI_STATUS }));
     }
 
     public async WebDAVMultiStatus report (string url, string xml, string depth, GLib.Cancellable cancellable) throws GLib.Error {
+        Services.LogService.get_default ().debug ("WebDAV", "REPORT request (depth: %s)".printf (depth));
         return new WebDAVMultiStatus.from_string (yield send_request ("REPORT", url, "application/xml", xml, depth, cancellable, { Soup.Status.MULTI_STATUS }));
     }
 
@@ -66,12 +69,14 @@ public class Services.CalDAV.WebDAVClient : GLib.Object {
         if (abs_url == null)
             throw new GLib.IOError.FAILED ("Invalid URL: %s".printf (url));
 
+        Services.LogService.get_default ().debug ("WebDAV", "%s %s".printf (method, abs_url));
+
         var msg = new Soup.Message (method, abs_url);
         msg.request_headers.append ("User-Agent", Constants.SOUP_USER_AGENT);
 
         msg.authenticate.connect ((auth, retrying) => {
             if (retrying) {
-                warning ("Authentication failed\n");
+                Services.LogService.get_default ().error ("WebDAV", "Authentication failed, not retrying");
                 return false;
             }
 
@@ -79,7 +84,7 @@ public class Services.CalDAV.WebDAVClient : GLib.Object {
                 auth.authenticate (this.username, this.password);
                 return true;
             }
-            warning ("Unsupported auth schema: %s", auth.scheme_name);
+            Services.LogService.get_default ().warn ("WebDAV", "Unsupported auth schema: %s".printf (auth.scheme_name));
             return false;
         });
 
@@ -115,6 +120,7 @@ public class Services.CalDAV.WebDAVClient : GLib.Object {
             response = yield session.send_and_read_async (msg, Priority.DEFAULT, cancellable);
         } catch (Error e) {
             if (e is GLib.IOError.CANCELLED) {
+                Services.LogService.get_default ().info ("WebDAV", "Request cancelled");
                 throw e;
             }
             throw new GLib.IOError.FAILED ("Request failed: %s".printf (e.message));
@@ -130,6 +136,7 @@ public class Services.CalDAV.WebDAVClient : GLib.Object {
 
         if (!ok) {
             var response_text = (string) response.get_data ();
+            Services.LogService.get_default ().error ("WebDAV", "%s %s failed: HTTP %u %s".printf (method, abs_url, msg.status_code, msg.reason_phrase ?? ""));
             throw new GLib.IOError.FAILED (
                 "%s %s failed: HTTP %u %s\n%s".printf (
                     method, abs_url, msg.status_code, msg.reason_phrase ?? "", response_text ?? "")
@@ -155,9 +162,7 @@ public class Services.CalDAV.WebDAVMultiStatus : Object {
     }
 
     public void debug_print () {
-        print ("-------------------------------\n");
-        debug ("%s\b", xml_content);
-        print ("-------------------------------\n");
+        Services.LogService.get_default ().debug ("WebDAV", "Response XML: %s".printf (xml_content));
     }
 
     public Gee.ArrayList<WebDAVResponse> responses () {

--- a/core/Services/LogService.vala
+++ b/core/Services/LogService.vala
@@ -1,0 +1,108 @@
+public class Services.LogService : Object {
+    public enum Level {
+        DEBUG,
+        INFO,
+        WARNING,
+        ERROR;
+
+        public string to_string () {
+            switch (this) {
+                case DEBUG: return "DEBUG";
+                case INFO: return "INFO";
+                case WARNING: return "WARNING";
+                case ERROR: return "ERROR";
+                default: return "UNKNOWN";
+            }
+        }
+    }
+
+    private static LogService? _instance;
+    public static LogService get_default () {
+        if (_instance == null) {
+            _instance = new LogService ();
+        }
+        return _instance;
+    }
+
+    private string log_path;
+    private FileOutputStream? stream = null;
+    private const int MAX_LOG_SIZE = 5 * 1024 * 1024; // 5MB
+
+    construct {
+        var dir = Path.build_filename (Environment.get_user_data_dir (), "io.github.alainm23.planify");
+        log_path = Path.build_filename (dir, "planify.log");
+
+        try {
+            var dir_file = File.new_for_path (dir);
+            if (!dir_file.query_exists ()) {
+                dir_file.make_directory_with_parents ();
+            }
+
+            rotate_if_needed ();
+
+            var file = File.new_for_path (log_path);
+            stream = file.append_to (FileCreateFlags.NONE);
+        } catch (Error e) {
+            warning ("Could not initialize log file: %s", e.message);
+        }
+    }
+
+    public void log (Level level, string context, string message) {
+        var timestamp = new DateTime.now_local ().format ("%Y-%m-%d %H:%M:%S");
+        var line = "[%s] [%s] [%s] %s\n".printf (timestamp, level.to_string (), context, message);
+
+        // Always print to stdout
+        print ("%s", line);
+
+        // Write to file
+        if (stream != null) {
+            try {
+                stream.write (line.data);
+                stream.flush ();
+            } catch (Error e) {
+                warning ("Could not write to log: %s", e.message);
+            }
+        }
+    }
+
+    public void debug (string context, string message) {
+        log (Level.DEBUG, context, message);
+    }
+
+    public void info (string context, string message) {
+        log (Level.INFO, context, message);
+    }
+
+    public void warn (string context, string message) {
+        log (Level.WARNING, context, message);
+    }
+
+    public void error (string context, string message) {
+        log (Level.ERROR, context, message);
+    }
+
+    private void rotate_if_needed () {
+        try {
+            var file = File.new_for_path (log_path);
+            if (!file.query_exists ()) {
+                return;
+            }
+
+            var info = file.query_info (FileAttribute.STANDARD_SIZE, FileQueryInfoFlags.NONE);
+            if (info.get_size () > MAX_LOG_SIZE) {
+                var old_path = log_path + ".old";
+                var old_file = File.new_for_path (old_path);
+                if (old_file.query_exists ()) {
+                    old_file.delete ();
+                }
+                file.move (old_file, FileCopyFlags.OVERWRITE);
+            }
+        } catch (Error e) {
+            warning ("Could not rotate log: %s", e.message);
+        }
+    }
+
+    public string get_log_path () {
+        return log_path;
+    }
+}

--- a/core/meson.build
+++ b/core/meson.build
@@ -10,6 +10,7 @@ core_files = files(
     'Services/Settings.vala',
     'Services/EventBus.vala',
     'Services/Database.vala',
+    'Services/LogService.vala',
     'Services/Store.vala',
     'Services/Todoist.vala',
     'Services/ColorSchemeSettings.vala',

--- a/src/App.vala
+++ b/src/App.vala
@@ -35,6 +35,7 @@ public class Planify : Adw.Application {
     private static bool run_in_background = false;
     private static bool n_version = false;
     private static bool clear_database = false;
+    private static bool show_log_path = false;
     private static string lang = "";
 
     
@@ -45,6 +46,7 @@ public class Planify : Adw.Application {
     private const OptionEntry[] OPTIONS = {
         { "version", 'v', 0, OptionArg.NONE, ref n_version, "Display version number", null },
         { "reset", 'r', 0, OptionArg.NONE, ref clear_database, "Reset Planify", null },
+        { "log-path", 0, 0, OptionArg.NONE, ref show_log_path, "Print the log file path", null },
         { "background", 'b', 0, OptionArg.NONE, out run_in_background, "Run the Application in background", null },
         { "lang", 'l', 0, OptionArg.STRING, ref lang, "Open Planify in a specific language", "LANG" },
         { null }
@@ -113,6 +115,11 @@ public class Planify : Adw.Application {
 
         if (n_version) {
             debug ("%s\n".printf (Build.VERSION));
+            return;
+        }
+
+        if (show_log_path) {
+            stdout.printf ("%s\n", Services.LogService.get_default ().get_log_path ());
             return;
         }
 


### PR DESCRIPTION
Add `LogService` that writes to a log file with timestamps, levels, and context. Integrated across all CalDAV files (Core, CalDAVClient, WebDAVClient, Nextcloud) to track sync actions and errors without exposing user data. Added `--log-path` CLI option so users can easily share their log file when reporting issues.