### PR TITLE
Fix due date not cleared when removed from external CalDAV client

### DIFF
--- a/core/Objects/Item.vala
+++ b/core/Objects/Item.vala
@@ -511,6 +511,8 @@ public class Objects.Item : Objects.BaseObject {
 
         if (!ical.get_due ().is_null_time ()) {
             due.date = Utils.Datetime.ical_to_date_time_local (ical.get_due ()).to_string ();
+        } else if (is_update) {
+            due.reset ();
         }
 
         ICal.Property ? rrule_property = ical_vtodo.get_first_property (ICal.PropertyKind.RRULE_PROPERTY);


### PR DESCRIPTION
When a task's due date was removed from an external client (Nextcloud web, tasks.org, etc.), Planify kept the old date after sync. The `patch_from_vtodo` method only updated the date when `DUE` was present in the VTODO, but never cleared it when absent. Fixed by resetting the due date when `DUE` is missing during an update.

Fixes: #2156