### PR TITLE
fix: improve accessibility for keyboard navigation and screen readers

### DIFF
--- a/core/Widgets/Calendar/CalendarScroll.vala
+++ b/core/Widgets/Calendar/CalendarScroll.vala
@@ -344,6 +344,8 @@ public class Widgets.Calendar.CalendarScroll : Adw.Bin {
                 css_classes = { "flat", "calendar-day" }
             };
 
+            button.update_property (Gtk.AccessibleProperty.LABEL, date.format (_("%A, %B %e, %Y")), -1);
+
             if (is_today) {
                 button.add_css_class ("today");
             } else if (is_past) {

--- a/core/Widgets/Calendar/CalendarWeek.vala
+++ b/core/Widgets/Calendar/CalendarWeek.vala
@@ -52,6 +52,15 @@ public class Widgets.Calendar.CalendarWeek : Gtk.Box {
             new Gtk.Label (_("Sa"))
         };
 
+        string[] full_day_names = {
+            _("Sunday"), _("Monday"), _("Tuesday"), _("Wednesday"),
+            _("Thursday"), _("Friday"), _("Saturday")
+        };
+
+        for (int i = 0; i < day_labels.length; i++) {
+            day_labels[i].update_property (Gtk.AccessibleProperty.LABEL, full_day_names[i], -1);
+        }
+
         foreach (var label in day_labels) {
             label.add_css_class ("dimmed");
             append (label);

--- a/core/Widgets/DateTimePicker/DateTimePicker.vala
+++ b/core/Widgets/DateTimePicker/DateTimePicker.vala
@@ -720,7 +720,8 @@ public class Widgets.DateTimePicker.DateTimePicker : Gtk.Popover {
             margin_start = 6,
             margin_top = 6,
             margin_bottom = 6,
-            halign = START
+            halign = START,
+            tooltip_text = _("Back")
         };
 
         calendar_scroll_view = new Widgets.Calendar.CalendarScroll () {
@@ -754,7 +755,8 @@ public class Widgets.DateTimePicker.DateTimePicker : Gtk.Popover {
             margin_start = 6,
             margin_top = 6,
             margin_bottom = 6,
-            halign = START
+            halign = START,
+            tooltip_text = _("Back")
         };
 
         var toolbar_view = new Adw.ToolbarView () {

--- a/core/Widgets/MarkdownEditor.vala
+++ b/core/Widgets/MarkdownEditor.vala
@@ -96,6 +96,7 @@ public class Widgets.MarkdownEditor : Adw.Bin {
             wrap_mode = Gtk.WrapMode.WORD,
             accepts_tab = false
         };
+        text_view.update_property (Gtk.AccessibleProperty.LABEL, _("Task description"), -1);
         text_view.remove_css_class ("view");
         
         create_text_tags ();

--- a/data/resources/stylesheet/stylesheet.css
+++ b/data/resources/stylesheet/stylesheet.css
@@ -674,6 +674,12 @@ checkbutton.theme-selector radio:checked {
     padding: 6px;
 }
 
+.magic-button:focus {
+    outline: 2px solid @accent_color;
+    outline-offset: 1px;
+    border-radius: 50%;
+}
+
 .add-button:hover image,
 .magic-button:hover image {
     transform: rotate(90deg);

--- a/src/Layouts/ItemRow.vala
+++ b/src/Layouts/ItemRow.vala
@@ -1959,7 +1959,8 @@ public class Layouts.ItemRow : Layouts.ItemBase {
         markdown_editor.is_editable = !item.completed && !item.project.is_deck;
 
         markdown_editor.set_text (item.description);
-        markdown_editor.text_view.update_property (Gtk.AccessibleProperty.LABEL, item.description, -1);
+        markdown_editor.text_view.update_property (Gtk.AccessibleProperty.LABEL, _("Task description"), -1);
+        markdown_editor.text_view.update_property (Gtk.AccessibleProperty.VALUE_TEXT, item.description, -1);
         markdown_revealer.child = markdown_editor;
         markdown_revealer.reveal_child = true;
 

--- a/src/Widgets/MagicButton.vala
+++ b/src/Widgets/MagicButton.vala
@@ -47,7 +47,11 @@ public class Widgets.MagicButton : Adw.Bin {
             height_request = 48,
             width_request = 48,
             css_classes = { "suggested-action", "magic-button" },
-            tooltip_text = _("Add Task")
+            tooltip_text = _("Add Task"),
+            margin_top = 3,
+            margin_start = 3,
+            margin_end = 3,
+            margin_bottom = 3
         };
 
         main_revealer = new Gtk.Revealer () {

--- a/src/Widgets/ScrolledWindow.vala
+++ b/src/Widgets/ScrolledWindow.vala
@@ -61,7 +61,8 @@ public class Widgets.ScrolledWindow : Adw.Bin {
             vscrollbar_policy = orientation == Gtk.Orientation.VERTICAL ? Gtk.PolicyType.AUTOMATIC : Gtk.PolicyType.NEVER,
             child = widget,
             propagate_natural_height = true,
-            propagate_natural_width = true
+            propagate_natural_width = true,
+            focusable = false
         };
 
         drop_motion_ctrl = new Gtk.DropControllerMotion ();


### PR DESCRIPTION
Addresses several accessibility issues reported during GNOME Circle review:

- Fixed ScrolledWindow stealing Tab focus before content — set focusable=false
  so keyboard navigation skips directly to the content
- Fixed MagicButton missing focus border — added circular outline style
  using accent color on :focus
- Fixed task description only reading first line in Orca — set proper
  accessible LABEL and VALUE_TEXT on the MarkdownEditor text view
- Fixed calendar arrow buttons reading as "button" in Orca — added
  tooltip_text to back buttons in DateTimePicker
- Fixed calendar day cells only reading a number in Orca — added full
  date format label (e.g. "Monday, January 13, 2025") to CalendarDay
  and CalendarScroll DayItem
- Fixed day-of-week headers reading abbreviations in Orca — added full
  day name accessible labels to CalendarWeek labels
