### PR TITLE
Fix inbox project radio button allowing deselection

### DIFF
--- a/src/Dialogs/Preferences/Pages/Accounts/InboxPage.vala
+++ b/src/Dialogs/Preferences/Pages/Accounts/InboxPage.vala
@@ -174,12 +174,16 @@ public class Dialogs.Preferences.Pages.InboxPage : Dialogs.Preferences.Pages.Bas
             var select_gesture = new Gtk.GestureClick ();
             action_row.add_controller (select_gesture);
             select_gesture.released.connect (() => {
-                radio_button.active = !radio_button.active;
-                toggled ();
+                if (!radio_button.active) {
+                    radio_button.active = true;
+                    toggled ();
+                }
             });
 
             radio_button.toggled.connect (() => {
-                toggled ();
+                if (radio_button.active) {
+                    toggled ();
+                }
             });
         }
     }


### PR DESCRIPTION
The radio button in the Inbox Project settings could be visually deselected but the change was never saved, causing confusion. Radio buttons by design require selecting another option to change the selection — deselecting is not supported.

Fixes: #2330