### PR TITLE
fix: labels not being removed when deselected in multi-select toolbar

### DIFF
--- a/core/Widgets/LabelPicker/LabelsPickerCore.vala
+++ b/core/Widgets/LabelPicker/LabelsPickerCore.vala
@@ -37,8 +37,14 @@ public class Widgets.LabelsPickerCore : Adw.Bin {
         set {
             picked.clear ();
 
+            foreach (var entry in labels_widgets_map.entries) {
+                entry.value.active = false;
+            }
+
             foreach (Objects.Label label in value) {
-                labels_widgets_map[label.id].active = true;
+                if (labels_widgets_map.has_key (label.id)) {
+                    labels_widgets_map[label.id].active = true;
+                }
                 picked[label.id] = label;
             }
         }

--- a/src/Widgets/MultiSelectToolbar.vala
+++ b/src/Widgets/MultiSelectToolbar.vala
@@ -34,6 +34,7 @@ public class Widgets.MultiSelectToolbar : Adw.Bin {
 
     public Gee.HashMap<string, Layouts.ItemBase> items_selected = new Gee.HashMap<string, Layouts.ItemBase> ();
     public Gee.HashMap<string, Objects.Label> labels = new Gee.HashMap<string, Objects.Label> ();
+    private Gee.HashMap<string, Objects.Label> _initial_labels = new Gee.HashMap<string, Objects.Label> ();
     public signal void closed ();
 
     public MultiSelectToolbar (Objects.Project project) {
@@ -162,10 +163,17 @@ public class Widgets.MultiSelectToolbar : Adw.Bin {
             dialog.present (Planify._instance.main_window);
         });
 
-        label_button.labels_changed.connect ((labels) => {
-            if (labels.size > 0) {
-                set_labels (labels);
+        label_button.picker_opened.connect ((active) => {
+            if (active) {
+                _initial_labels = new Gee.HashMap<string, Objects.Label> ();
+                foreach (var entry in labels.entries) {
+                    _initial_labels[entry.key] = entry.value;
+                }
             }
+        });
+
+        label_button.labels_changed.connect ((new_labels) => {
+            apply_label_changes (new_labels);
         });
 
         priority_button.changed.connect ((priority) => {
@@ -216,6 +224,45 @@ public class Widgets.MultiSelectToolbar : Adw.Bin {
 
                 objects.add (item);
             }
+        }
+
+        update_items (objects);
+    }
+
+    private void apply_label_changes (Gee.HashMap<string, Objects.Label> new_labels) {
+        // Labels added by the user
+        var added = new Gee.HashMap<string, Objects.Label> ();
+        foreach (var entry in new_labels.entries) {
+            if (!_initial_labels.has_key (entry.key)) {
+                added[entry.key] = entry.value;
+            }
+        }
+
+        // Labels removed by the user
+        var removed = new Gee.ArrayList<string> ();
+        foreach (var entry in _initial_labels.entries) {
+            if (!new_labels.has_key (entry.key)) {
+                removed.add (entry.key);
+            }
+        }
+
+        if (added.size == 0 && removed.size == 0) {
+            return;
+        }
+
+        Gee.ArrayList<Objects.Item> objects = new Gee.ArrayList<Objects.Item> ();
+        foreach (string key in items_selected.keys) {
+            var item = items_selected[key].item;
+
+            foreach (var entry in added.entries) {
+                item.add_label_if_not_exists (entry.value);
+            }
+
+            foreach (var label_id in removed) {
+                item.delete_item_label (label_id);
+            }
+
+            objects.add (item);
         }
 
         update_items (objects);

--- a/src/Widgets/MultiSelectToolbar.vala
+++ b/src/Widgets/MultiSelectToolbar.vala
@@ -401,16 +401,11 @@ public class Widgets.MultiSelectToolbar : Adw.Bin {
     }
 
     private void check_labels (Objects.Item item, bool active) {
-        if (active) {
-            foreach (Objects.Label label in item.get_labels_list ()) {
+        labels.clear ();
+        foreach (var entry in items_selected.entries) {
+            foreach (Objects.Label label in entry.value.item.get_labels_list ()) {
                 if (!labels.has_key (label.id)) {
                     labels[label.id] = label;
-                }
-            }
-        } else {
-            foreach (Objects.Label label in item.get_labels_list ()) {
-                if (labels.has_key (label.id)) {
-                    labels.unset (label.id);
                 }
             }
         }


### PR DESCRIPTION
When using the multi-select toolbar to manage labels across multiple tasks, deselecting a label had no effect. Also, opening the label picker and closing it without changes would incorrectly assign labels from one task to others that didn't have them.

Fixed by tracking the initial label state when the picker opens and applying only the changes the user explicitly made — adding or removing labels — instead of overwriting the full label state of every selected task.

Fixes: #2154 #2153
 