### PR TITLE
Fix project names containing "&" empty in Home View

### DIFF
--- a/src/Dialogs/Preferences/Pages/HomeView.vala
+++ b/src/Dialogs/Preferences/Pages/HomeView.vala
@@ -161,6 +161,7 @@ public class Dialogs.Preferences.Pages.HomeView : Dialogs.Preferences.Pages.Base
 
             var action_row = new Adw.ActionRow () {
                 title = base_object.name,
+                use_markup = false,
                 activatable = true
             };
 


### PR DESCRIPTION
The "home view" entry in the settings menu displays empty names for projects containing a "&":
<img width="351" height="115" alt="image" src="https://github.com/user-attachments/assets/fa1415c4-b170-44fb-8abf-1c89a43e7d30" />
<img width="525" height="548" alt="image" src="https://github.com/user-attachments/assets/ca469306-c5dd-4a00-93a7-4346d868935f" />

Because the default behavior of `ActionRow` is to interpret titles as markup, as indicated by this warning:
> Gtk-WARNING **: Failed to set text 'test & testing' from markup due to error parsing markup: Error on line 1: Entity did not end with a semicolon; most likely you used an ampersand character without intending to start an entity — escape ampersand as &amp;amp;

Since project names AFAIK never contain markup anyway, the proposed fix here is to simply disable markup for the title.
