### PR TITLE
Skip sync for disabled CalDAV/Todoist accounts

### DIFF
--- a/core/Objects/Source.vala
+++ b/core/Objects/Source.vala
@@ -148,6 +148,11 @@ public class Objects.Source : Objects.BaseObject {
     }
 
     private void _run_server () {
+        if (!is_visible) {
+            Services.LogService.get_default ().info ("Source", "Skipping sync for disabled source: %s".printf (display_name));
+            return;
+        }
+
         if (source_type == SourceType.TODOIST) {
             Services.Todoist.get_default ().sync.begin (this);
         } else if (source_type == SourceType.CALDAV) {


### PR DESCRIPTION
Disabled accounts (`is_visible = false`) were still being synced because `_run_server()` only checked `sync_server` but not `is_visible`. Fixed by adding an `is_visible` check before starting any sync.

fixes: #2360