### PR TITLE
fix: prevent long text from breaking sidebar width in HeaderItem

### DIFF
--- a/core/Layouts/HeaderItem.vala
+++ b/core/Layouts/HeaderItem.vala
@@ -180,6 +180,7 @@ public class Layouts.HeaderItem : Adw.Bin {
 
         subheader_label = new Gtk.Label (null) {
             halign = Gtk.Align.START,
+            ellipsize = Pango.EllipsizeMode.END,
             css_classes = { "caption", "dimmed" }
         };
 
@@ -207,7 +208,7 @@ public class Layouts.HeaderItem : Adw.Bin {
             halign = END
         };
 
-        var header_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0) {
+        var header_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 6) {
             hexpand = true,
             margin_start = 6,
             margin_end = 6

--- a/src/Layouts/Sidebar.vala
+++ b/src/Layouts/Sidebar.vala
@@ -303,7 +303,8 @@ public class Layouts.Sidebar : Adw.Bin {
             margin_end = 3,
             margin_top = 3,
             margin_bottom = 3,
-            min_children_per_line = 2
+            min_children_per_line = 2,
+            max_children_per_line = 2,
         };
 
         flowbox.append (new Layouts.FilterPaneChild (Objects.Filters.Inbox.get_default ()));


### PR DESCRIPTION
Fixes: #2472

Added `ellipsize` to `subheader_label` in HeaderItem to prevent long text from expanding the sidebar beyond its intended width.
