### PR TITLE
remove css

### DIFF
--- a/core/Widgets/PriorityButton.vala
+++ b/core/Widgets/PriorityButton.vala
@@ -206,6 +206,8 @@ public class Widgets.PriorityButton : Adw.Bin {
 
     public void reset () {
         priority_image.icon_name = "flag-outline-thick-symbolic";
+        priority_image.css_classes = {};
+        Util.get_default ().set_widget_color (((ItemPriority) Constants.PRIORITY_4).get_color (), button);
     }
 
     public void animation () {


### PR DESCRIPTION
Fixes #2436

When using "Keep Adding" mode, the priority button visually retained the  previously selected priority after each task was saved. This caused users to believe the priority was still active, but the new item was actually saved with no priority.
