### PR TITLE
Enable sync by default for new CalDAV/Nextcloud accounts

### DIFF
--- a/core/Objects/Source.vala
+++ b/core/Objects/Source.vala
@@ -132,15 +132,18 @@ public class Objects.Source : Objects.BaseObject {
             return;
         }
 
+        Services.LogService.get_default ().info ("Source", "Starting sync server for source: %s".printf (display_name));
         _run_server ();
 
         server_timeout = Timeout.add_seconds (15 * 60, () => {
             if (sync_server) {
+                Services.LogService.get_default ().info ("Source", "Periodic sync for source: %s".printf (display_name));
                 _run_server ();
                 return true;
             }
 
-            return false; // Don't repeat timeout if sync server isn't active
+            Services.LogService.get_default ().info ("Source", "Sync server stopped for source: %s".printf (display_name));
+            return false;
         });
     }
 

--- a/core/Services/CalDAV/Core.vala
+++ b/core/Services/CalDAV/Core.vala
@@ -185,6 +185,7 @@ public class Services.CalDAV.Core : GLib.Object {
             source.id = Util.get_default ().generate_id ();
             source.source_type = SourceType.CALDAV;
             source.last_sync = new GLib.DateTime.now_local ().to_string ();
+            source.sync_server = true;
 
             Objects.SourceCalDAVData caldav_data = new Objects.SourceCalDAVData ();
             caldav_data.server_url = dav_url;

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -214,6 +214,12 @@ public class MainWindow : Adw.ApplicationWindow {
                 return GLib.Source.REMOVE;
             });
 
+            Services.Store.instance ().source_added.connect ((source) => {
+                if (source.sync_server) {
+                    source.run_server ();
+                }
+            });
+
             // TODO: network_changed is sometimes called very rapidly, so we should debounce it ...
             var network_monitor = GLib.NetworkMonitor.get_default ();
             network_monitor.network_changed.connect (() => {


### PR DESCRIPTION
CalDAV and Nextcloud accounts were created with `sync_server = false`, so automatic sync never started unless the app was restarted. Fixed by setting `sync_server = true` on account creation and starting the sync timer immediately via `source_added` signal.

