### PR TITLE
fix: cursor no longer jumps to end when editing tasks in Today and Scheduled views

### DIFF
--- a/src/Views/Scheduled/ScheduledDay.vala
+++ b/src/Views/Scheduled/ScheduledDay.vala
@@ -157,7 +157,7 @@ public class Views.Scheduled.ScheduledDay : Views.Scheduled.ScheduledSection {
     }
 
     protected override void valid_update_item (Objects.Item item, string? update_id = null) {
-        if (items.has_key (item.id)) {
+        if (items.has_key (item.id) && items[item.id].update_id != update_id) {
             items[item.id].update_request ();
         }
 

--- a/src/Views/Scheduled/ScheduledMonth.vala
+++ b/src/Views/Scheduled/ScheduledMonth.vala
@@ -126,7 +126,7 @@ public class Views.Scheduled.ScheduledMonth : Views.Scheduled.ScheduledSection {
 #endif
 
     protected override void valid_update_item (Objects.Item item, string? update_id = null) {
-        if (items.has_key (item.id)) {
+        if (items.has_key (item.id) && items[item.id].update_id != update_id) {
             items[item.id].update_request ();
         }
 

--- a/src/Views/Scheduled/ScheduledOverdue.vala
+++ b/src/Views/Scheduled/ScheduledOverdue.vala
@@ -165,7 +165,7 @@ public class Views.Scheduled.ScheduledOverdue : Views.Scheduled.ScheduledSection
     }
 
     protected override void valid_update_item (Objects.Item item, string? update_id = null) {
-        if (items.has_key (item.id)) {
+        if (items.has_key (item.id) && items[item.id].update_id != update_id) {
             items[item.id].update_request ();
         }
 

--- a/src/Views/Scheduled/ScheduledRange.vala
+++ b/src/Views/Scheduled/ScheduledRange.vala
@@ -125,7 +125,7 @@ public class Views.Scheduled.ScheduledRange : Views.Scheduled.ScheduledSection {
     }
 
     protected override void valid_update_item (Objects.Item item, string? update_id = null) {
-        if (items.has_key (item.id)) {
+        if (items.has_key (item.id) && items[item.id].update_id != update_id) {
             items[item.id].update_request ();
         }
 

--- a/src/Views/Scheduled/ScheduledSection.vala
+++ b/src/Views/Scheduled/ScheduledSection.vala
@@ -158,7 +158,7 @@ public abstract class Views.Scheduled.ScheduledSection : Gtk.ListBoxRow {
     }
 
     protected virtual void valid_update_item (Objects.Item item, string? update_id = null) {
-        if (items.has_key (item.id)) {
+        if (items.has_key (item.id) && items[item.id].update_id != update_id) {
             items[item.id].update_request ();
         }
 

--- a/src/Views/Today.vala
+++ b/src/Views/Today.vala
@@ -609,11 +609,15 @@ public class Views.Today : Adw.Bin {
 
     private void valid_update_item (Objects.Item item, string update_id) {
         if (items.has_key (item.id)) {
-            items[item.id].update_request ();
+            if (items[item.id].update_id != update_id) {
+                items[item.id].update_request ();
+            }
         }
 
         if (overdue_items.has_key (item.id)) {
-            overdue_items[item.id].update_request ();
+            if (overdue_items[item.id].update_id != update_id) {
+                overdue_items[item.id].update_request ();
+            }
         }
 
         if (items.has_key (item.id) && !item.has_due && !item.has_deadline) {


### PR DESCRIPTION
When editing a task title or description in the Today or Scheduled views, the cursor would unexpectedly jump to the end of the text a few seconds after stopping to type. This made it frustrating to edit text in the middle of a task.

The root cause was that these views were reloading the full content of the task widget every time an update was saved, even when the update originated from that same widget. The fix applies the same pattern already used in the Project view — skipping the reload when the update came from the widget itself, so the cursor stays exactly where the user left it.

Fixes: #2220
