### PR TITLE
Use ICU for language names in Translation Row

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,17 +80,18 @@
 | libsecret-1 | ≥ 0.21.4 |
 | libspelling-dev | latest |
 | gtksourceview-5 | 5.12.1 |
+| libicu-dev | ≥ 76.1 |
 
 **Install Dependencies:**
 
 **Fedora/RHEL:**
 ```bash
-sudo dnf install vala meson ninja-build gtk4-devel libadwaita-devel libgee-devel libsoup3-devel libportal-devel libportal-gtk4-devel evolution-devel libspelling-devel gtksourceview5-devel
+sudo dnf install vala meson ninja-build gtk4-devel libadwaita-devel libgee-devel libsoup3-devel libportal-devel libportal-gtk4-devel evolution-devel libspelling-devel gtksourceview5-devel libicu-devel
 ```
 
 **Ubuntu/Debian:**
 ```bash
-sudo apt install valac meson ninja-build libgtk-4-dev libadwaita-1-dev libgee-0.8-dev libjson-glib-dev libecal2.0-dev libsoup-3.0-dev libportal-dev libportal-gtk4-dev libspelling-1-dev libgtksourceview-5-dev
+sudo apt install valac meson ninja-build libgtk-4-dev libadwaita-1-dev libgee-0.8-dev libjson-glib-dev libecal2.0-dev libsoup-3.0-dev libportal-dev libportal-gtk4-dev libspelling-1-dev libgtksourceview-5-dev libicu-dev
 ```
 
 </details>

--- a/meson.build
+++ b/meson.build
@@ -4,13 +4,36 @@ project(
   version: '4.19.0'
 )
 
+###########
+# Profile #
+###########
+
+profile = get_option('profile')
+if profile == 'development'
+  find_program('git')
+  rev_txt = run_command('git','rev-parse','--short','HEAD').stdout().strip()
+  rev = '-@0@'.format(rev_txt)
+  application_id = 'io.github.alainm23.planify.Devel'
+  application_path = '/io/github/alainm23/planify/Devel'
+  add_project_arguments(['--define=DEVELOPMENT'], language: 'vala')
+else
+  rev = ''
+  application_id = 'io.github.alainm23.planify'
+  application_path = '/io/github/alainm23/planify'
+endif
+
+################
+# Dependencies #
+################
+
+
 cc = meson.get_compiler('c')
 
 gnome = import('gnome')
 i18n = import('i18n')
 pkgconfig = import('pkgconfig')
 
-add_global_arguments('-DGETTEXT_PACKAGE="@0@"'.format (meson.project_name()), language:'c')
+add_global_arguments('-DGETTEXT_PACKAGE="@0@"'.format (application_id), language:'c')
 add_project_arguments('-DLIBICAL_GLIB_UNSTABLE_API=1', language: 'c')
 
 gio_dep = dependency('gio-2.0')
@@ -27,6 +50,11 @@ libsecret_dep = dependency('libsecret-1')
 libspelling = dependency('libspelling-1', required: get_option('spelling'))
 gtksourceview_dep = dependency('gtksourceview-5')
 m_dep = meson.get_compiler('c').find_library('m', required : false)
+icu_uc_dep = dependency('icu-uc')
+
+if icu_uc_dep.found ()
+  add_project_arguments(['--vapidir=' + meson.project_source_root() / 'vapi'], language: 'vala')
+endif
 
 if libspelling.found ()
   add_project_arguments(['--define=WITH_LIBSPELLING'], language: 'vala')
@@ -65,24 +93,6 @@ asresources = gnome.compile_resources (
     source_dir: 'data',
     c_name: 'as'
 )
-
-###########
-# Profile #
-###########
-
-profile = get_option('profile')
-if profile == 'development'
-  find_program('git')
-  rev_txt = run_command('git','rev-parse','--short','HEAD').stdout().strip()
-  rev = '-@0@'.format(rev_txt)
-  application_id = 'io.github.alainm23.planify.Devel'
-  application_path = '/io/github/alainm23/planify/Devel'
-  add_project_arguments(['--define=DEVELOPMENT'], language: 'vala')
-else
-  rev = ''
-  application_id = 'io.github.alainm23.planify'
-  application_path = '/io/github/alainm23/planify'
-endif
 
 ############
 # Config #

