### PR TITLE
fix: Improve inbox section visibility and UX in Board view

### DIFF
--- a/core/Widgets/ProjectPicker/ProjectPickerButton.vala
+++ b/core/Widgets/ProjectPicker/ProjectPickerButton.vala
@@ -313,7 +313,9 @@ public class Widgets.ProjectPicker.ProjectPickerButton : Adw.Bin {
         sections_map.clear ();
 
         sections_map["no-section"] = new Widgets.SectionPicker.SectionPickerRow.for_no_section ();
-        sections_listbox.append (sections_map["no-section"]);
+        if (project.sections.size == 0) {
+            sections_listbox.append (sections_map["no-section"]);
+        }
         foreach (Objects.Section section in project.sections) {
             sections_map[section.id] = new Widgets.SectionPicker.SectionPickerRow (section);
             sections_listbox.append (sections_map[section.id]);

--- a/core/Widgets/SectionPicker/SectionPickerRow.vala
+++ b/core/Widgets/SectionPicker/SectionPickerRow.vala
@@ -74,11 +74,6 @@ public class Widgets.SectionPicker.SectionPickerRow : Gtk.ListBoxRow {
             child = selected_icon
         };
 
-        var hidded_switch = new Gtk.Switch () {
-            css_classes = { "active-switch" },
-            active = section.id == "" ? !section.project.inbox_section_hidded : !section.hidded
-        };
-
         var order_icon = new Gtk.Image.from_icon_name ("list-drag-handle-symbolic") {
             css_classes = { "dimmed" },
             pixel_size = 12

--- a/src/Layouts/ItemBoard.vala
+++ b/src/Layouts/ItemBoard.vala
@@ -1154,6 +1154,8 @@ public class Layouts.ItemBoard : Layouts.ItemBase {
 
             Utils.TaskUtils.update_single_item_order (target_list, picked_widget, new_index);
 
+            picked_widget.item.project.count_update ();
+
             return true;
         })] = drop_order_target;
     }

--- a/src/Layouts/SectionBoard.vala
+++ b/src/Layouts/SectionBoard.vala
@@ -356,6 +356,8 @@ public class Layouts.SectionBoard : Gtk.FlowBoxChild {
                         items_map.unset (row.item.id);
                     }
                 }
+
+                section.project.count_update ();
             }
         })] = Services.EventBus.get_default ();
 
@@ -740,7 +742,9 @@ public class Layouts.SectionBoard : Gtk.FlowBoxChild {
             Utils.TaskUtils.update_single_item_order (listbox, picked_widget, picked_widget.get_index ());
 
             Services.EventBus.get_default ().update_inserted_item_map (picked_widget, old_section_id, old_parent_id);
-            
+
+            section.project.count_update ();
+
             return true;
         })] = drop_target;
     }

--- a/src/Views/Project/Board.vala
+++ b/src/Views/Project/Board.vala
@@ -182,10 +182,14 @@ public class Views.Board : Adw.Bin {
             Layouts.SectionBoard item = ((Layouts.SectionBoard) child);
 
             if (item.is_inbox_section) {
-                return !project.inbox_section_hidded;
+                bool has_uncompleted = project.items.any_match ((i) => !i.checked);
+                if (project.show_completed) {
+                    return has_uncompleted || project.items_checked.size > 0;
+                }
+                return has_uncompleted;
             }
 
-            return !item.section.hidded;
+            return !item.section.was_archived ();
         });
 
         signal_map[description_widget.changed.connect (() => {
@@ -208,6 +212,17 @@ public class Views.Board : Adw.Bin {
 
         signal_map[project.count_updated.connect (() => {
             icon_project.update_request ();
+            flowbox.invalidate_filter ();
+        })] = project;
+
+        signal_map[Services.EventBus.get_default ().checked_toggled.connect ((item) => {
+            if (item.project_id == project.id && item.section_id == "") {
+                flowbox.invalidate_filter ();
+            }
+        })] = Services.EventBus.get_default ();
+
+        signal_map[project.show_completed_changed.connect (() => {
+            flowbox.invalidate_filter ();
         })] = project;
 
         signal_map[project.source.sync_finished.connect (() => {
@@ -242,7 +257,12 @@ public class Views.Board : Adw.Bin {
     }
 
     public void prepare_new_item (string content = "") {
-        inbox_board.prepare_new_item (content);
+        var sections = project.sections;
+        if (sections.size > 0) {
+            sections_map[sections[0].id].prepare_new_item (content);
+        } else {
+            inbox_board.prepare_new_item (content);
+        }
     }
 
     private void update_duedate () {

--- a/src/Views/Project/List.vala
+++ b/src/Views/Project/List.vala
@@ -218,12 +218,7 @@ public class Views.List : Adw.Bin {
 
         listbox.set_filter_func ((child) => {
             Layouts.SectionRow item = ((Layouts.SectionRow) child);
-
-            if (item.is_inbox_section) {
-                return !project.inbox_section_hidded;
-            }
-
-            return !item.section.hidded;
+            return !item.section.was_archived ();
         });
 
         signal_map[description_widget.changed.connect (() => {

--- a/src/Widgets/SectionItemRow.vala
+++ b/src/Widgets/SectionItemRow.vala
@@ -73,13 +73,6 @@ public class Widgets.SectionItemRow : Gtk.ListBoxRow {
             child = selected_icon
         };
 
-        var hidded_switch = new Gtk.Switch () {
-            css_classes = { "active-switch" },
-            active = is_inbox_section ? !section.project.inbox_section_hidded : !section.hidded,
-            halign = Gtk.Align.END,
-            hexpand = true
-        };
-
         var order_icon = new Gtk.Image.from_icon_name ("list-drag-handle-symbolic") {
             css_classes = { "dimmed" },
             pixel_size = 12
@@ -104,9 +97,7 @@ public class Widgets.SectionItemRow : Gtk.ListBoxRow {
             if (!is_inbox_section) {
                 content_box.append (order_icon);
             }
-
             content_box.append (name_label);
-            content_box.append (hidded_switch);
         }
 
         if (widget_type == "picker") {
@@ -157,18 +148,6 @@ public class Widgets.SectionItemRow : Gtk.ListBoxRow {
             if (!is_inbox_section) {
                 reorder_child.build_drag_and_drop ();
             }
-
-            signal_map[hidded_switch.notify["active"].connect (() => {
-                if (section.id == "") {
-                    section.project.inbox_section_hidded = !hidded_switch.active;
-                    section.project.update_local ();
-                } else {
-                    section.hidded = !hidded_switch.active;
-                    Services.Database.get_default ().update_section (section);
-                }
-
-                update_section ();
-            })] = hidded_switch;
 
             signal_map[reorder_child.on_drop_end.connect (() => {
                 update_section ();


### PR DESCRIPTION
Several UX improvements related to the inbox (no section) column in Board view:

- Inbox section now auto-hides when it has no uncompleted tasks, matching Todoist behavior
- Inbox section re-appears when `show_completed` is active and has completed tasks
- Magic button in Board now opens QuickAdd in the first real section instead of inbox
- "No Section" option hidden from section picker when project has sections, preventing tasks from being created in a hidden inbox
- Removed the "hide section" toggle from Manage Sections — archiving is the correct way to hide sections
- Fixed DnD between Board columns triggering inbox visibility update via `count_update()`

Fixes: #2430