### PR TITLE
Support builds with libical 4

### DIFF
--- a/core/Objects/Item.vala
+++ b/core/Objects/Item.vala
@@ -1319,7 +1319,11 @@ public class Objects.Item : Objects.BaseObject {
                         }
                     }
 
+                    #if IS_LIBICAL4
                     rrule.set_by_array (ICal.RecurrenceByRule.BY_DAY, values);
+                    #else
+                    rrule.set_by_day_array (values);
+                    #endif
                 } else if (due.recurrency_type == RecurrencyType.EVERY_MONTH) {
                     rrule.set_freq (ICal.RecurrenceFrequency.MONTHLY_RECURRENCE);
                 } else if (due.recurrency_type == RecurrencyType.EVERY_YEAR) {

--- a/core/Objects/Item.vala
+++ b/core/Objects/Item.vala
@@ -26,7 +26,7 @@ public class Objects.Item : Objects.BaseObject {
     public string completed_at { get; set; default = ""; }
     public string updated_at { get; set; default = ""; }
     public string calendar_event_uid { get; set; default = ""; }
-    public string deadline_date { get; set; default = ""; }  
+    public string deadline_date { get; set; default = ""; }
 
     string _section_id = "";
     public string section_id {
@@ -36,7 +36,7 @@ public class Objects.Item : Objects.BaseObject {
             _section = null;
         }
     }
-    
+
     string _project_id = "";
     public string project_id {
         get { return _project_id; }
@@ -45,7 +45,7 @@ public class Objects.Item : Objects.BaseObject {
             _project = null;
         }
     }
-    
+
     string _parent_id = "";
     public string parent_id {
         get { return _parent_id; }
@@ -1319,7 +1319,7 @@ public class Objects.Item : Objects.BaseObject {
                         }
                     }
 
-                    rrule.set_by_day_array (values);
+                    rrule.set_by_array (ICal.RecurrenceByRule.BY_DAY, values);
                 } else if (due.recurrency_type == RecurrencyType.EVERY_MONTH) {
                     rrule.set_freq (ICal.RecurrenceFrequency.MONTHLY_RECURRENCE);
                 } else if (due.recurrency_type == RecurrencyType.EVERY_YEAR) {
@@ -1552,34 +1552,34 @@ public class Objects.Item : Objects.BaseObject {
     private async void delete_caldav () {
         loading = true;
         var caldav_client = Services.CalDAV.Core.get_default ().get_client (project.source);
-        
+
         try {
             yield delete_subitems_caldav (this, caldav_client);
-            
+
             var response = yield caldav_client.delete_item (this);
-            
+
             if (!response.status) {
                 throw new IOError.FAILED (response.error);
             }
-            
+
             Services.Store.instance ().delete_item (this);
         } catch (Error e) {
             Services.EventBus.get_default ().send_error_toast (0, e.message);
         }
-        
+
         loading = false;
     }
 
     private async void delete_subitems_caldav (Objects.Item item, Services.CalDAV.CalDAVClient caldav_client) throws Error {
         foreach (Objects.Item subitem in Services.Store.instance ().get_subitems (item)) {
             yield delete_subitems_caldav (subitem, caldav_client);
-            
+
             var response = yield caldav_client.delete_item (subitem);
 
             if (!response.status) {
                 throw new IOError.FAILED (response.error);
             }
-            
+
             Services.Store.instance ().delete_item (subitem);
         }
     }
@@ -1709,7 +1709,7 @@ public class Objects.Item : Objects.BaseObject {
         } else if (project.source_type == SourceType.TODOIST) {
             loading = true;
             sensitive = false;
-            
+
             string move_id = project.id;
             string move_type = "project_id";
             if (_section_id != "") {
@@ -1730,17 +1730,17 @@ public class Objects.Item : Objects.BaseObject {
         } else if (project.source_type == SourceType.CALDAV) {
             loading = true;
             sensitive = false;
-            
+
             move_caldav_recursive.begin (project, _section_id, notify);
         }
     }
 
     private async void move_caldav_recursive (Objects.Project project, string _section_id, bool notify = true) {
         var caldav_client = Services.CalDAV.Core.get_default ().get_client (project.source);
-        
+
         try {
             var response = yield caldav_client.move_item (this, project);
-            
+
             if (!response.status) {
                 throw new IOError.FAILED (response.error);
             }
@@ -1749,21 +1749,21 @@ public class Objects.Item : Objects.BaseObject {
             if (old_parent_id != "") {
                 parent_id = "";
                 response = yield caldav_client.add_item (this, true);
-                
+
                 if (!response.status) {
                     throw new IOError.FAILED (response.error);
                 }
 
                 Services.EventBus.get_default ().item_moved (this, project_id, section_id, old_parent_id);
             }
-            
+
             yield move_all_subitems_caldav (this, project, caldav_client);
-            
+
             _move (project.id, _section_id, notify);
         } catch (Error e) {
             Services.EventBus.get_default ().send_error_toast (0, e.message);
         }
-        
+
         loading = false;
         show_item = true;
     }
@@ -1775,7 +1775,7 @@ public class Objects.Item : Objects.BaseObject {
             if (!response.status) {
                 throw new IOError.FAILED (response.error);
             }
-            
+
             yield move_all_subitems_caldav (subitem, project, caldav_client);
         }
     }
@@ -1792,7 +1792,7 @@ public class Objects.Item : Objects.BaseObject {
         Services.Store.instance ().move_item (this, old_project_id, old_section_id, old_parent_id);
         Services.EventBus.get_default ().item_moved (this, old_project_id, old_section_id, old_parent_id);
         Services.EventBus.get_default ().drag_n_drop_active (old_project_id, false);
-        
+
         if (notify) {
             Services.EventBus.get_default ().send_toast (
                 Util.get_default ().create_toast (_("Moved to %s".printf (project.name)))

--- a/core/Utils/Datetime.vala
+++ b/core/Utils/Datetime.vala
@@ -224,7 +224,7 @@ public class Utils.Datetime {
 
         if (due.recurrency_type == RecurrencyType.EVERY_WEEK) {
             string recurrency_weeks = "";
-            GLib.Array<short> day_array = recurrence.get_by_day_array ();
+            GLib.Array<short> day_array = recurrence.get_by_array (ICal.RecurrenceByRule.BY_DAY);
 
             if (check_by_day ("1", day_array)) {
                 recurrency_weeks += "7,";

--- a/core/Utils/Datetime.vala
+++ b/core/Utils/Datetime.vala
@@ -224,7 +224,11 @@ public class Utils.Datetime {
 
         if (due.recurrency_type == RecurrencyType.EVERY_WEEK) {
             string recurrency_weeks = "";
+            #if IS_LIBICAL4
             GLib.Array<short> day_array = recurrence.get_by_array (ICal.RecurrenceByRule.BY_DAY);
+            #else
+            GLib.Array<short> day_array = recurrence.get_by_day_array ();
+            #endif
 
             if (check_by_day ("1", day_array)) {
                 recurrency_weeks += "7,";

--- a/meson.build
+++ b/meson.build
@@ -33,30 +33,6 @@ gnome = import('gnome')
 i18n = import('i18n')
 pkgconfig = import('pkgconfig')
 
-# is this a Windows build?
-is_windows = (host_machine.system() == 'windows')
-if is_windows
-    add_project_arguments('-D', 'IS_WINDOWS', language: 'vala')
-endif
-
-# parse webkit, portal, evolution, and winconsole options
-# on Windows these are unsupported and are forced to false
-with_portal = (get_option('portal') and not is_windows)
-with_evolution = (get_option('evolution') and not is_windows)
-with_win_console = (get_option('winconsole'))
-
-# is this a Windows build?
-is_windows = (host_machine.system() == 'windows')
-if is_windows
-    add_project_arguments('-D', 'IS_WINDOWS', language: 'vala')
-endif
-
-# parse webkit, portal, evolution, and winconsole options
-# on Windows these are unsupported and are forced to false
-with_portal = (get_option('portal') and not is_windows)
-with_evolution = (get_option('evolution') and not is_windows)
-with_win_console = (get_option('winconsole'))
-
 add_global_arguments('-DGETTEXT_PACKAGE="@0@"'.format (application_id), language:'c')
 add_project_arguments('-DLIBICAL_GLIB_UNSTABLE_API=1', language: 'c')
 

--- a/meson.build
+++ b/meson.build
@@ -33,6 +33,30 @@ gnome = import('gnome')
 i18n = import('i18n')
 pkgconfig = import('pkgconfig')
 
+# is this a Windows build?
+is_windows = (host_machine.system() == 'windows')
+if is_windows
+    add_project_arguments('-D', 'IS_WINDOWS', language: 'vala')
+endif
+
+# parse webkit, portal, evolution, and winconsole options
+# on Windows these are unsupported and are forced to false
+with_portal = (get_option('portal') and not is_windows)
+with_evolution = (get_option('evolution') and not is_windows)
+with_win_console = (get_option('winconsole'))
+
+# is this a Windows build?
+is_windows = (host_machine.system() == 'windows')
+if is_windows
+    add_project_arguments('-D', 'IS_WINDOWS', language: 'vala')
+endif
+
+# parse webkit, portal, evolution, and winconsole options
+# on Windows these are unsupported and are forced to false
+with_portal = (get_option('portal') and not is_windows)
+with_evolution = (get_option('evolution') and not is_windows)
+with_win_console = (get_option('winconsole'))
+
 add_global_arguments('-DGETTEXT_PACKAGE="@0@"'.format (application_id), language:'c')
 add_project_arguments('-DLIBICAL_GLIB_UNSTABLE_API=1', language: 'c')
 
@@ -51,6 +75,12 @@ libspelling = dependency('libspelling-1', required: get_option('spelling'))
 gtksourceview_dep = dependency('gtksourceview-5')
 m_dep = meson.get_compiler('c').find_library('m', required : false)
 icu_uc_dep = dependency('icu-uc')
+
+# is libical version 4 or higher?
+is_libical4 = libical_dep.version().version_compare('>= 4.0.0')
+if is_libical4
+  add_project_arguments('-D', 'IS_LIBICAL4', language: 'vala')
+endif
 
 if icu_uc_dep.found ()
   add_project_arguments(['--vapidir=' + meson.project_source_root() / 'vapi'], language: 'vala')


### PR DESCRIPTION
libical version 4 removed the `get_by_day_array` and `set_by_day_array` methods, which were replaced with `get_by_array` and `set_by_array` with an `ICal.RecurrenceByRule.BY_DAY` parameter.

See libical documentation: [Migrating to version 4](https://github.com/libical/libical/blob/4.0/docs/MigrationGuide_to_4.md)

Arch-based Linux distributions have already switched to libical 4, which broke new builds. But other distros (and Windows MSYS2) are still using libical 3.

This change adds conditional logic so the correct method is used whether it's building against libical 3 or 4.