### PR TITLE
Hide the position marker for new tasks when done (fix for #2388)

### DIFF
--- a/src/Layouts/ItemRow.vala
+++ b/src/Layouts/ItemRow.vala
@@ -1794,6 +1794,9 @@ public class Layouts.ItemRow : Layouts.ItemBase {
                 }
             }
 
+            signals_map[dialog.closed.connect (() => {
+                motion_top_revealer.reveal_child = false;
+            })] = dialog;
             dialog.present (Planify._instance.main_window);
             return true;
         })] = drop_order_magic_button_target;


### PR DESCRIPTION
Fix for #2388.

See the commit message for details.

This does _not_ fix the issue that often more than one position marker appears while dragging the magic plus button: with nested items, further up in the chain, and particularly when moving the drop position from a new space between two existing entries down onto an existing entry (so that a sub-item will be created). These have to be fixed separately.