### PR TITLE
Fix: correctly update if priority_property is null

### DIFF
--- a/core/Objects/Item.vala
+++ b/core/Objects/Item.vala
@@ -515,6 +515,8 @@ public class Objects.Item : Objects.BaseObject {
             } else {
                 priority = Constants.PRIORITY_4;
             }
+        } else {
+            priority = Constants.PRIORITY_4;
         }
 
         if (!ical.get_due ().is_null_time ()) {


### PR DESCRIPTION
Fix fetching tasks from mailbox.org/Open-Xchange with no priority set (#2417)

