### PR TITLE
fix: Calendar events not updated when kept open over midnight

### DIFF
--- a/src/Views/Scheduled/Scheduled.vala
+++ b/src/Views/Scheduled/Scheduled.vala
@@ -165,6 +165,16 @@ public class Views.Scheduled.Scheduled : Adw.Bin {
             prepare_new_item ();
         })] = magic_button;
 
+        signal_map[Services.EventBus.get_default ().day_changed.connect (() => {
+            foreach (var row in Util.get_default ().get_children (listbox)) {
+                if (row is Views.Scheduled.ScheduledSection) {
+                    ((Views.Scheduled.ScheduledSection) row).clean_up ();
+                }
+                listbox.remove (row);
+            }
+            add_days ();
+        })] = Services.EventBus.get_default ();
+
         signal_map[scrolled_window.vadjustment.value_changed.connect (() => {
             headerbar.revealer_title_box (scrolled_window.vadjustment.value >= Constants.HEADERBAR_TITLE_SCROLL_THRESHOLD);
         })] = scrolled_window.vadjustment;

--- a/src/Views/Today.vala
+++ b/src/Views/Today.vala
@@ -362,9 +362,9 @@ public class Views.Today : Adw.Bin {
         })] = magic_button;
 
         #if WITH_EVOLUTION
