### PR TITLE
fix: subtasks not reset not updated when recurring task completes

### DIFF
--- a/core/Objects/Item.vala
+++ b/core/Objects/Item.vala
@@ -1608,6 +1608,13 @@ public class Objects.Item : Objects.BaseObject {
             due.recurrency_count = due.recurrency_count - 1;
         }
 
+        foreach (Objects.Item subitem in Services.Store.instance ().get_subitems (this)) {
+            if (subitem.checked) {
+                subitem.checked = false;
+                subitem.completed_at = "";
+                Services.Store.instance ().update_item (subitem);
+            }
+        }
         if (project.source_type == SourceType.LOCAL) {
             Services.Store.instance ().update_item (this);
             promise.resolve (next_recurrency);

--- a/core/Objects/Item.vala
+++ b/core/Objects/Item.vala
@@ -1610,9 +1610,11 @@ public class Objects.Item : Objects.BaseObject {
 
         foreach (Objects.Item subitem in Services.Store.instance ().get_subitems (this)) {
             if (subitem.checked) {
+                bool old_checked = subitem.checked;
                 subitem.checked = false;
                 subitem.completed_at = "";
-                Services.Store.instance ().update_item (subitem);
+                subitem.update_async ();
+                Services.EventBus.get_default ().checked_toggled (subitem, old_checked);
             }
         }
         if (project.source_type == SourceType.LOCAL) {

--- a/src/Layouts/ItemBoard.vala
+++ b/src/Layouts/ItemBoard.vala
@@ -610,6 +610,9 @@ public class Layouts.ItemBoard : Layouts.ItemBase {
     private void recurrency_update_complete (GLib.DateTime next_recurrency) {
         checked_button.active = false;
         complete_timeout = 0;
+        card_widget.remove_css_class ("complete");
+        content_label.remove_css_class ("line-through");
+        content_label.remove_css_class ("dimmed");
 
         var title = _ ("Completed. Next occurrence: %s".printf (Utils.Datetime.get_default_date_format_from_date (next_recurrency)));
         var toast = Util.get_default ().create_toast (title, 3);


### PR DESCRIPTION
**Subtasks not reset on recurrence:**
When a recurring task advanced to its next occurrence, completed subtasks stayed completed. Now they are reset (checked = false) and synced to the corresponding source (LOCAL/Todoist/CalDAV). `checked_toggled` is emitted for each subitem so the UI also reflects the uncompleted state.


Fixes #1438