### PR TITLE
fix: use UTC timezone for COMPLETED property in VTODO

### DIFF
--- a/core/Objects/Item.vala
+++ b/core/Objects/Item.vala
@@ -1365,7 +1365,7 @@ public class Objects.Item : Objects.BaseObject {
             ical.add_property (new ICal.Property.percentcomplete (100));
             // RFC requires Date-Time (https://datatracker.ietf.org/doc/html/rfc5545#section-3.8.2.1)
             // Nextcloud also accepted .today () which didn't include the Timezone, but Radicale and probably other CalDAV implementations want Date-Time
-            ical.add_property (new ICal.Property.completed (ICal.Time.current_with_zone (ICal.Timezone.get_utc_timezone ())));
+            ical.add_property (new ICal.Property.completed (new ICal.Time.current_with_zone (ICal.Timezone.get_utc_timezone ())));
         } else {
             ical.set_status (ICal.PropertyStatus.NEEDSACTION);
         }

--- a/core/Objects/Item.vala
+++ b/core/Objects/Item.vala
@@ -1365,7 +1365,7 @@ public class Objects.Item : Objects.BaseObject {
             ical.add_property (new ICal.Property.percentcomplete (100));
             // RFC requires Date-Time (https://datatracker.ietf.org/doc/html/rfc5545#section-3.8.2.1)
             // Nextcloud also accepted .today () which didn't include the Timezone, but Radicale and probably other CalDAV implementations want Date-Time
-            ical.add_property (new ICal.Property.completed (new ICal.Time.current_with_zone (ICal.Timezone.get_utc_timezone ())));
+            ical.add_property (new ICal.Property.completed (new ICal.Time.from_timet_with_zone ((time_t) new GLib.DateTime.now_utc ().to_unix (), 0, ICal.Timezone.get_utc_timezone ())));
         } else {
             ical.set_status (ICal.PropertyStatus.NEEDSACTION);
         }

--- a/core/Objects/Item.vala
+++ b/core/Objects/Item.vala
@@ -1365,7 +1365,7 @@ public class Objects.Item : Objects.BaseObject {
             ical.add_property (new ICal.Property.percentcomplete (100));
             // RFC requires Date-Time (https://datatracker.ietf.org/doc/html/rfc5545#section-3.8.2.1)
             // Nextcloud also accepted .today () which didn't include the Timezone, but Radicale and probably other CalDAV implementations want Date-Time
-            ical.add_property (new ICal.Property.completed (new ICal.Time.current_with_zone (null)));
+            ical.add_property (new ICal.Property.completed (ICal.Time.current_with_zone (ICal.Timezone.get_utc_timezone ())));
         } else {
             ical.set_status (ICal.PropertyStatus.NEEDSACTION);
         }


### PR DESCRIPTION
The COMPLETED property was being generated with local time and no timezone indicator (e.g. COMPLETED:20260519T073638), which is ambiguous per RFC 5545 and caused DAVx5 on Android to throw a ClassCastException when syncing.

Fixed by using ICal.Timezone.get_utc_timezone() instead of null, producing a proper UTC timestamp with Z suffix  (e.g. COMPLETED:20260519T073638Z).

Fixes: #2489
