### PR TITLE
Fix day change not detected after system suspend/resume

### DIFF
--- a/build-aux/io.github.alainm23.planify.Devel.json
+++ b/build-aux/io.github.alainm23.planify.Devel.json
@@ -15,7 +15,6 @@
         "--socket=wayland",
         "--talk-name=org.gnome.evolution.dataserver.Calendar8",
         "--talk-name=org.gnome.evolution.dataserver.Sources5",
-        "--system-talk-name=org.freedesktop.login1",
         "--talk-name=org.gnome.ScreenSaver",
         "--talk-name=io.github.alainm23.planify",
         "--talk-name=io.github.alainm23.planify.quick-add",

--- a/build-aux/io.github.alainm23.planify.Devel.json
+++ b/build-aux/io.github.alainm23.planify.Devel.json
@@ -15,6 +15,8 @@
         "--socket=wayland",
         "--talk-name=org.gnome.evolution.dataserver.Calendar8",
         "--talk-name=org.gnome.evolution.dataserver.Sources5",
+        "--system-talk-name=org.freedesktop.login1",
+        "--talk-name=org.gnome.ScreenSaver",
         "--talk-name=io.github.alainm23.planify",
         "--talk-name=io.github.alainm23.planify.quick-add",
         "--own-name=io.github.alainm23.planify.quick-add",