-        signal_map[event_list.change.connect (() => {
+        event_list.change.connect (() => {
             event_list_revealer.reveal_child = event_list.has_items;
-        })] = event_list;
+        });
         #endif
 
         signal_map[Services.Settings.get_default ().settings.changed["today-sort-order"].connect (() => {

--- a/src/Views/Today.vala
+++ b/src/Views/Today.vala
@@ -315,6 +315,9 @@ public class Views.Today : Adw.Bin {
             date = new GLib.DateTime.now_local ();
             update_today_label ();
             add_today_items ();
+            #if WITH_EVOLUTION
+            event_list.refresh (date);
+            #endif
         })] = Services.EventBus.get_default ();
 
         signal_map[Services.Store.instance ().item_added.connect (valid_add_item)] = Services.Store.instance ();

--- a/src/Widgets/EventsList.vala
+++ b/src/Widgets/EventsList.vala
@@ -20,8 +20,8 @@
  */
 
 public class Widgets.EventsList : Adw.Bin {
-    public GLib.DateTime start_date { get; construct; }
-    public GLib.DateTime end_date { get; construct; }
+    public GLib.DateTime start_date { get; set; }
+    public GLib.DateTime end_date { get; set; }
 
     public bool is_day { get; construct; }
     public bool is_month { get; construct; }
@@ -243,6 +243,32 @@ public class Widgets.EventsList : Adw.Bin {
         var event_end_day = new GLib.DateTime.local (event_end.get_year (), event_end.get_month (), event_end.get_day_of_month (), 23, 59, 59);
         
         return event_start_day.compare (range_end) <= 0 && event_end_day.compare (range_start) >= 0;
+    }
+
+    public void refresh (GLib.DateTime new_start_date, GLib.DateTime? new_end_date = null) {
+        // Update dates
+        start_date = new_start_date;
+        end_date = new_end_date ?? new_start_date;
+
+        // Clean current events
+        foreach (var row in Util.get_default ().get_children (listbox)) {
+            ((Widgets.EventRow) row).clean_up ();
+            listbox.remove (row);
+        }
+        event_hashmap.clear ();
+
+        // Disconnect old model signals
+        foreach (var entry in signal_map.entries.to_array ()) {
+            if (entry.value == event_model) {
+                event_model.disconnect (entry.key);
+                signal_map.unset (entry.key);
+            }
+        }
+
+        // Recreate model with new date
+        event_model = new Services.CalendarEvents (start_date);
+        add_events ();
+        change ();
     }
 
     public void clean_up () {

--- a/src/Widgets/EventsList.vala
+++ b/src/Widgets/EventsList.vala
@@ -20,8 +20,8 @@
  */
 
 public class Widgets.EventsList : Adw.Bin {
-    public GLib.DateTime start_date { get; set; }
-    public GLib.DateTime end_date { get; set; }
+    public GLib.DateTime start_date { get; construct; }
+    public GLib.DateTime end_date { get; construct; }
 
     public bool is_day { get; construct; }
     public bool is_month { get; construct; }
@@ -32,6 +32,9 @@ public class Widgets.EventsList : Adw.Bin {
 
     private Gee.HashMap<string, Widgets.EventRow> event_hashmap;
     private Services.CalendarEvents event_model;
+
+    private GLib.DateTime current_start_date;
+    private GLib.DateTime current_end_date;
 
     public signal void change ();
 
@@ -78,7 +81,9 @@ public class Widgets.EventsList : Adw.Bin {
     }
 
     construct {
-        event_model = new Services.CalendarEvents (start_date);
+        current_start_date = start_date;
+        current_end_date = end_date;
+        event_model = new Services.CalendarEvents (current_start_date);
         event_hashmap = new Gee.HashMap<string, Widgets.EventRow> ();
 
         listbox = new Gtk.ListBox () {
@@ -125,11 +130,11 @@ public class Widgets.EventsList : Adw.Bin {
     private void add_event_model (E.Source source, Gee.Collection<ECal.Component> components) {
         foreach (ECal.Component ? component in components) {
             if (is_day) {
-                if (CalendarEventsUtil.calcomp_is_on_day (component, start_date)) {
+                if (CalendarEventsUtil.calcomp_is_on_day (component, current_start_date)) {
                     add_row_event (component, source);
                 }
             } else if (is_month) {
-                if (CalendarEventsUtil.calcomp_is_on_month (component, start_date)) {
+                if (CalendarEventsUtil.calcomp_is_on_month (component, current_start_date)) {
                     add_row_event (component, source);
                 }
             } else if (is_range) {
@@ -145,7 +150,7 @@ public class Widgets.EventsList : Adw.Bin {
         var event_uid = ical.get_uid ();
         if (!event_hashmap.has_key (event_uid)) {
             bool show_date = is_month || is_range;
-            GLib.DateTime? display_date = start_date;
+            GLib.DateTime? display_date = current_start_date;
             
             event_hashmap[event_uid] = new Widgets.EventRow (ical, source, show_date, display_date);
             listbox.append (event_hashmap[event_uid]);
@@ -161,9 +166,9 @@ public class Widgets.EventsList : Adw.Bin {
             bool in_range = false;
 
             if (is_day) {
-                in_range = CalendarEventsUtil.calcomp_is_on_day (component, start_date);
+                in_range = CalendarEventsUtil.calcomp_is_on_day (component, current_start_date);
             } else if (is_month) {
-                in_range = CalendarEventsUtil.calcomp_is_on_month (component, start_date);
+                in_range = CalendarEventsUtil.calcomp_is_on_month (component, current_start_date);
             } else if (is_range) {
                 in_range = event_overlaps_range (component);
             }
@@ -237,8 +242,8 @@ public class Widgets.EventsList : Adw.Bin {
         var event_start = CalendarEventsUtil.ical_to_date_time (start_time);
         var event_end = CalendarEventsUtil.ical_to_date_time (end_time);
         
-        var range_start = new GLib.DateTime.local (start_date.get_year (), start_date.get_month (), start_date.get_day_of_month (), 0, 0, 0);
-        var range_end = new GLib.DateTime.local (end_date.get_year (), end_date.get_month (), end_date.get_day_of_month (), 23, 59, 59);
+        var range_start = new GLib.DateTime.local (current_start_date.get_year (), current_start_date.get_month (), current_start_date.get_day_of_month (), 0, 0, 0);
+        var range_end = new GLib.DateTime.local (current_end_date.get_year (), current_end_date.get_month (), current_end_date.get_day_of_month (), 23, 59, 59);
         var event_start_day = new GLib.DateTime.local (event_start.get_year (), event_start.get_month (), event_start.get_day_of_month (), 0, 0, 0);
         var event_end_day = new GLib.DateTime.local (event_end.get_year (), event_end.get_month (), event_end.get_day_of_month (), 23, 59, 59);
         
@@ -247,8 +252,8 @@ public class Widgets.EventsList : Adw.Bin {
 
     public void refresh (GLib.DateTime new_start_date, GLib.DateTime? new_end_date = null) {
         // Update dates
-        start_date = new_start_date;
-        end_date = new_end_date ?? new_start_date;
+        current_start_date = new_start_date;
+        current_end_date = new_end_date ?? new_start_date;
 
         // Clean current events
         foreach (var row in Util.get_default ().get_children (listbox)) {
@@ -266,7 +271,7 @@ public class Widgets.EventsList : Adw.Bin {
         }
 
         // Recreate model with new date
-        event_model = new Services.CalendarEvents (start_date);
+        event_model = new Services.CalendarEvents (current_start_date);
         add_events ();
         change ();
     }


### PR DESCRIPTION
When Planify was kept open past midnight, the calendar events widget in the Today view would still show the previous day's events instead of updating to the current day.

Fixes: #2441