### PR TITLE
Use GLib.debug() instead of print() in production builds

### DIFF
--- a/core/Constants.vala
+++ b/core/Constants.vala
@@ -21,6 +21,12 @@
 
 namespace Constants {
     public const string SOUP_USER_AGENT = "Planify";
+
+#if DEVELOPMENT
+    public const bool IS_DEVELOPMENT = true;
+#else
+    public const bool IS_DEVELOPMENT = false;
+#endif
     public const string TODOIST_CLIENT_ID = "b0dd7d3714314b1dbbdab9ee03b6b432";
     public const string TODOIST_CLIENT_SECRET = "a86dfeb12139459da3e5e2a8c197c678";
     public const string TODOIST_SCOPE = "data:read_write,data:delete,project:delete";

--- a/core/Constants.vala
+++ b/core/Constants.vala
@@ -21,7 +21,6 @@
 
 namespace Constants {
     public const string SOUP_USER_AGENT = "Planify";
-
 #if DEVELOPMENT
     public const bool IS_DEVELOPMENT = true;
 #else

--- a/core/Services/LogService.vala
+++ b/core/Services/LogService.vala
@@ -51,8 +51,11 @@ public class Services.LogService : Object {
         var timestamp = new DateTime.now_local ().format ("%Y-%m-%d %H:%M:%S");
         var line = "[%s] [%s] [%s] %s\n".printf (timestamp, level.to_string (), context, message);
 
-        // Always print to stdout
-        print ("%s", line);
+        if (Constants.IS_DEVELOPMENT) {
+            print ("%s", line);
+        } else {
+            GLib.debug ("%s", line.chomp ());
+        }
 
         // Write to file
         if (stream != null) {

--- a/meson.build
+++ b/meson.build
@@ -77,6 +77,7 @@ if profile == 'development'
   rev = '-@0@'.format(rev_txt)
   application_id = 'io.github.alainm23.planify.Devel'
   application_path = '/io/github/alainm23/planify/Devel'
+  add_project_arguments(['--define=DEVELOPMENT'], language: 'vala')
 else
   rev = ''
   application_id = 'io.github.alainm23.planify'


### PR DESCRIPTION
Added `IS_DEVELOPMENT` constant to `Constants.vala` using the `DEVELOPMENT` Vala preprocessor define (set when `-Dprofile=development`). `LogService` now uses `print()` in development and `GLib.debug()` in production, avoiding console spam in release builds while keeping logs accessible via `journalctl`.