--- a/src/Services/TimeMonitor.vala
+++ b/src/Services/TimeMonitor.vala
@@ -46,9 +46,10 @@ public class Services.TimeMonitor : Object {
     }
 
     private void listen_for_system_resume () {
+        // Try logind via system bus (works on local installs)
         try {
-            var connection = GLib.Bus.get_sync (GLib.BusType.SYSTEM);
-            connection.signal_subscribe (
+            var system_bus = GLib.Bus.get_sync (GLib.BusType.SYSTEM);
+            system_bus.signal_subscribe (
                 "org.freedesktop.login1",
                 "org.freedesktop.login1.Manager",
                 "PrepareForSleep",
@@ -62,14 +63,34 @@ public class Services.TimeMonitor : Object {
                     if (going_to_sleep) {
                         Services.LogService.get_default ().info ("TimeMonitor", "System going to sleep");
                     } else {
-                        Services.LogService.get_default ().info ("TimeMonitor", "System resumed from sleep, checking day change");
+                        Services.LogService.get_default ().info ("TimeMonitor", "System resumed from sleep (logind), checking day change");
                         check_day_change ();
                     }
                 }
             );
             Services.LogService.get_default ().info ("TimeMonitor", "Subscribed to logind PrepareForSleep signal");
         } catch (Error e) {
-            Services.LogService.get_default ().warn ("TimeMonitor", "Could not subscribe to logind PrepareForSleep: %s".printf (e.message));
+            Services.LogService.get_default ().warn ("TimeMonitor", "Could not subscribe to logind: %s".printf (e.message));
+        }
+
+        // Also listen to ScreenSaver WakeUpScreen via session bus (works in Flatpak)
+        try {
+            var session_bus = GLib.Bus.get_sync (GLib.BusType.SESSION);
+            session_bus.signal_subscribe (
+                "org.gnome.ScreenSaver",
+                "org.gnome.ScreenSaver",
+                "WakeUpScreen",
+                "/org/gnome/ScreenSaver",
+                null,
+                GLib.DBusSignalFlags.NONE,
+                (conn, sender, path, iface, signal_name, parameters) => {
+                    Services.LogService.get_default ().info ("TimeMonitor", "Screen woke up (ScreenSaver), checking day change");
+                    check_day_change ();
+                }
+            );
+            Services.LogService.get_default ().info ("TimeMonitor", "Subscribed to ScreenSaver WakeUpScreen signal");
+        } catch (Error e) {
+            Services.LogService.get_default ().warn ("TimeMonitor", "Could not subscribe to ScreenSaver: %s".printf (e.message));
         }
     }
 

--- a/src/Services/TimeMonitor.vala
+++ b/src/Services/TimeMonitor.vala
@@ -46,51 +46,55 @@ public class Services.TimeMonitor : Object {
     }
 
     private void listen_for_system_resume () {
-        // Try logind via system bus (works on local installs)
-        try {
-            var system_bus = GLib.Bus.get_sync (GLib.BusType.SYSTEM);
-            system_bus.signal_subscribe (
-                "org.freedesktop.login1",
-                "org.freedesktop.login1.Manager",
-                "PrepareForSleep",
-                "/org/freedesktop/login1",
-                null,
-                GLib.DBusSignalFlags.NONE,
-                (conn, sender, path, iface, signal_name, parameters) => {
-                    bool going_to_sleep;
-                    parameters.get ("(b)", out going_to_sleep);
+        // logind via system bus — only works outside Flatpak
+        if (!Util.get_default ().is_flatpak ()) {
+            try {
+                var system_bus = GLib.Bus.get_sync (GLib.BusType.SYSTEM);
+                system_bus.signal_subscribe (
+                    "org.freedesktop.login1",
+                    "org.freedesktop.login1.Manager",
+                    "PrepareForSleep",
+                    "/org/freedesktop/login1",
+                    null,
+                    GLib.DBusSignalFlags.NONE,
+                    (conn, sender, path, iface, signal_name, parameters) => {
+                        bool going_to_sleep;
+                        parameters.get ("(b)", out going_to_sleep);
 
-                    if (going_to_sleep) {
-                        Services.LogService.get_default ().info ("TimeMonitor", "System going to sleep");
-                    } else {
-                        Services.LogService.get_default ().info ("TimeMonitor", "System resumed from sleep (logind), checking day change");
-                        check_day_change ();
+                        if (going_to_sleep) {
+                            Services.LogService.get_default ().info ("TimeMonitor", "System going to sleep");
+                        } else {
+                            Services.LogService.get_default ().info ("TimeMonitor", "System resumed from sleep (logind), checking day change");
+                            check_day_change ();
+                        }
                     }
-                }
-            );
-            Services.LogService.get_default ().info ("TimeMonitor", "Subscribed to logind PrepareForSleep signal");
-        } catch (Error e) {
-            Services.LogService.get_default ().warn ("TimeMonitor", "Could not subscribe to logind: %s".printf (e.message));
+                );
+                Services.LogService.get_default ().info ("TimeMonitor", "Subscribed to logind PrepareForSleep signal");
+            } catch (Error e) {
+                Services.LogService.get_default ().warn ("TimeMonitor", "Could not subscribe to logind: %s".printf (e.message));
+            }
         }
 
-        // Also listen to ScreenSaver WakeUpScreen via session bus (works in Flatpak)
-        try {
-            var session_bus = GLib.Bus.get_sync (GLib.BusType.SESSION);
-            session_bus.signal_subscribe (
-                "org.gnome.ScreenSaver",
-                "org.gnome.ScreenSaver",
-                "WakeUpScreen",
-                "/org/gnome/ScreenSaver",
-                null,
-                GLib.DBusSignalFlags.NONE,
-                (conn, sender, path, iface, signal_name, parameters) => {
-                    Services.LogService.get_default ().info ("TimeMonitor", "Screen woke up (ScreenSaver), checking day change");
-                    check_day_change ();
-                }
-            );
-            Services.LogService.get_default ().info ("TimeMonitor", "Subscribed to ScreenSaver WakeUpScreen signal");
-        } catch (Error e) {
-            Services.LogService.get_default ().warn ("TimeMonitor", "Could not subscribe to ScreenSaver: %s".printf (e.message));
+        // ScreenSaver WakeUpScreen via session bus — only needed in Flatpak
+        if (Util.get_default ().is_flatpak ()) {
+            try {
+                var session_bus = GLib.Bus.get_sync (GLib.BusType.SESSION);
+                session_bus.signal_subscribe (
+                    "org.gnome.ScreenSaver",
+                    "org.gnome.ScreenSaver",
+                    "WakeUpScreen",
+                    "/org/gnome/ScreenSaver",
+                    null,
+                    GLib.DBusSignalFlags.NONE,
+                    (conn, sender, path, iface, signal_name, parameters) => {
+                        Services.LogService.get_default ().info ("TimeMonitor", "Screen woke up (ScreenSaver), checking day change");
+                        check_day_change ();
+                    }
+                );
+                Services.LogService.get_default ().info ("TimeMonitor", "Subscribed to ScreenSaver WakeUpScreen signal");
+            } catch (Error e) {
+                Services.LogService.get_default ().warn ("TimeMonitor", "Could not subscribe to ScreenSaver: %s".printf (e.message));
+            }
         }
     }
 

--- a/src/Services/TimeMonitor.vala
+++ b/src/Services/TimeMonitor.vala
@@ -20,37 +20,72 @@
  */
 
 public class Services.TimeMonitor : Object {
-	private static TimeMonitor? _instance;
-	public static TimeMonitor get_default () {
-		if (_instance == null) {
-			_instance = new TimeMonitor ();
-		}
+    private static TimeMonitor? _instance;
+    public static TimeMonitor get_default () {
+        if (_instance == null) {
+            _instance = new TimeMonitor ();
+        }
 
-		return _instance;
-	}
+        return _instance;
+    }
 
-	private DateTime last_registered_date;
+    private DateTime last_registered_date;
 
-	public void init_timeout () {
-		last_registered_date = new DateTime.now_local ();
+    public void init_timeout () {
+        last_registered_date = new DateTime.now_local ();
+        Services.LogService.get_default ().info ("TimeMonitor", "Initialized, tracking date: %s".printf (last_registered_date.format ("%Y-%m-%d")));
 
-		Timeout.add_seconds (300, () => {
-			check_day_change ();
-			return true;
-		});
-	}
+        // Periodic check every 5 minutes as fallback
+        Timeout.add_seconds (300, () => {
+            check_day_change ();
+            return true;
+        });
 
-	private void check_day_change () {
-		DateTime now = new DateTime.now_local ();
+        // Listen for system resume from suspend via logind
+        listen_for_system_resume ();
+    }
 
-		if (now.get_day_of_month () != last_registered_date.get_day_of_month () ||
-		    now.get_month () != last_registered_date.get_month () ||
-		    now.get_year () != last_registered_date.get_year ()) {
+    private void listen_for_system_resume () {
+        try {
+            var connection = GLib.Bus.get_sync (GLib.BusType.SYSTEM);
+            connection.signal_subscribe (
+                "org.freedesktop.login1",
+                "org.freedesktop.login1.Manager",
+                "PrepareForSleep",
+                "/org/freedesktop/login1",
+                null,
+                GLib.DBusSignalFlags.NONE,
+                (conn, sender, path, iface, signal_name, parameters) => {
+                    bool going_to_sleep;
+                    parameters.get ("(b)", out going_to_sleep);
 
-			Services.EventBus.get_default ().day_changed ();
-			Services.Notification.get_default ().regresh ();
+                    if (going_to_sleep) {
+                        Services.LogService.get_default ().info ("TimeMonitor", "System going to sleep");
+                    } else {
+                        Services.LogService.get_default ().info ("TimeMonitor", "System resumed from sleep, checking day change");
+                        check_day_change ();
+                    }
+                }
+            );
+            Services.LogService.get_default ().info ("TimeMonitor", "Subscribed to logind PrepareForSleep signal");
+        } catch (Error e) {
+            Services.LogService.get_default ().warn ("TimeMonitor", "Could not subscribe to logind PrepareForSleep: %s".printf (e.message));
+        }
+    }
 
-			last_registered_date = now;
-		}
-	}
+    private void check_day_change () {
+        DateTime now = new DateTime.now_local ();
+        Services.LogService.get_default ().debug ("TimeMonitor", "Checking day change: last=%s now=%s".printf (last_registered_date.format ("%Y-%m-%d"), now.format ("%Y-%m-%d")));
+
+        if (now.get_day_of_month () != last_registered_date.get_day_of_month () ||
+            now.get_month () != last_registered_date.get_month () ||
+            now.get_year () != last_registered_date.get_year ()) {
+
+            Services.LogService.get_default ().info ("TimeMonitor", "Day changed from %s to %s".printf (last_registered_date.format ("%Y-%m-%d"), now.format ("%Y-%m-%d")));
+            Services.EventBus.get_default ().day_changed ();
+            Services.Notification.get_default ().regresh ();
+
+            last_registered_date = now;
+        }
+    }
 }

--- a/src/Services/TimeMonitor.vala
+++ b/src/Services/TimeMonitor.vala
@@ -30,19 +30,35 @@ public class Services.TimeMonitor : Object {
     }
 
     private DateTime last_registered_date;
+    private uint midnight_timeout_id = 0;
 
     public void init_timeout () {
         last_registered_date = new DateTime.now_local ();
         Services.LogService.get_default ().info ("TimeMonitor", "Initialized, tracking date: %s".printf (last_registered_date.format ("%Y-%m-%d")));
 
-        // Periodic check every 5 minutes as fallback
-        Timeout.add_seconds (300, () => {
-            check_day_change ();
-            return true;
-        });
-
-        // Listen for system resume from suspend via logind
+        schedule_midnight_check ();
         listen_for_system_resume ();
+    }
+
+    private void schedule_midnight_check () {
+        if (midnight_timeout_id != 0) {
+            GLib.Source.remove (midnight_timeout_id);
+            midnight_timeout_id = 0;
+        }
+
+        var now = new DateTime.now_local ();
+        var tomorrow = now.add_days (1);
+        var midnight = new DateTime.local (tomorrow.get_year (), tomorrow.get_month (), tomorrow.get_day_of_month (), 0, 0, 0);
+        int seconds = (int) (midnight.difference (now) / TimeSpan.SECOND);
+
+        Services.LogService.get_default ().info ("TimeMonitor", "Next day check scheduled in %d seconds".printf (seconds));
+
+        midnight_timeout_id = Timeout.add_seconds (seconds, () => {
+            midnight_timeout_id = 0;
+            check_day_change ();
+            schedule_midnight_check ();
+            return GLib.Source.REMOVE;
+        });
     }
 
     private void listen_for_system_resume () {
@@ -66,6 +82,7 @@ public class Services.TimeMonitor : Object {
                         } else {
                             Services.LogService.get_default ().info ("TimeMonitor", "System resumed from sleep (logind), checking day change");
                             check_day_change ();
+                            schedule_midnight_check ();
                         }
                     }
                 );
@@ -89,6 +106,7 @@ public class Services.TimeMonitor : Object {
                     (conn, sender, path, iface, signal_name, parameters) => {
                         Services.LogService.get_default ().info ("TimeMonitor", "Screen woke up (ScreenSaver), checking day change");
                         check_day_change ();
+                        schedule_midnight_check ();
                     }
                 );
                 Services.LogService.get_default ().info ("TimeMonitor", "Subscribed to ScreenSaver WakeUpScreen signal");


### PR DESCRIPTION
Replace 5-minute polling with precise midnight scheduling that fires exactly at day change. On resume from suspend, the timeout is cancelled and rescheduled from the current time to avoid stale timers.

Fixes: #2173 #2127