### PR TITLE
fix: improve Todoist offline queue reliability

### DIFF
--- a/core/Objects/Queue.vala
+++ b/core/Objects/Queue.vala
@@ -25,5 +25,6 @@ public class Objects.Queue : GLib.Object {
     public string temp_id { get; set; default = ""; }
     public string query { get; set; default = ""; }
     public string args { get; set; default = ""; }
+    public string source_id { get; set; default = ""; }
     public string date_added { get; set; default = new GLib.DateTime.now_local ().to_string (); }
 }

--- a/core/Services/Database.vala
+++ b/core/Services/Database.vala
@@ -137,6 +137,7 @@ public class Services.Database : GLib.Object {
         table_columns["Queue"].add ("query");
         table_columns["Queue"].add ("temp_id");
         table_columns["Queue"].add ("args");
+        table_columns["Queue"].add ("source_id");
         table_columns["Queue"].add ("date_added");
 
         table_columns["Reminders"] = new Gee.ArrayList<string> ();
@@ -322,6 +323,7 @@ public class Services.Database : GLib.Object {
                 query      TEXT,
                 temp_id    TEXT,
                 args       TEXT,
+                source_id  TEXT,
                 date_added TEXT
             );
         """;
@@ -693,6 +695,7 @@ public class Services.Database : GLib.Object {
          */
         add_text_column ("Projects", "markdown_setting", MarkdownSetting.GLOBAL_DEFAULT.to_string ());
         add_text_column ("Sections", "extra_data", "");
+        add_text_column ("Queue", "source_id", "");
     }
 
     public void clear_database () {
@@ -1961,8 +1964,8 @@ public class Services.Database : GLib.Object {
         Sqlite.Statement stmt;
 
         sql = """
-            INSERT OR IGNORE INTO Queue (uuid, object_id, query, temp_id, args, date_added)
-            VALUES ($uuid, $object_id, $query, $temp_id, $args, $date_added);
+            INSERT OR IGNORE INTO Queue (uuid, object_id, query, temp_id, args, source_id, date_added)
+            VALUES ($uuid, $object_id, $query, $temp_id, $args, $source_id, $date_added);
         """;
 
         db.prepare_v2 (sql, sql.length, out stmt);
@@ -1971,6 +1974,7 @@ public class Services.Database : GLib.Object {
         set_parameter_str (stmt, "$query", queue.query);
         set_parameter_str (stmt, "$temp_id", queue.temp_id);
         set_parameter_str (stmt, "$args", queue.args);
+        set_parameter_str (stmt, "$source_id", queue.source_id);
         set_parameter_str (stmt, "$date_added", queue.date_added);
 
         if (stmt.step () != Sqlite.DONE) {
@@ -1978,15 +1982,22 @@ public class Services.Database : GLib.Object {
         }
     }
 
-    public Gee.ArrayList<Objects.Queue> get_all_queue () {
+    public Gee.ArrayList<Objects.Queue> get_all_queue (string source_id = "") {
         Gee.ArrayList<Objects.Queue> return_value = new Gee.ArrayList<Objects.Queue> ();
         Sqlite.Statement stmt;
 
-        sql = """
-            SELECT * FROM Queue ORDER BY date_added;
-        """;
-
-        db.prepare_v2 (sql, sql.length, out stmt);
+        if (source_id != "") {
+            sql = """
+                SELECT * FROM Queue WHERE source_id=$source_id ORDER BY date_added;
+            """;
+            db.prepare_v2 (sql, sql.length, out stmt);
+            set_parameter_str (stmt, "$source_id", source_id);
+        } else {
+            sql = """
+                SELECT * FROM Queue ORDER BY date_added;
+            """;
+            db.prepare_v2 (sql, sql.length, out stmt);
+        }
 
         while (stmt.step () == Sqlite.ROW) {
             return_value.add (_fill_queue (stmt));
@@ -2002,7 +2013,8 @@ public class Services.Database : GLib.Object {
         return_value.query = stmt.column_text (2);
         return_value.temp_id = stmt.column_text (3);
         return_value.args = stmt.column_text (4);
-        return_value.date_added = stmt.column_text (5);
+        return_value.source_id = stmt.column_text (5);
+        return_value.date_added = stmt.column_text (6);
         return return_value;
     }
 

--- a/core/Services/Todoist/Todoist.vala
+++ b/core/Services/Todoist/Todoist.vala
@@ -242,7 +242,7 @@ public class Services.Todoist : GLib.Object {
      */
 
     public async void queue (Objects.Source source) {
-        Gee.ArrayList<Objects.Queue ?> queue_collection = Services.Database.get_default ().get_all_queue ();
+        Gee.ArrayList<Objects.Queue ?> queue_collection = Services.Database.get_default ().get_all_queue (source.id);
         if (queue_collection.size <= 0) {
             return;
         }
@@ -264,24 +264,47 @@ public class Services.Todoist : GLib.Object {
             foreach (var q in queue_collection) {
                 var uuid_member = node.get_object_member ("sync_status").get_member (q.uuid);
                 if (uuid_member.get_node_type () == Json.NodeType.VALUE) {
+                    var temp_id_mapping = node.get_object_member ("temp_id_mapping");
+
                     if (q.query == "project_add") {
-                        var id = node.get_object_member ("temp_id_mapping").get_string_member (q.temp_id);
-                        Services.Store.instance ().update_project_id (q.object_id, id);
-                        Services.Database.get_default ().remove_CurTempIds (q.object_id);
+                        if (temp_id_mapping.has_member (q.temp_id)) {
+                            var id = temp_id_mapping.get_string_member (q.temp_id);
+                            Services.Store.instance ().update_project_id (q.object_id, id);
+                            Services.Database.get_default ().remove_CurTempIds (q.object_id);
+                        } else {
+                            Services.LogService.get_default ().warn ("Todoist", "temp_id_mapping missing for project_add: %s".printf (q.temp_id));
+                        }
                     }
 
                     if (q.query == "section_add") {
-                        var id = node.get_object_member ("temp_id_mapping").get_string_member (q.temp_id);
-                        Services.Store.instance ().update_section_id (q.object_id, id);
-                        Services.Database.get_default ().remove_CurTempIds (q.object_id);
+                        if (temp_id_mapping.has_member (q.temp_id)) {
+                            var id = temp_id_mapping.get_string_member (q.temp_id);
+                            Services.Store.instance ().update_section_id (q.object_id, id);
+                            Services.Database.get_default ().remove_CurTempIds (q.object_id);
+                        } else {
+                            Services.LogService.get_default ().warn ("Todoist", "temp_id_mapping missing for section_add: %s".printf (q.temp_id));
+                        }
                     }
 
                     if (q.query == "item_add") {
-                        var id = node.get_object_member ("temp_id_mapping").get_string_member (q.temp_id);
-                        Services.Store.instance ().update_item_id (q.object_id, id);
-                        Services.Database.get_default ().remove_CurTempIds (q.object_id);
+                        if (temp_id_mapping.has_member (q.temp_id)) {
+                            var id = temp_id_mapping.get_string_member (q.temp_id);
+                            Services.Store.instance ().update_item_id (q.object_id, id);
+                            Services.Database.get_default ().remove_CurTempIds (q.object_id);
+                        } else {
+                            Services.LogService.get_default ().warn ("Todoist", "temp_id_mapping missing for item_add: %s".printf (q.temp_id));
+                        }
                     }
 
+                    Services.Database.get_default ().remove_queue (q.uuid);
+                } else {
+                    var sync_status = node.get_object_member ("sync_status");
+                    if (sync_status.has_member (q.uuid)) {
+                        var error_obj = sync_status.get_object_member (q.uuid);
+                        Services.LogService.get_default ().warn ("Todoist",
+                            "Queue item failed — query: %s, error: %s".printf (
+                                q.query, error_obj.get_string_member ("error")));
+                    }
                     Services.Database.get_default ().remove_queue (q.uuid);
                 }
             }
@@ -331,7 +354,11 @@ public class Services.Todoist : GLib.Object {
             } else if (q.query == "section_add") {
                 begin_command (builder, "section_add", q.uuid, q.temp_id);
                 builder.set_member_name ("name"); builder.add_string_value (Utils.JsonUtils.get_string (q.args, "name"));
-                builder.set_member_name ("project_id"); builder.add_string_value (Utils.JsonUtils.get_string (q.args, "project_id"));
+                string section_project_id = Utils.JsonUtils.get_string (q.args, "project_id");
+                if (Services.Database.get_default ().curTempIds_exists (section_project_id)) {
+                    section_project_id = Services.Database.get_default ().get_temp_id (section_project_id);
+                }
+                builder.set_member_name ("project_id"); builder.add_string_value (section_project_id);
                 end_command (builder);
             } else if (q.query == "section_update") {
                 begin_command (builder, "section_update", q.uuid);
@@ -346,6 +373,11 @@ public class Services.Todoist : GLib.Object {
                 begin_command (builder, "section_move", q.uuid);
                 builder.set_member_name ("id"); builder.add_string_value (Utils.JsonUtils.get_string (q.args, "id"));
                 builder.set_member_name ("project_id"); builder.add_string_value (Utils.JsonUtils.get_string (q.args, "project_id"));
+                end_command (builder);
+            } else if (q.query == "project_move") {
+                begin_command (builder, "project_move", q.uuid);
+                builder.set_member_name ("id"); builder.add_string_value (Utils.JsonUtils.get_string (q.args, "id"));
+                builder.set_member_name ("parent_id"); builder.add_string_value (Utils.JsonUtils.get_string (q.args, "parent_id"));
                 end_command (builder);
             } else if (q.query == "item_add") {
                 begin_command (builder, "item_add", q.uuid, q.temp_id);

--- a/core/Services/Todoist/Todoist.vala
+++ b/core/Services/Todoist/Todoist.vala
@@ -241,13 +241,23 @@ public class Services.Todoist : GLib.Object {
      * Queue
      */
 
+    private bool _queue_running = false;
+
     public async void queue (Objects.Source source) {
+        if (_queue_running) {
+            Services.LogService.get_default ().debug ("Todoist", "Queue already running, skipping");
+            return;
+        }
+
+        _queue_running = true;
         Gee.ArrayList<Objects.Queue ?> queue_collection = Services.Database.get_default ().get_all_queue (source.id);
         if (queue_collection.size <= 0) {
             return;
         }
 
         string json = get_queue_json (queue_collection);
+        Services.LogService.get_default ().info ("Todoist", "Flushing queue: %d items".printf (queue_collection.size));
+        Services.LogService.get_default ().debug ("Todoist", "Queue JSON: %s".printf (json));
 
         var message = new Soup.Message ("POST", TODOIST_SYNC_URL);
         message.request_headers.append ("Authorization", "Bearer %s".printf (source.todoist_data.access_token));
@@ -263,6 +273,7 @@ public class Services.Todoist : GLib.Object {
 
             foreach (var q in queue_collection) {
                 var uuid_member = node.get_object_member ("sync_status").get_member (q.uuid);
+                Services.LogService.get_default ().debug ("Todoist", "Processing queue item — query: %s, uuid: %s, object_id: %s".printf (q.query, q.uuid, q.object_id));
                 if (uuid_member.get_node_type () == Json.NodeType.VALUE) {
                     var temp_id_mapping = node.get_object_member ("temp_id_mapping");
 
@@ -311,6 +322,8 @@ public class Services.Todoist : GLib.Object {
         } catch (Error e) {
             debug (e.message);
         }
+
+        _queue_running = false;
     }
 
     private void begin_command (Json.Builder builder, string type, string uuid, string? temp_id = null) {
@@ -385,8 +398,14 @@ public class Services.Todoist : GLib.Object {
                 builder.set_member_name ("description"); builder.add_string_value (Utils.JsonUtils.get_string (q.args, "description"));
                 builder.set_member_name ("priority"); builder.add_int_value (Utils.JsonUtils.get_int (q.args, "priority"));
                 builder.set_member_name ("project_id"); builder.add_string_value (Utils.JsonUtils.get_string (q.args, "project_id"));
-                builder.set_member_name ("section_id"); builder.add_string_value (Utils.JsonUtils.get_string (q.args, "section_id"));
-                builder.set_member_name ("parent_id"); builder.add_string_value (Utils.JsonUtils.get_string (q.args, "parent_id"));
+                var section_id = Utils.JsonUtils.get_string (q.args, "section_id");
+                if (section_id != "") {
+                    builder.set_member_name ("section_id"); builder.add_string_value (section_id);
+                }
+                var parent_id = Utils.JsonUtils.get_string (q.args, "parent_id");
+                if (parent_id != "") {
+                    builder.set_member_name ("parent_id"); builder.add_string_value (parent_id);
+                }
                 end_command (builder);
             } else if (q.query == "item_update") {
                 begin_command (builder, "item_update", q.uuid);

--- a/core/Services/Todoist/Todoist.vala
+++ b/core/Services/Todoist/Todoist.vala
@@ -252,6 +252,7 @@ public class Services.Todoist : GLib.Object {
         _queue_running = true;
         Gee.ArrayList<Objects.Queue ?> queue_collection = Services.Database.get_default ().get_all_queue (source.id);
         if (queue_collection.size <= 0) {
+            _queue_running = false;
             return;
         }
 
@@ -326,6 +327,13 @@ public class Services.Todoist : GLib.Object {
         _queue_running = false;
     }
 
+    private string resolve_id (string id) {
+        if (Services.Database.get_default ().curTempIds_exists (id)) {
+            return Services.Database.get_default ().get_temp_id (id);
+        }
+        return id;
+    }
+
     private void begin_command (Json.Builder builder, string type, string uuid, string? temp_id = null) {
         builder.begin_object ();
         builder.set_member_name ("type"); builder.add_string_value (type);
@@ -367,11 +375,7 @@ public class Services.Todoist : GLib.Object {
             } else if (q.query == "section_add") {
                 begin_command (builder, "section_add", q.uuid, q.temp_id);
                 builder.set_member_name ("name"); builder.add_string_value (Utils.JsonUtils.get_string (q.args, "name"));
-                string section_project_id = Utils.JsonUtils.get_string (q.args, "project_id");
-                if (Services.Database.get_default ().curTempIds_exists (section_project_id)) {
-                    section_project_id = Services.Database.get_default ().get_temp_id (section_project_id);
-                }
-                builder.set_member_name ("project_id"); builder.add_string_value (section_project_id);
+                builder.set_member_name ("project_id"); builder.add_string_value (resolve_id (Utils.JsonUtils.get_string (q.args, "project_id")));
                 end_command (builder);
             } else if (q.query == "section_update") {
                 begin_command (builder, "section_update", q.uuid);
@@ -397,10 +401,11 @@ public class Services.Todoist : GLib.Object {
                 builder.set_member_name ("content"); builder.add_string_value (Utils.JsonUtils.get_string (q.args, "content"));
                 builder.set_member_name ("description"); builder.add_string_value (Utils.JsonUtils.get_string (q.args, "description"));
                 builder.set_member_name ("priority"); builder.add_int_value (Utils.JsonUtils.get_int (q.args, "priority"));
-                builder.set_member_name ("project_id"); builder.add_string_value (Utils.JsonUtils.get_string (q.args, "project_id"));
+                string item_project_id = resolve_id (Utils.JsonUtils.get_string (q.args, "project_id"));
+                builder.set_member_name ("project_id"); builder.add_string_value (item_project_id);
                 var section_id = Utils.JsonUtils.get_string (q.args, "section_id");
                 if (section_id != "") {
-                    builder.set_member_name ("section_id"); builder.add_string_value (section_id);
+                    builder.set_member_name ("section_id"); builder.add_string_value (resolve_id (section_id));
                 }
                 var parent_id = Utils.JsonUtils.get_string (q.args, "parent_id");
                 if (parent_id != "") {
@@ -409,7 +414,7 @@ public class Services.Todoist : GLib.Object {
                 end_command (builder);
             } else if (q.query == "item_update") {
                 begin_command (builder, "item_update", q.uuid);
-                builder.set_member_name ("id"); builder.add_string_value (Utils.JsonUtils.get_string (q.args, "id"));
+                builder.set_member_name ("id"); builder.add_string_value (resolve_id (Utils.JsonUtils.get_string (q.args, "id")));
                 builder.set_member_name ("content"); builder.add_string_value (Utils.JsonUtils.get_string (q.args, "content"));
                 builder.set_member_name ("description"); builder.add_string_value (Utils.JsonUtils.get_string (q.args, "description"));
                 builder.set_member_name ("priority"); builder.add_int_value (Utils.JsonUtils.get_int (q.args, "priority"));
@@ -424,17 +429,17 @@ public class Services.Todoist : GLib.Object {
                 end_command (builder);
             } else if (q.query == "item_delete") {
                 begin_command (builder, "item_delete", q.uuid);
-                builder.set_member_name ("id"); builder.add_string_value (Utils.JsonUtils.get_string (q.args, "id"));
+                builder.set_member_name ("id"); builder.add_string_value (resolve_id (Utils.JsonUtils.get_string (q.args, "id")));
                 end_command (builder);
             } else if (q.query == "item_move") {
                 begin_command (builder, "item_move", q.uuid);
-                builder.set_member_name ("id"); builder.add_string_value (Utils.JsonUtils.get_string (q.args, "id"));
+                builder.set_member_name ("id"); builder.add_string_value (resolve_id (Utils.JsonUtils.get_string (q.args, "id")));
                 string move_type = Utils.JsonUtils.get_string (q.args, "type");
-                builder.set_member_name (move_type); builder.add_string_value (Utils.JsonUtils.get_string (q.args, move_type));
+                builder.set_member_name (move_type); builder.add_string_value (resolve_id (Utils.JsonUtils.get_string (q.args, move_type)));
                 end_command (builder);
             } else if (q.query == "item_complete" || q.query == "item_uncomplete") {
                 begin_command (builder, q.query, q.uuid);
-                builder.set_member_name ("id"); builder.add_string_value (Utils.JsonUtils.get_string (q.args, "id"));
+                builder.set_member_name ("id"); builder.add_string_value (resolve_id (Utils.JsonUtils.get_string (q.args, "id")));
                 end_command (builder);
             }
         }

--- a/core/Services/Todoist/TodoistItems.vala
+++ b/core/Services/Todoist/TodoistItems.vala
@@ -89,6 +89,7 @@ public class Services.TodoistItems : GLib.Object {
                 queue.temp_id = temp_id;
                 queue.query = object.type_add;
                 queue.args = object.to_json ();
+                queue.source_id = object.source.id;
 
                 Services.Database.get_default ().insert_queue (queue);
                 Services.Database.get_default ().insert_CurTempIds (object.id, temp_id, object.object_type_string);
@@ -154,6 +155,7 @@ public class Services.TodoistItems : GLib.Object {
                 queue.object_id = object.id;
                 queue.query = object.type_update;
                 queue.args = object.to_json ();
+                queue.source_id = object.source.id;
 
                 Services.Database.get_default ().insert_queue (queue);
                 response.status = true;
@@ -215,6 +217,7 @@ public class Services.TodoistItems : GLib.Object {
                 queue.object_id = object.id;
                 queue.query = object.type_delete;
                 queue.args = object.to_json ();
+                queue.source_id = object.source.id;
 
                 Services.Database.get_default ().insert_queue (queue);
                 response.status = true;
@@ -277,6 +280,7 @@ public class Services.TodoistItems : GLib.Object {
                 queue.object_id = item.id;
                 queue.query = item.checked ? "item_complete" : "item_uncomplete";
                 queue.args = item.to_json ();
+                queue.source_id = item.source.id;
 
                 Services.Database.get_default ().insert_queue (queue);
                 response.status = true;
@@ -339,6 +343,7 @@ public class Services.TodoistItems : GLib.Object {
                 queue.object_id = item.id;
                 queue.query = "item_move";
                 queue.args = item.to_move_json (type, id);
+                queue.source_id = item.source.id;
 
                 Services.Database.get_default ().insert_queue (queue);
                 response.status = true;

--- a/core/Services/Todoist/TodoistItems.vala
+++ b/core/Services/Todoist/TodoistItems.vala
@@ -92,7 +92,7 @@ public class Services.TodoistItems : GLib.Object {
                 queue.source_id = object.source.id;
 
                 Services.Database.get_default ().insert_queue (queue);
-                Services.Database.get_default ().insert_CurTempIds (object.id, temp_id, object.object_type_string);
+                Services.Database.get_default ().insert_CurTempIds (id, temp_id, object.object_type_string);
 
                 response.status = true;
                 response.data = queue.object_id;

--- a/core/Services/Todoist/TodoistProjects.vala
+++ b/core/Services/Todoist/TodoistProjects.vala
@@ -80,6 +80,7 @@ public class Services.TodoistProjects : GLib.Object {
                     queue.query = "section_move";
                 }
                 queue.args = base_object.to_json ();
+                queue.source_id = base_object.source.id;
                 response.status = true;
                 Services.Database.get_default ().insert_queue (queue);
             }

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -22,6 +22,8 @@
 public class MainWindow : Adw.ApplicationWindow {
     public weak Planify app { get; construct; }
 
+    private bool _did_startup_sync = false;
+
     private Layouts.Sidebar sidebar;
     private Adw.ViewStack views_stack;
     private Adw.OverlaySplitView overlay_split_view;
@@ -210,7 +212,7 @@ public class MainWindow : Adw.ApplicationWindow {
                 foreach (Objects.Source source in Services.Store.instance ().sources) {
                     source.run_server ();
                 }
-                did_startup_sync = true;
+                _did_startup_sync = true;
 
                 return GLib.Source.REMOVE;
             });
@@ -221,18 +223,7 @@ public class MainWindow : Adw.ApplicationWindow {
                 }
             });
 
-            // TODO: network_changed is sometimes called very rapidly, so we should debounce it ...
-            var network_monitor = GLib.NetworkMonitor.get_default ();
-            network_monitor.network_changed.connect (() => {
-                if (did_startup_sync == false) {
-                    debug ("Ignoring early network change due to bug 1690\n");
-                    return;
-                }
-                debug ("Network has changed, starting sync\n");
-                foreach (Objects.Source source in Services.Store.instance ().sources) {
-                    source.run_server ();
-                }
-            });
+            setup_network_monitor ();
             
 #if WITH_EVOLUTION
             Services.Store.instance ().setup_calendar_events ();
@@ -918,6 +909,43 @@ public class MainWindow : Adw.ApplicationWindow {
         });
 
         return toolbar_view;
+    }
+
+    private void setup_network_monitor () {
+        uint network_timeout_id = 0;
+        var network_monitor = GLib.NetworkMonitor.get_default ();
+        network_monitor.network_changed.connect (() => {
+            bool available = network_monitor.get_network_available ();
+            Services.LogService.get_default ().info ("NetworkMonitor", "Network changed — available: %s".printf (available.to_string ()));
+
+            if (_did_startup_sync == false) {
+                Services.LogService.get_default ().debug ("NetworkMonitor", "Ignoring early network change (startup sync not done yet)");
+                return;
+            }
+
+            if (!available) {
+                Services.LogService.get_default ().info ("NetworkMonitor", "Network unavailable, skipping sync");
+                if (network_timeout_id != 0) {
+                    GLib.Source.remove (network_timeout_id);
+                    network_timeout_id = 0;
+                }
+                return;
+            }
+
+            if (network_timeout_id != 0) {
+                GLib.Source.remove (network_timeout_id);
+            }
+
+            network_timeout_id = Timeout.add_seconds (3, () => {
+                network_timeout_id = 0;
+                Services.LogService.get_default ().info ("NetworkMonitor", "Network stable, triggering sync for all sources");
+                foreach (Objects.Source source in Services.Store.instance ().sources) {
+                    Services.LogService.get_default ().debug ("NetworkMonitor", "Triggering sync for source: %s".printf (source.display_name));
+                    source.run_server ();
+                }
+                return GLib.Source.REMOVE;
+            });
+        });
     }
 
     private void cleanup_unused_views () {


### PR DESCRIPTION
Several improvements to the Todoist offline queue:

- Queue items are now filtered by source — fixes a bug where operations 
  from one Todoist account could be sent using the token of another account
- Added source_id field to Queue object and database table with migration
- Fixed project_move operations being silently lost — now included in queue flush
- Fixed potential crash when temp_id_mapping is missing for project_add, 
  section_add or item_add — now logs a warning instead of crashing
- Failed queue items now log the error from Todoist before being removed, 
  instead of silently disappearing
- Fixed section_add referencing a local project ID when the project was 
  also created offline — now correctly uses the temp_id so Todoist can 
  resolve the dependency within the same batch
