### PR TITLE
fix: store attachment file_size as TEXT to prevent integer overflow

### DIFF
--- a/core/Objects/Attachment.vala
+++ b/core/Objects/Attachment.vala
@@ -24,7 +24,7 @@ public class Objects.Attachment : GLib.Object {
     public string item_id { get; set; default = ""; }
     public string file_type { get; set; default = ""; }
     public string file_name { get; set; default = ""; }
-    public int64 file_size { get; set; default = 0; }
+    public string file_size { get; set; default = ""; }
     public string file_path { get; set; default = ""; }
 
     public signal void deleted ();
@@ -56,7 +56,7 @@ public class Objects.Attachment : GLib.Object {
             item_id,
             file_type,
             file_name,
-            file_size.to_string (),
+            file_size,
             file_path
         );
     }

--- a/core/Services/Database.vala
+++ b/core/Services/Database.vala
@@ -1897,7 +1897,7 @@ public class Services.Database : GLib.Object {
         set_parameter_str (stmt, "$item_id", attachment.item_id);
         set_parameter_str (stmt, "$file_type", attachment.file_type);
         set_parameter_str (stmt, "$file_name", attachment.file_name);
-        set_parameter_int64 (stmt, "$file_size", attachment.file_size);
+        set_parameter_str (stmt, "$file_size", attachment.file_size);
         set_parameter_str (stmt, "$file_path", attachment.file_path);
 
         int result = stmt.step ();
@@ -1932,7 +1932,7 @@ public class Services.Database : GLib.Object {
         return_value.item_id = stmt.column_text (1);
         return_value.file_type = stmt.column_text (2);
         return_value.file_name = stmt.column_text (3);
-        return_value.file_size = stmt.column_int64 (4);
+        return_value.file_size = stmt.column_text (4);
         return_value.file_path = stmt.column_text (5);
         return return_value;
     }

--- a/src/Widgets/Attachments.vala
+++ b/src/Widgets/Attachments.vala
@@ -185,7 +185,7 @@ public class Widgets.Attachments : Adw.Bin {
                 if (file_content_type != null) {
                     file_content_type = file_content_type.down ();
 
-                    attachment.file_size = file_info.get_size ();
+                    attachment.file_size = file_info.get_size ().to_string ();
                     attachment.file_type = file_content_type;
                     attachment.file_name = file.get_basename ();
                     attachment.file_path = file.get_uri ();


### PR DESCRIPTION
`file_size` was declared as `TEXT` in the schema but handled as `int64` in code, causing a mismatch. More importantly, passing a value ≥ 2^63 would cause an unhandled overflow error.

Since `file_size` is only used for display purposes, the fix is to treat it as a string throughout — no parsing or arithmetic is ever needed.

Closes #2507

