### PR TITLE
fix: Don't show archived subprojects on restart

### DIFF
--- a/src/Layouts/ProjectRow.vala
+++ b/src/Layouts/ProjectRow.vala
@@ -848,7 +848,9 @@ public class Layouts.ProjectRow : Gtk.ListBoxRow {
 
     private void add_subprojects () {
         foreach (Objects.Project subproject in project.subprojects) {
-            add_subproject (subproject);
+            if (!subproject.is_archived) {
+                add_subproject (subproject);
+            }
         }
     }
 
@@ -861,7 +863,7 @@ public class Layouts.ProjectRow : Gtk.ListBoxRow {
     }
 
     public void add_subproject (Objects.Project project) {
-        if (!subprojects_hashmap.has_key (project.id) && show_subprojects) {
+        if (!subprojects_hashmap.has_key (project.id) && show_subprojects && !project.is_archived) {
             subprojects_hashmap[project.id] = new Layouts.ProjectRow (project);
             listbox.append (subprojects_hashmap[project.id]);
         }


### PR DESCRIPTION
When a subproject was archived, it would reappear in the sidebar after  restarting Planify because `add_subprojects` and `add_subproject` in `ProjectRow` didn't check `is_archived` before adding them to the list.

Fixes: #2438
