### PR TITLE
fix: update libical API to 4.0.0 (fixes #2463)

### DIFF
--- a/core/Objects/Item.vala
+++ b/core/Objects/Item.vala
@@ -1319,7 +1319,7 @@ public class Objects.Item : Objects.BaseObject {
                         }
                     }
 
-                    rrule.set_by_day_array (values);
+                    rrule.set_by_array (ICal.RecurrenceByRule.BY_DAY, values);
                 } else if (due.recurrency_type == RecurrencyType.EVERY_MONTH) {
                     rrule.set_freq (ICal.RecurrenceFrequency.MONTHLY_RECURRENCE);
                 } else if (due.recurrency_type == RecurrencyType.EVERY_YEAR) {

--- a/core/Utils/Datetime.vala
+++ b/core/Utils/Datetime.vala
@@ -224,7 +224,7 @@ public class Utils.Datetime {
 
         if (due.recurrency_type == RecurrencyType.EVERY_WEEK) {
             string recurrency_weeks = "";
-            GLib.Array<short> day_array = recurrence.get_by_day_array ();
+            GLib.Array<short> day_array = recurrence.get_by_array (ICal.RecurrenceByRule.BY_DAY);
 
             if (check_by_day ("1", day_array)) {
                 recurrency_weeks += "7,";


### PR DESCRIPTION
This PR fixes the build failure caused by the recent `libical-glib` 4.0.0 update on rolling-release distros like Arch Linux.

In version 4.0.0, the `ICal.Recurrence` API removed `get_by_day_array` and `set_by_day_array`, consolidating them into generic methods. This patch updates the code to use the new `get_by_array(ICal.RecurrenceByRule.BY_DAY)` and `set_by_array` syntax.

**Resolves #2463**