--- a/po/meson.build
+++ b/po/meson.build
@@ -1,4 +1,4 @@
-i18n.gettext(meson.project_name(),
+i18n.gettext(application_id,
     args: '--directory=' + meson.source_root(),
     preset: 'glib'
 )

--- a/src/Widgets/TranslationRow.vala
+++ b/src/Widgets/TranslationRow.vala
@@ -110,6 +110,8 @@ public class Widgets.TranslationRow : Adw.PreferencesRow {
         try {
             var languages = Intl.get_language_names ();
 
+            bool is_english = false;
+
             foreach (string lang in languages) {
                 if (lang == "C" || lang == "POSIX") {
                     continue;
@@ -118,29 +120,32 @@ public class Widgets.TranslationRow : Adw.PreferencesRow {
                 string user_lang = lang.contains ("_") ? lang.split ("_")[0] : lang;
 
                 if (user_lang == "en") {
-                    title = _ ("Translations");
-                    subtitle = _ ("Help make Planify available worldwide");
-                    hide_level_bar ();
-                    return;
+                    is_english = true;
+                    break;
                 }
+            }
 
-                var metric = yield get_current_translation_metric ();
-                if (metric != null && metric.translated_percent > 0.0) {
-                    title = _ ("Help improve translations");
-                    var language_name = get_language_name (metric.code);
-                    prepare_animation (language_name, metric.translated_percent);
-                    return;
-                }
-
-                string language_name = get_language_name (lang);
-                title = _ ("Start a new translation");
-                subtitle = _ ("<b>%s</b> is not available yet. Be the first to translate it!").printf (language_name);
+            if (is_english) {
+                title = _ ("Translations");
+                subtitle = _ ("Help make Planify available worldwide");
                 hide_level_bar ();
                 return;
             }
 
-            title = _ ("Translations");
-            subtitle = _ ("Help make Planify available worldwide");
+            var metric = yield get_current_translation_metric ();
+
+            if (metric != null && metric.translated_percent > 0.0) {
+                title = _ ("Help improve translations");
+                var language_name = ICU.get_display_language (metric.code, metric.code);
+                prepare_animation (language_name, metric.translated_percent);
+                return;
+            }
+
+            string language_name = ICU.get_display_language (metric.code, "en");
+
+            title = _ ("Start a new translation");
+            subtitle = _ ("<b>%s</b> is not available yet. Be the first to translate it!").printf (language_name);
+
             hide_level_bar ();
         } catch (Error e) {
             title = _ ("Translations");
@@ -149,105 +154,6 @@ public class Widgets.TranslationRow : Adw.PreferencesRow {
         }
     }
 
-    private string get_language_name (string lang_code) {
-        var locale_names = new Gee.HashMap<string, string> ();
-        locale_names.set ("af", "Afrikaans");
-        locale_names.set ("ak", "Akan");
-        locale_names.set ("ar", "Arabic");
-        locale_names.set ("az", "Azerbaijani");
-        locale_names.set ("be", "Belarusian");
-        locale_names.set ("bg", "Bulgarian");
-        locale_names.set ("bn", "Bengali");
-        locale_names.set ("bs", "Bosnian");
-        locale_names.set ("ca", "Catalan");
-        locale_names.set ("ckb", "Central Kurdish");
-        locale_names.set ("cs", "Czech");
-        locale_names.set ("cv", "Chuvash");
-        locale_names.set ("da", "Danish");
-        locale_names.set ("de", "German");
-        locale_names.set ("el", "Greek");
-        locale_names.set ("eo", "Esperanto");
-        locale_names.set ("es", "Spanish");
-        locale_names.set ("et", "Estonian");
-        locale_names.set ("eu", "Basque");
-        locale_names.set ("fa", "Persian");
-        locale_names.set ("fi", "Finnish");
-        locale_names.set ("fr", "French");
-        locale_names.set ("ga", "Irish");
-        locale_names.set ("gl", "Galician");
-        locale_names.set ("he", "Hebrew");
-        locale_names.set ("hi", "Hindi");
-        locale_names.set ("hr", "Croatian");
-        locale_names.set ("hu", "Hungarian");
-        locale_names.set ("hy", "Armenian");
-        locale_names.set ("id", "Indonesian");
-        locale_names.set ("is", "Icelandic");
-        locale_names.set ("it", "Italian");
-        locale_names.set ("ja", "Japanese");
-        locale_names.set ("jv", "Javanese");
-        locale_names.set ("ka", "Georgian");
-        locale_names.set ("kk", "Kazakh");
-        locale_names.set ("kn", "Kannada");
-        locale_names.set ("ko", "Korean");
-        locale_names.set ("ku", "Kurdish");
-        locale_names.set ("lb", "Luxembourgish");
-        locale_names.set ("lg", "Luganda");
-        locale_names.set ("lt", "Lithuanian");
-        locale_names.set ("lv", "Latvian");
-        locale_names.set ("mg", "Malagasy");
-        locale_names.set ("mk", "Macedonian");
-        locale_names.set ("mn", "Mongolian");
-        locale_names.set ("mo", "Moldovan");
-        locale_names.set ("mr", "Marathi");
-        locale_names.set ("ms", "Malay");
-        locale_names.set ("my", "Burmese");
-        locale_names.set ("nb", "Norwegian Bokmål");
-        locale_names.set ("nl", "Dutch");
-        locale_names.set ("nn", "Norwegian Nynorsk");
-        locale_names.set ("no", "Norwegian");
-        locale_names.set ("pa", "Punjabi");
-        locale_names.set ("pl", "Polish");
-        locale_names.set ("pt", "Portuguese");
-        locale_names.set ("ro", "Romanian");
-        locale_names.set ("ru", "Russian");
-        locale_names.set ("sa", "Sanskrit");
-        locale_names.set ("si", "Sinhala");
-        locale_names.set ("sk", "Slovak");
-        locale_names.set ("sl", "Slovenian");
-        locale_names.set ("sma", "Southern Sami");
-        locale_names.set ("sq", "Albanian");
-        locale_names.set ("sr", "Serbian");
-        locale_names.set ("sv", "Swedish");
-        locale_names.set ("szl", "Silesian");
-        locale_names.set ("ta", "Tamil");
-        locale_names.set ("te", "Telugu");
-        locale_names.set ("th", "Thai");
-        locale_names.set ("tl", "Tagalog");
-        locale_names.set ("tr", "Turkish");
-        locale_names.set ("ug", "Uyghur");
-        locale_names.set ("uk", "Ukrainian");
-        locale_names.set ("ur", "Urdu");
-        locale_names.set ("uz", "Uzbek");
-        locale_names.set ("vi", "Vietnamese");
-        locale_names.set ("zh", "Chinese");
-        locale_names.set ("zu", "Zulu");
-        locale_names.set ("en_AU", "English (Australia)");
-        locale_names.set ("en_CA", "English (Canada)");
-        locale_names.set ("en_GB", "English (UK)");
-        locale_names.set ("fr_CA", "French (Canada)");
-        locale_names.set ("pt_BR", "Portuguese (Brazil)");
-        locale_names.set ("zh_CN", "Chinese (Simplified)");
-        locale_names.set ("zh_TW", "Chinese (Traditional)");
-        locale_names.set ("tr_TR", "Turkish (Turkey)");
-        locale_names.set ("nb_NO", "Norwegian Bokmål (Norway)");
-
-        if (locale_names.has_key (lang_code)) {
-            return locale_names.get (lang_code);
-        }
-
-        string base_lang = lang_code.contains ("_") ? lang_code.split ("_")[0] : lang_code;
-        return locale_names.has_key (base_lang) ? locale_names.get (base_lang) : base_lang.up ();
-    }
 
 
     /**
@@ -287,7 +193,7 @@ public class Widgets.TranslationRow : Adw.PreferencesRow {
         }
 
         if (mo_path == null) {
-            warning ("Current locale has no translations available");
+            info ("Current locale has no translations available");
             return null;
         }
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,7 +1,8 @@
 deps = [
   core_dep,
   gee_dep,
-  m_dep
+  m_dep,
+  icu_uc_dep
 ]
 
 

--- a/vapi/icu-uc.vapi
+++ b/vapi/icu-uc.vapi
@@ -1,0 +1,62 @@
+// Loosely based on icu-uc.vapi from Geary project which in turn is based on the Dino project.
+
+[CCode (cheader_filename = "unicode/uloc.h")]
+namespace ICU {
+
+    [CCode (cname = "UChar")]
+	[IntegerType (rank = 5, min = 0, max = 65535)]
+	public struct Char {}
+
+	[CCode (cname = "UErrorCode", cprefix = "U_", cheader_filename = "unicode/utypes.h")]
+	public enum ErrorCode {
+		ZERO_ERROR,
+		INVALID_CHAR_FOUND,
+		INDEX_OUTOFBOUNDS_ERROR,
+		BUFFER_OVERFLOW_ERROR,
+		STRINGPREP_PROHIBITED_ERROR,
+		UNASSIGNED_CODE_POINT_FOUND,
+		IDNA_STD3_ASCII_RULES_ERROR;
+
+		[CCode (cname = "u_errorName")]
+		public unowned string errorName();
+
+		[CCode (cname = "U_SUCCESS")]
+		public bool is_success();
+
+		[CCode (cname = "U_FAILURE")]
+		public bool is_failure();
+	}
+
+    [CCode (cname = "uloc_getDisplayLanguage")]
+    public int c_get_display_language (
+        string locale,
+        string display_locale,
+        [CCode (array_length = false)] Char[] dest,
+        int dest_capacity,
+        ref ErrorCode error
+    );
+
+    public string get_display_language (string locale, string display_locale) {
+        ICU.ErrorCode status = ICU.ErrorCode.ZERO_ERROR;
+
+        ICU.Char[] tmp = new ICU.Char[256];
+
+        int len = ICU.c_get_display_language (
+            locale,
+            display_locale,
+            tmp,
+            tmp.length,
+            ref status
+        );
+
+        if (status.is_failure () || len <= 0) {
+            return "Unknown";
+        }
+
+        try {
+            return GLib.convert ((string)((uint8[]) tmp), len * 2, "UTF-8", "UTF-16");
+        }  catch (GLib.ConvertError e) {
+            return "Unknown";
+        }
+    }
+}


### PR DESCRIPTION
This PR improves the language name shown in the Translation Row.

Since flatpak and basically any systems has ICU, I implemented a vapi binding to get the display language in the local Name for showing the percentage and in English if the language is not available yet.

Other small Fixes include:
Having locales work in the Devel Flatpak
Changed warning message to an info message so debugging using fatal-warning is easier
