### PR TITLE
Add ETag and If-Match support for CalDAV conflict detection

### DIFF
--- a/core/Objects/Item.vala
+++ b/core/Objects/Item.vala
@@ -226,6 +226,14 @@ public class Objects.Item : Objects.BaseObject {
         }
     }
 
+    string _etag = "";
+    public string etag {
+        get {
+            _etag = Services.Todoist.get_default ().get_string_member_by_object (extra_data, "etag");
+            return _etag;
+        }
+    }
+
     GLib.DateTime _added_datetime;
     public GLib.DateTime added_datetime {
         get {
@@ -745,6 +753,8 @@ public class Objects.Item : Objects.BaseObject {
 
                     if (response.status) {
                         Services.Store.instance ().update_item (this, update_id);
+                    } else if (response.error_code == 412) {
+                        Services.EventBus.get_default ().send_conflict_toast (project.source);
                     }
                 });
             }
@@ -778,6 +788,8 @@ public class Objects.Item : Objects.BaseObject {
 
                     if (response.status) {
                         Services.Store.instance ().update_item (this, update_id);
+                    } else if (response.error_code == 412) {
+                        Services.EventBus.get_default ().send_conflict_toast (project.source);
                     }
 
                     loading = false;
@@ -807,6 +819,8 @@ public class Objects.Item : Objects.BaseObject {
 
                 if (response.status) {
                     Services.Store.instance ().update_item (this, update_id);
+                } else if (response.error_code == 412) {
+                    Services.EventBus.get_default ().send_conflict_toast (project.source);
                 }
 
                 loading = false;

--- a/core/Objects/Item.vala
+++ b/core/Objects/Item.vala
@@ -1882,6 +1882,8 @@ public class Objects.Item : Objects.BaseObject {
                     subitem.complete_item.begin (old_checked);
                 }
             }
+        } else if (response.error_code == 412) {
+            Services.EventBus.get_default ().send_conflict_toast (project.source);
         }
 
         return response;

--- a/core/Services/CalDAV/CalDAVClient.vala
+++ b/core/Services/CalDAV/CalDAVClient.vala
@@ -339,7 +339,11 @@ public class Services.CalDAV.CalDAVClient : Services.CalDAV.WebDAVClient {
                     continue;
                 }
 
+                var getetag = propstat.get_first_prop_with_tagname ("getetag");
+                string etag = getetag != null ? getetag.text_content.strip () : "";
+
                 Objects.Item item = new Objects.Item.from_vtodo (calendar_data.text_content, get_absolute_url (href), project.id);
+                item.extra_data = Util.generate_extra_data (get_absolute_url (href), etag, calendar_data.text_content);
                 items_list.add (item);
             }
 
