### PR TITLE
fix: Tasks added in wrong order when using keep adding mode

### DIFF
--- a/core/QuickAddCore.vala
+++ b/core/QuickAddCore.vala
@@ -990,6 +990,8 @@ public class Layouts.QuickAddCore : Adw.Bin {
         item.section_id = old_section_id;
         item.parent_id = old_parent_id;
 
+        position = -1;
+
         item_labels.item = item;
         label_button.source = item.project.source;
         labels_quick_picker.source = item.project.source;


### PR DESCRIPTION
When using "Keep Adding" mode, tasks were being inserted in reverse order after the first one (e.g. Task 1, Task 3, Task 2 instead of Task 1, Task 2, Task 3).