### PR TITLE
Add copy to clipboard for multi-select tasks

### DIFF
--- a/core/Objects/Item.vala
+++ b/core/Objects/Item.vala
@@ -1386,9 +1386,44 @@ public class Objects.Item : Objects.BaseObject {
         _items.add (item);
     }
 
+    public string to_clipboard_text () {
+        var text = new StringBuilder ();
+
+        text.append ("[%s] %s".printf (checked ? "x" : " ", content));
+
+        if (priority != Constants.PRIORITY_4) {
+            text.append (" (P%d)".printf (5 - priority));
+        }
+
+        if (has_due) {
+            text.append (" · %s".printf (Utils.Datetime.get_relative_date_from_date (due.datetime)));
+        }
+
+        if (has_deadline) {
+            text.append (" · %s %s".printf (_("Deadline:"), Utils.Datetime.get_relative_time_from_date (deadline_datetime)));
+        }
+
+        if (labels.size > 0) {
+            var label_names = new StringBuilder ();
+            foreach (Objects.Label label in labels) {
+                if (label_names.len > 0) {
+                    label_names.append (", ");
+                }
+                label_names.append (label.name);
+            }
+            text.append (" @%s".printf (label_names.str));
+        }
+
+        if (description != null && description.strip () != "") {
+            text.append ("\n    %s".printf (description.strip ()));
+        }
+
+        return text.str;
+    }
+
     public void copy_clipboard () {
         Gdk.Clipboard clipboard = Gdk.Display.get_default ().get_clipboard ();
-        clipboard.set_text ("[%s]%s%s\n------------------------------------------\n%s".printf (checked ? "x" : " ", get_format_date (this), content, description));
+        clipboard.set_text (to_clipboard_text ());
         Services.EventBus.get_default ().send_toast (
             Util.get_default ().create_toast (_("Task copied to clipboard"))
         );
@@ -1416,14 +1451,6 @@ public class Objects.Item : Objects.BaseObject {
         new_item.labels = labels;
         new_item.item_type = item_type;
         return new_item;
-    }
-
-    private string get_format_date (Objects.Item item) {
-        if (!item.has_due) {
-            return " ";
-        }
-
-        return " (" + Utils.Datetime.get_relative_date_from_date (item.due.datetime) + ") ";
     }
 
     public void delete_item () {

--- a/src/Widgets/MultiSelectToolbar.vala
+++ b/src/Widgets/MultiSelectToolbar.vala
@@ -241,12 +241,15 @@ public class Widgets.MultiSelectToolbar : Adw.Bin {
     private Gtk.Popover build_menu_popover () {
         complete_item = new Widgets.ContextMenu.MenuItem (_ ("Mark as Completed"), "check-round-outline-symbolic");
 
+        var copy_item = new Widgets.ContextMenu.MenuItem (_ ("Copy to Clipboard"), "edit-copy-symbolic");
+
         delete_item = new Widgets.ContextMenu.MenuItem (_ ("Delete"), "user-trash-symbolic");
         delete_item.add_css_class ("menu-item-danger");
 
         var menu_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 0);
         menu_box.margin_top = menu_box.margin_bottom = 3;
         menu_box.append (complete_item);
+        menu_box.append (copy_item);
         menu_box.append (new Widgets.ContextMenu.MenuSeparator ());
         menu_box.append (delete_item);
 
@@ -262,6 +265,30 @@ public class Widgets.MultiSelectToolbar : Adw.Bin {
             }
 
             unselect_all ();
+        });
+
+        copy_item.clicked.connect (() => {
+            var text = new StringBuilder ();
+            foreach (string key in items_selected.keys) {
+                var item = items_selected[key].item;
+                text.append (item.to_clipboard_text ());
+                text.append ("\n\n");
+            }
+
+            Gdk.Clipboard clipboard = Gdk.Display.get_default ().get_clipboard ();
+            clipboard.set_text (text.str);
+
+            Services.EventBus.get_default ().send_toast (
+                Util.get_default ().create_toast (
+                    GLib.ngettext (
+                        "%d task copied to clipboard",
+                        "%d tasks copied to clipboard",
+                        items_selected.size
+                    ).printf (items_selected.size)
+                )
+            );
+
+            popover.popdown ();
         });
 
         delete_item.clicked.connect (() => {


### PR DESCRIPTION
Add "Copy to Clipboard" option in the multi-select toolbar menu. Copies all selected tasks with full details (priority, due date, deadline, labels, description). Created shared `to_clipboard_text()` method in Item to avoid duplicating logic between single and multi-select copy.

Fixes: #2287