### PR TITLE
Fix task completion sound repeating while app is idle

### DIFF
--- a/core/Utils/Util.vala
+++ b/core/Utils/Util.vala
@@ -400,13 +400,11 @@ public class Util : GLib.Object {
         return str;
     }
 
-    private Gtk.MediaFile soud_medida = null;
     public void play_audio () {
-        if (soud_medida == null) {
-            soud_medida = Gtk.MediaFile.for_resource ("/io/github/alainm23/planify/success.ogg");
-        }
-        
-        soud_medida.play ();
+        Services.LogService.get_default ().info ("Audio", "Playing task completion sound");
+        var media = Gtk.MediaFile.for_resource ("/io/github/alainm23/planify/success.ogg");
+        media.loop = false;
+        media.play ();
     }    
 
     public bool is_input_valid (Gtk.Entry entry) {

--- a/src/Layouts/ItemBoard.vala
+++ b/src/Layouts/ItemBoard.vala
@@ -542,6 +542,7 @@ public class Layouts.ItemBoard : Layouts.ItemBase {
 
     private void complete_item (bool old_checked, uint ? time = null) {
         if (Services.Settings.get_default ().settings.get_boolean ("task-complete-tone")) {
+            Services.LogService.get_default ().info ("ItemBoard", "Task completed, playing audio: %s".printf (item.content));
             Util.get_default ().play_audio ();
         }
 

--- a/src/Layouts/ItemRow.vala
+++ b/src/Layouts/ItemRow.vala
@@ -1473,6 +1473,7 @@ public class Layouts.ItemRow : Layouts.ItemBase {
 
     private void complete_item (bool old_checked, uint ? time = null) {
         if (Services.Settings.get_default ().settings.get_boolean ("task-complete-tone")) {
+            Services.LogService.get_default ().info ("ItemRow", "Task completed, playing audio: %s".printf (item.content));
             Util.get_default ().play_audio ();
         }
 


### PR DESCRIPTION
The `MediaFile` instance was kept alive as a class variable, keeping the audio stream open permanently. This caused the sound to replay unexpectedly and triggered Wayland idle inhibitors even when no audio was playing. Fixed by creating a new `MediaFile` instance per playback so the stream closes after each use. Added logging to track unexpected audio calls.

Fixes: #2250