### PR TITLE
Fix duplicate projects when adding CalDAV account and Enter key in password field

### DIFF
--- a/core/Services/CalDAV/Core.vala
+++ b/core/Services/CalDAV/Core.vala
@@ -231,7 +231,6 @@ public class Services.CalDAV.Core : GLib.Object {
 
 
             yield caldav_client.update_userdata (principal_url, source, cancellable);
-            Services.Store.instance ().insert_source (source);
 
             Gee.ArrayList<Objects.Project> projects = yield caldav_client.fetch_project_list (source, cancellable);
 
@@ -257,6 +256,10 @@ public class Services.CalDAV.Core : GLib.Object {
                     processed++;
                 }
             }
+
+            // Insert source after all projects and items are fetched
+            // to avoid concurrent sync triggering duplicate project insertion
+            Services.Store.instance ().insert_source (source);
 
             sync_progress (projects.size, projects.size, _("Sync completed"));
             Services.LogService.get_default ().info ("CalDAV.Core", "Account added successfully, %d projects synced".printf (projects.size));

--- a/src/Dialogs/Preferences/Pages/Accounts/CalDAVSetup.vala
+++ b/src/Dialogs/Preferences/Pages/Accounts/CalDAVSetup.vala
@@ -196,6 +196,12 @@ public class Dialogs.Preferences.Pages.CalDAVSetup : Dialogs.Preferences.Pages.B
         signal_map[username_entry.changed.connect (() => validate_entries ())] = username_entry;
         signal_map[password_entry.changed.connect (() => validate_entries ())] = password_entry;
 
+        signal_map[password_entry.entry_activated.connect (() => {
+            if (login_button.sensitive) {
+                on_login_button_clicked ();
+            }
+        })] = password_entry;
+
         signal_map[login_button.clicked.connect (() => on_login_button_clicked ())] = login_button;
 
         signal_map[Services.CalDAV.Core.get_default ().sync_progress.connect ((current, total, message) => {


### PR DESCRIPTION
- Fixed duplicate project insertion when adding a CalDAV account. The source was inserted before the initial fetch completed, triggering a concurrent sync that found the same projects and inserted them again. Now `insert_source` is called after all projects and items are fetched. 
- Added Enter key support in the password field of CalDAV setup to trigger login.