### PR TITLE
fix: use system accent color consistently across the app

### DIFF
--- a/core/Constants.vala
+++ b/core/Constants.vala
@@ -56,4 +56,5 @@ namespace Constants {
     public const bool BLOCK_PAST_DAYS = true;
     public const int COMPLETED_PAGE_SIZE = 15;
     public const int HEADERBAR_TITLE_SCROLL_THRESHOLD = 24;
+    public const string DEFAULT_ACCENT_COLOR = "#3584e4";
 }

--- a/core/Utils/Util.vala
+++ b/core/Utils/Util.vala
@@ -268,6 +268,20 @@ public class Util : GLib.Object {
         return returned;
     }
 
+    public string get_accent_color () {
+        if (Services.Settings.get_default ().settings.get_boolean ("use-system-accent")) {
+            if (Adw.StyleManager.get_default ().get_system_supports_accent_colors ()) {
+                var rgba = Adw.StyleManager.get_default ().get_accent_color_rgba ();
+                return "#%02x%02x%02x".printf (
+                    (uint) (rgba.red * 255),
+                    (uint) (rgba.green * 255),
+                    (uint) (rgba.blue * 255)
+                );
+            }
+        }
+        return Constants.DEFAULT_ACCENT_COLOR;
+    }
+
     public void update_theme () {
         Appearance appearance_mode = Appearance.parse (Services.Settings.get_default ().settings.get_enum ("appearance"));
         bool dark_mode = Services.Settings.get_default ().settings.get_boolean ("dark-mode");
@@ -278,17 +292,7 @@ public class Util : GLib.Object {
             dark_mode = color_scheme_settings.prefers_color_scheme == ColorSchemeSettings.Settings.ColorScheme.DARK;
         }
 
-        string accent_color = "#3584e4";
-        if (Services.Settings.get_default ().settings.get_boolean ("use-system-accent")) {
-            if (Adw.StyleManager.get_default ().get_system_supports_accent_colors ()) {
-                var rgba = Adw.StyleManager.get_default ().get_accent_color_rgba ();
-                accent_color = "#%02x%02x%02x".printf (
-                    (uint) (rgba.red * 255),
-                    (uint) (rgba.green * 255),
-                    (uint) (rgba.blue * 255)
-                );
-            }
-        }
+        string accent_color = get_accent_color ();
 
         string window_bg_color = "";
         string popover_bg_color = "";

--- a/data/resources/stylesheet/stylesheet.css
+++ b/data/resources/stylesheet/stylesheet.css
@@ -56,7 +56,7 @@ entry.flat:focus-within {
 }
 
 .color-primary {
-    color: #1e63ec;
+    color: @accent_color;
 }
 
 .color-radio {
@@ -524,13 +524,13 @@ checkbutton.theme-selector radio:checked {
 }
 
 .drop-area {
-    background-color: alpha(#1e63ec, 0.35);
+    background-color: alpha(@accent_color, 0.35);
     border-radius: 6px;
 }
 
 .drop-target:drop(active) {
     border-radius: 6px;
-    background-color: alpha(#1e63ec, 0.35);
+    background-color: alpha(@accent_color, 0.35);
 }
 
 .drop-target-none:drop(active) {
@@ -553,7 +553,7 @@ checkbutton.theme-selector radio:checked {
 }
 
 .indicator {
-    background: #1e63ec;
+    background: @accent_color;
     border-radius: 50%;
 }
 

--- a/src/Widgets/NewVersionPopup.vala
+++ b/src/Widgets/NewVersionPopup.vala
@@ -37,7 +37,7 @@ public class Widgets.NewVersionPopup : Adw.Bin {
             pixel_size = 32
         };
         star_icon.add_css_class ("view-icon");
-        Util.get_default ().set_widget_color ("#3584e4", star_icon);
+        Util.get_default ().set_widget_color (Util.get_default ().get_accent_color (), star_icon);
 
         var title_label = new Gtk.Label (_("New version available!")) {
             halign = START,


### PR DESCRIPTION
Added DEFAULT_ACCENT_COLOR constant to avoid hardcoded hex values scattered across the codebase. Added get_accent_color() helper to Util that centralizes the logic — returns the system accent color 
when supported and enabled, or falls back to the default blue.

Fixes: #2479
