### PR TITLE
fix: prevent double sync when adding a new source

### DIFF
--- a/core/Objects/Source.vala
+++ b/core/Objects/Source.vala
@@ -127,13 +127,16 @@ public class Objects.Source : Objects.BaseObject {
         }
     }
 
-    public void run_server () {
+    public void run_server (bool skip_first_sync = false) {
         if (source_type == SourceType.LOCAL) {
             return;
         }
 
         Services.LogService.get_default ().info ("Source", "Starting sync server for source: %s".printf (display_name));
-        _run_server ();
+
+        if (!skip_first_sync) {
+            _run_server ();
+        }
 
         server_timeout = Timeout.add_seconds (15 * 60, () => {
             if (sync_server) {

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -216,7 +216,7 @@ public class MainWindow : Adw.ApplicationWindow {
 
             Services.Store.instance ().source_added.connect ((source) => {
                 if (source.sync_server) {
-                    source.run_server ();
+                    source.run_server (true);
                 }
             });
 


### PR DESCRIPTION
When a new source was connected, the sync was triggered twice — once during the connection process and again when `run_server()` was called on source_added. Fixed by adding a `skip_first_sync` parameter to `run_server()` so the periodic timer is registered without firing an immediate sync when the source has just been added.
