### PR TITLE
Skip archived projects during CalDAV sync

### DIFF
--- a/build-aux/io.github.alainm23.planify.Devel.json
+++ b/build-aux/io.github.alainm23.planify.Devel.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "io.github.alainm23.planify.Devel",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "49",
+    "runtime-version" : "50",
     "sdk" : "org.gnome.Sdk",
     "command" : "io.github.alainm23.planify.Devel",
     "tags" : [

--- a/core/Services/CalDAV/CalDAVClient.vala
+++ b/core/Services/CalDAV/CalDAVClient.vala
@@ -367,7 +367,8 @@ public class Services.CalDAV.CalDAVClient : Services.CalDAV.WebDAVClient {
     }
 
     public async void sync_tasklist (Objects.Project project, GLib.Cancellable cancellable) throws GLib.Error {
-        if (project.is_deck) {
+        if (project.is_deck || project.is_archived) {
+            Services.LogService.get_default ().debug ("CalDAV", "Skipping sync for %s project".printf (project.is_archived ? "archived" : "deck"));
             return;
         }
 


### PR DESCRIPTION
Archived projects are now skipped in `sync_tasklist`, improving sync performance for users with many archived projects. Previously all projects were synced regardless of archive status, causing the sync spinner to appear stuck with no visible activity.

Fixes: #2347