@@ -441,6 +445,9 @@ public class Services.CalDAV.CalDAVClient : Services.CalDAV.WebDAVClient {
                     }
 
                     if (is_vtodo) {
+                        var getetag = propstat.get_first_prop_with_tagname ("getetag");
+                        string etag = getetag != null ? getetag.text_content.strip () : "";
+
                         string vtodo_content = yield get_vtodo_by_url (get_absolute_url (href), cancellable);
 
                         try {
@@ -458,6 +465,7 @@ public class Services.CalDAV.CalDAVClient : Services.CalDAV.WebDAVClient {
                                         bool old_checked = item.checked;
 
                                         item.update_from_vtodo (vtodo_content, get_absolute_url (href));
+                                        item.extra_data = Util.generate_extra_data (get_absolute_url (href), etag, vtodo_content);
                                         item.project_id = project.id;
                                         Services.Store.instance ().update_item (item);
 
@@ -637,13 +645,24 @@ public class Services.CalDAV.CalDAVClient : Services.CalDAV.WebDAVClient {
         HttpResponse response = new HttpResponse ();
 
         try {
-            yield send_request ("PUT", url, "text/calendar", body, null, null, expected);
-            item.extra_data = Util.generate_extra_data (url, "", body);
+            HashTable<string, string>? headers = null;
+            if (update && item.etag != null && item.etag != "") {
+                headers = new HashTable<string, string> (str_hash, str_equal);
+                headers.insert ("If-Match", item.etag);
+            }
+            yield send_request ("PUT", url, "text/calendar", body, null, null, expected, headers);
+            item.extra_data = Util.generate_extra_data (url, last_response_etag ?? "", body);
             response.status = true;
         } catch (Error e) {
-            Services.LogService.get_default ().error ("CalDAV", "Failed to %s item: %s".printf (update ? "update" : "add", e.message));
-            response.error_code = e.code;
-            response.error = e.message;
+            if ("HTTP 412" in e.message) {
+                Services.LogService.get_default ().warn ("CalDAV", "Conflict detected (412), re-fetching item");
+                response.error_code = 412;
+                response.error = _("Task was modified on another device. Please sync to get the latest version.");
+            } else {
+                Services.LogService.get_default ().error ("CalDAV", "Failed to %s item: %s".printf (update ? "update" : "add", e.message));
+                response.error_code = e.code;
+                response.error = e.message;
+            }
         }
 
         return response;
@@ -656,14 +675,25 @@ public class Services.CalDAV.CalDAVClient : Services.CalDAV.WebDAVClient {
         HttpResponse response = new HttpResponse ();
 
         try {
-            yield send_request ("PUT", item.ical_url, "text/calendar", body, null, null, { Soup.Status.NO_CONTENT, Soup.Status.CREATED });
-            item.extra_data = Util.generate_extra_data (item.ical_url, "", body);
+            HashTable<string, string>? headers = null;
+            if (item.etag != null && item.etag != "") {
+                headers = new HashTable<string, string> (str_hash, str_equal);
+                headers.insert ("If-Match", item.etag);
+            }
+            yield send_request ("PUT", item.ical_url, "text/calendar", body, null, null, { Soup.Status.NO_CONTENT, Soup.Status.CREATED }, headers);
+            item.extra_data = Util.generate_extra_data (item.ical_url, last_response_etag ?? "", body);
 
             response.status = true;
         } catch (Error e) {
-            Services.LogService.get_default ().error ("CalDAV", "Failed to complete item: %s".printf (e.message));
-            response.error_code = e.code;
-            response.error = e.message;
+            if ("HTTP 412" in e.message) {
+                Services.LogService.get_default ().warn ("CalDAV", "Conflict detected (412) on complete, re-fetching item");
+                response.error_code = 412;
+                response.error = _("Task was modified on another device. Please sync to get the latest version.");
+            } else {
+                Services.LogService.get_default ().error ("CalDAV", "Failed to complete item: %s".printf (e.message));
+                response.error_code = e.code;
+                response.error = e.message;
+            }
         }
 
         return response;

--- a/core/Services/CalDAV/WebDAVClient.vala
+++ b/core/Services/CalDAV/WebDAVClient.vala
@@ -27,6 +27,7 @@ public class Services.CalDAV.WebDAVClient : GLib.Object {
     protected string password;
     protected string base_url;
     protected bool ignore_ssl;
+    public string? last_response_etag { get; private set; default = null; }
 
 
     public WebDAVClient (Soup.Session session, string base_url, string username, string password, bool ignore_ssl = false) {
@@ -145,6 +146,8 @@ public class Services.CalDAV.WebDAVClient : GLib.Object {
 
         var response_data = response.get_data ();
         response_data += '\0';
+
+        last_response_etag = msg.response_headers.get_one ("ETag");
 
         return (string) response_data;
     }

--- a/core/Services/EventBus.vala
+++ b/core/Services/EventBus.vala
@@ -82,6 +82,7 @@ public class Services.EventBus : Object {
     // Notifications
     public signal void send_toast (Adw.Toast toast);
     public signal void send_error_toast (int error_code, string error_message);
+    public signal void send_conflict_toast (Objects.Source source);
     public signal void send_task_completed_toast (string project_id);
 
     // Multi Select

--- a/src/Layouts/ItemBoard.vala
+++ b/src/Layouts/ItemBoard.vala
@@ -602,10 +602,10 @@ public class Layouts.ItemBoard : Layouts.ItemBase {
         content_label.remove_css_class ("dimmed");
         content_label.remove_css_class ("line-through");
 
-        Services.EventBus.get_default ().send_error_toast (response.error_code, response.error);
-    }
-
-    private void recurrency_update_complete (GLib.DateTime next_recurrency) {
+        if (response.error_code != 412) {
+            Services.EventBus.get_default ().send_error_toast (response.error_code, response.error);
+        }
+    }    private void recurrency_update_complete (GLib.DateTime next_recurrency) {
         checked_button.active = false;
         complete_timeout = 0;
 

--- a/src/Layouts/ItemBoard.vala
+++ b/src/Layouts/ItemBoard.vala
@@ -605,7 +605,9 @@ public class Layouts.ItemBoard : Layouts.ItemBase {
         if (response.error_code != 412) {
             Services.EventBus.get_default ().send_error_toast (response.error_code, response.error);
         }
-    }    private void recurrency_update_complete (GLib.DateTime next_recurrency) {
+    }
+    
+    private void recurrency_update_complete (GLib.DateTime next_recurrency) {
         checked_button.active = false;
         complete_timeout = 0;
 

--- a/src/Layouts/ItemRow.vala
+++ b/src/Layouts/ItemRow.vala
@@ -1535,7 +1535,9 @@ public class Layouts.ItemRow : Layouts.ItemBase {
         content_label.remove_css_class ("dimmed");
         content_label.remove_css_class ("line-through");
 
-        Services.EventBus.get_default ().send_error_toast (response.error_code, response.error);
+        if (response.error_code != 412) {
+            Services.EventBus.get_default ().send_error_toast (response.error_code, response.error);
+        }
     }
 
     public void update_content (string content = "") {

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -331,6 +331,21 @@ public class MainWindow : Adw.ApplicationWindow {
 
         Services.EventBus.get_default ().send_error_toast.connect (send_toast_error);
 
+        Services.EventBus.get_default ().send_conflict_toast.connect ((source) => {
+            var toast = new Adw.Toast (_("Task was modified on another device")) {
+                timeout = 5,
+                button_label = _("Sync Now")
+            };
+            toast.button_clicked.connect (() => {
+                if (source.source_type == SourceType.TODOIST) {
+                    Services.Todoist.get_default ().sync.begin (source);
+                } else if (source.source_type == SourceType.CALDAV) {
+                    Services.CalDAV.Core.get_default ().sync.begin (source);
+                }
+            });
+            toast_overlay.add_toast (toast);
+        });
+
         Services.EventBus.get_default ().send_task_completed_toast.connect (show_task_completed_toast);
 
         search_button.clicked.connect (() => {


### PR DESCRIPTION
Implement ETag tracking and `If-Match` header for CalDAV PUT requests to prevent silent data loss when multiple clients edit the same task concurrently.

- Extract and store ETag from server responses (PUT, full fetch, sync-collection)
- Send `If-Match` header on task updates and completions
- Handle HTTP 412 Precondition Failed with a friendly toast and "Sync Now" button instead of the error view
- ETag is captured immediately after PUT so no sync is needed to get it

Fixes: #2236