### PR TITLE
Added a Toggle in Appearance for using system accent color under Preferences 

### DIFF
--- a/core/Utils/Util.vala
+++ b/core/Utils/Util.vala
@@ -279,13 +279,15 @@ public class Util : GLib.Object {
         }
 
         string accent_color = "#3584e4";
-        if (Adw.StyleManager.get_default ().get_system_supports_accent_colors ()) {
-            var rgba = Adw.StyleManager.get_default ().get_accent_color_rgba ();
-            accent_color = "#%02x%02x%02x".printf (
-                (uint) (rgba.red * 255),
-                (uint) (rgba.green * 255),
-                (uint) (rgba.blue * 255)
-            );
+        if (Services.Settings.get_default ().settings.get_boolean ("use-system-accent")) {
+            if (Adw.StyleManager.get_default ().get_system_supports_accent_colors ()) {
+                var rgba = Adw.StyleManager.get_default ().get_accent_color_rgba ();
+                accent_color = "#%02x%02x%02x".printf (
+                    (uint) (rgba.red * 255),
+                    (uint) (rgba.green * 255),
+                    (uint) (rgba.blue * 255)
+                );
+            }
         }
 
         string window_bg_color = "";
@@ -307,8 +309,8 @@ public class Util : GLib.Object {
                 upcoming_fg_color = "#f0f0f0";
                 selected_color = "#2e3a46";
                 card_bg_color = "#222222";
-                Adw.StyleManager.get_default ().color_scheme = Adw.ColorScheme.FORCE_DARK;
-            } else if (appearance_mode == Appearance.DARK_BLUE) {
+                Adw.StyleManager.get_default ().color_scheme = Adw.ColorScheme.PREFER_DARK;
+            } else {
                 window_bg_color = "#0C0D12";
                 popover_bg_color = "#16171D";
                 sidebar_bg_color = "#14151a";

--- a/core/Utils/Util.vala
+++ b/core/Utils/Util.vala
@@ -278,12 +278,22 @@ public class Util : GLib.Object {
             dark_mode = color_scheme_settings.prefers_color_scheme == ColorSchemeSettings.Settings.ColorScheme.DARK;
         }
 
+        string accent_color = "#3584e4";
+        if (Adw.StyleManager.get_default ().get_system_supports_accent_colors ()) {
+            var rgba = Adw.StyleManager.get_default ().get_accent_color_rgba ();
+            accent_color = "#%02x%02x%02x".printf (
+                (uint) (rgba.red * 255),
+                (uint) (rgba.green * 255),
+                (uint) (rgba.blue * 255)
+            );
+        }
+
         string window_bg_color = "";
         string popover_bg_color = "";
         string sidebar_bg_color = "";
         string item_border_color = "";
         string upcoming_bg_color = "";
-        string upcoming_fg_color = ""; 
+        string upcoming_fg_color = "";
         string selected_color = "";
         string card_bg_color = "";
 
@@ -330,6 +340,8 @@ public class Util : GLib.Object {
             @define-color upcoming_fg_color %s;
             @define-color selected_color %s;
             @define-color card_bg_color %s;
+            @define-color accent_color %s;
+            @define-color accent_bg_color %s;
         """.printf (
             window_bg_color,
             popover_bg_color,
@@ -338,7 +350,9 @@ public class Util : GLib.Object {
             upcoming_bg_color,
             upcoming_fg_color,
             selected_color,
-            card_bg_color
+            card_bg_color,
+            accent_color,
+            accent_color
         );
 
         var provider = new Gtk.CssProvider ();

--- a/data/io.github.alainm23.planify.gschema.xml
+++ b/data/io.github.alainm23.planify.gschema.xml
@@ -323,6 +323,12 @@
             <description>Configure when automatic reminders are triggered - at due time, before due time, or custom intervals</description>
         </key>
 
+        <key name="use-system-accent" type="b">
+            <default>true</default>
+            <summary>Use system accent color</summary>
+            <description>Use the system-wide accent color instead of the default blue accent color</description>
+        </key>
+
         <key name="font-scale" type="d">
             <default>1</default>
             <summary>Font scale</summary>

--- a/src/Dialogs/Preferences/Pages/Appearance.vala
+++ b/src/Dialogs/Preferences/Pages/Appearance.vala
@@ -21,6 +21,7 @@
 
 public class Dialogs.Preferences.Pages.Appearance : Dialogs.Preferences.Pages.BasePage {
     private Gtk.Switch system_appearance_switch;
+    private Gtk.Switch system_accent_switch;
     private Adw.ActionRow light_row;
     private Adw.ActionRow dark_row;
     private Adw.ActionRow blue_row;
@@ -57,10 +58,26 @@ public class Dialogs.Preferences.Pages.Appearance : Dialogs.Preferences.Pages.Ba
         system_appearance_row.set_activatable_widget (system_appearance_switch);
         system_appearance_row.add_suffix (system_appearance_switch);
 
+        system_accent_switch = new Gtk.Switch () {
+            valign = Gtk.Align.CENTER,
+            active = Services.Settings.get_default ().settings.get_boolean ("use-system-accent")
+        };
+
+        var system_accent_row = new Adw.ActionRow () {
+            title = _("Use System Accent Color")
+        };
+
+        system_accent_row.add_prefix (new Gtk.Image.from_icon_name ("color-symbolic") {
+            pixel_size = 16
+        });
+        system_accent_row.set_activatable_widget (system_accent_switch);
+        system_accent_row.add_suffix (system_accent_switch);
+
         var system_appearance_group = new Adw.PreferencesGroup () {
             title = _("Select theme")
         };
         system_appearance_group.add (system_appearance_row);
+        system_appearance_group.add (system_accent_row);
 
         light_radio = new Gtk.CheckButton () {
             valign = CENTER
@@ -181,8 +198,13 @@ public class Dialogs.Preferences.Pages.Appearance : Dialogs.Preferences.Pages.Ba
 
         signal_map[system_appearance_switch.notify["active"].connect (() => {
             Services.Settings.get_default ().settings.set_boolean ("system-appearance",
-                                                                   system_appearance_switch.active);
+                                                                    system_appearance_switch.active);
         })] = system_appearance_switch;
+
+        signal_map[system_accent_switch.notify["active"].connect (() => {
+            Services.Settings.get_default ().settings.set_boolean ("use-system-accent",
+                                                                    system_accent_switch.active);
+        })] = system_accent_switch;
 
         signal_map[light_radio.notify["active"].connect (() => {
             if (light_radio.active) {
@@ -220,6 +242,9 @@ public class Dialogs.Preferences.Pages.Appearance : Dialogs.Preferences.Pages.Ba
 
         signal_map[Services.Settings.get_default ().settings.changed["system-appearance"].connect (verify_theme)] = Services.Settings.get_default ();
         signal_map[Services.Settings.get_default ().settings.changed["dark-mode"].connect (verify_theme)] = Services.Settings.get_default ();
+        signal_map[Services.Settings.get_default ().settings.changed["use-system-accent"].connect (() => {
+            Util.get_default ().update_theme ();
+        })] = Services.Settings.get_default ();
 
         destroy.connect (() => {
             clean_up ();

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -249,6 +249,10 @@ public class MainWindow : Adw.ApplicationWindow {
             }
         });
 
+        Adw.StyleManager.get_default ().notify["accent-color"].connect (() => {
+            Util.get_default ().update_theme ();
+        });
+
         Services.Settings.get_default ().settings.changed["system-appearance"].connect (() => {
             Services.Settings.get_default ().settings.set_boolean (
                 "dark-mode",


### PR DESCRIPTION
Toggle uses system accent color instead of default blue which is also a fallback for accent color which can be used when it is used under DE or WM which doesn't support accent color