### PR TITLE
fix: improve drag & drop reliability and visual feedback in ReorderChild

### DIFF
--- a/data/resources/stylesheet/stylesheet.css
+++ b/data/resources/stylesheet/stylesheet.css
@@ -559,20 +559,6 @@ checkbutton.theme-selector radio:checked {
     border: 1px solid @item_border_color;
 }
 
-/* ReorderChild2 — Ionic-inspired reorder */
-.reorder2-selected {
-    opacity: 0.7;
-    box-shadow: 0 4px 16px alpha(@shade_color, 0.4);
-    border-radius: 9px;
-    transition: opacity 150ms ease, box-shadow 150ms ease;
-}
-
-.reorder2-spacer {
-    background-color: alpha(@accent_color, 0.15);
-    border-radius: 6px;
-    transition: background-color 150ms ease;
-}
-
 .indicator {
     background: @accent_color;
     border-radius: 50%;

--- a/data/resources/stylesheet/stylesheet.css
+++ b/data/resources/stylesheet/stylesheet.css
@@ -524,13 +524,20 @@ checkbutton.theme-selector radio:checked {
 }
 
 .drop-area {
-    background-color: alpha(@accent_color, 0.35);
-    border-radius: 6px;
+    background-color: alpha(@accent_color, 0.12);
+    border: 1px solid alpha(@accent_color, 0.35);
+    border-radius: 12px;
+    transition: background-color 150ms ease, border 150ms ease;
+}
+
+.drop-target {
+    transition: background-color 150ms ease, border 150ms ease;
 }
 
 .drop-target:drop(active) {
-    border-radius: 6px;
-    background-color: alpha(@accent_color, 0.35);
+    border-radius: 12px;
+    background-color: alpha(@accent_color, 0.12);
+    border: 1px solid alpha(@accent_color, 0.35);
 }
 
 .drop-target-none:drop(active) {
@@ -542,14 +549,28 @@ checkbutton.theme-selector radio:checked {
 }
 
 .drop-target-list:drop(active) {
-    border-radius: 6px;
+    border-radius: 12px;
 }
 
 .drop-begin {
     padding: 3px;
     background: @selected_color;
-    border-radius: 9px;
+    border-radius: 12px;
     border: 1px solid @item_border_color;
+}
+
+/* ReorderChild2 — Ionic-inspired reorder */
+.reorder2-selected {
+    opacity: 0.7;
+    box-shadow: 0 4px 16px alpha(@shade_color, 0.4);
+    border-radius: 9px;
+    transition: opacity 150ms ease, box-shadow 150ms ease;
+}
+
+.reorder2-spacer {
+    background-color: alpha(@accent_color, 0.15);
+    border-radius: 6px;
+    transition: background-color 150ms ease;
 }
 
 .indicator {

--- a/src/Dialogs/Preferences/Pages/Sidebar.vala
+++ b/src/Dialogs/Preferences/Pages/Sidebar.vala
@@ -34,23 +34,6 @@ public class Dialogs.Preferences.Pages.Sidebar : Dialogs.Preferences.Pages.BaseP
     }
 
     construct {
-        views_group = new Layouts.HeaderItem (_("Show in Sidebar")) {
-            card = true,
-            reveal = true
-        };
-
-        views_group.add_child (new SidebarRow (Objects.Filters.Inbox.get_default ()));
-        views_group.add_child (new SidebarRow (Objects.Filters.Today.get_default ()));
-        views_group.add_child (new SidebarRow (Objects.Filters.Scheduled.get_default ()));
-        views_group.add_child (new SidebarRow (Objects.Filters.Pinboard.get_default ()));
-        views_group.add_child (new SidebarRow (Objects.Filters.Labels.get_default ()));
-        views_group.add_child (new SidebarRow (Objects.Filters.Completed.get_default ()));
-        views_group.add_child (new SidebarRow (Objects.Filters.Tomorrow.get_default ()));
-        views_group.add_child (new SidebarRow (Objects.Filters.Anytime.get_default ()));
-        views_group.add_child (new SidebarRow (Objects.Filters.Repeating.get_default ()));
-        views_group.add_child (new SidebarRow (Objects.Filters.Unlabeled.get_default ()));
-        views_group.add_child (new SidebarRow (Objects.Filters.AllItems.get_default ()));
-
         var show_count_row = new Adw.SwitchRow () {
             title = _("Show Task Count")
         };
@@ -76,6 +59,24 @@ public class Dialogs.Preferences.Pages.Sidebar : Dialogs.Preferences.Pages.BaseP
         count_group.add (sidebar_width_row);
         count_group.add (list_view_filters_row);
 
+        views_group = new Layouts.HeaderItem (_("Show in Sidebar")) {
+            card = true,
+            reveal = true,
+            margin_top = 12
+        };
+
+        views_group.add_child (new SidebarRow (Objects.Filters.Inbox.get_default ()));
+        views_group.add_child (new SidebarRow (Objects.Filters.Today.get_default ()));
+        views_group.add_child (new SidebarRow (Objects.Filters.Scheduled.get_default ()));
+        views_group.add_child (new SidebarRow (Objects.Filters.Pinboard.get_default ()));
+        views_group.add_child (new SidebarRow (Objects.Filters.Labels.get_default ()));
+        views_group.add_child (new SidebarRow (Objects.Filters.Completed.get_default ()));
+        views_group.add_child (new SidebarRow (Objects.Filters.Tomorrow.get_default ()));
+        views_group.add_child (new SidebarRow (Objects.Filters.Anytime.get_default ()));
+        views_group.add_child (new SidebarRow (Objects.Filters.Repeating.get_default ()));
+        views_group.add_child (new SidebarRow (Objects.Filters.Unlabeled.get_default ()));
+        views_group.add_child (new SidebarRow (Objects.Filters.AllItems.get_default ()));
+
         var content_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 0) {
             margin_start = 12,
             margin_end = 12,
@@ -91,12 +92,7 @@ public class Dialogs.Preferences.Pages.Sidebar : Dialogs.Preferences.Pages.BaseP
             margin_top = 3
         });
 
-        var scrolled_window = new Gtk.ScrolledWindow () {
-            hscrollbar_policy = Gtk.PolicyType.NEVER,
-            hexpand = true,
-            vexpand = true,
-            child = content_box
-        };
+        var scrolled_window = new Widgets.ScrolledWindow (content_box);
 
         var toolbar_view = new Adw.ToolbarView () {
             content = scrolled_window
@@ -174,6 +170,7 @@ public class Dialogs.Preferences.Pages.Sidebar : Dialogs.Preferences.Pages.BaseP
             add_css_class ("sidebar-row");
             add_css_class ("transition");
             add_css_class ("no-padding");
+            add_css_class ("no-selectable");
 
             check_button = new Gtk.Switch () {
                 valign = CENTER,
@@ -188,6 +185,9 @@ public class Dialogs.Preferences.Pages.Sidebar : Dialogs.Preferences.Pages.BaseP
                 activatable = true
             };
             action_row.add_prefix (new Gtk.Image.from_icon_name (base_object.icon_name));
+            action_row.add_prefix (new Gtk.Image.from_icon_name ("list-drag-handle-symbolic") {
+                css_classes = { "dimmed" }
+            });
             action_row.add_suffix (check_button);
 
             reorder = new Widgets.ReorderChild (action_row, this);

--- a/src/Widgets/ReorderChild.vala
+++ b/src/Widgets/ReorderChild.vala
@@ -23,6 +23,7 @@ public class Widgets.ReorderChild : Adw.Bin {
     public Gtk.Widget widget { get; construct; }
     public weak Gtk.ListBoxRow row { get; construct; }
 
+    private const int TRANSITION_DURATION = 200;
     private Adw.Bin motion_top_grid;
     private Gtk.Revealer motion_top_revealer;
     private Adw.Bin motion_bottom_grid;
@@ -63,22 +64,22 @@ public class Widgets.ReorderChild : Adw.Bin {
 
     construct {
         motion_top_grid = new Adw.Bin () {
-            css_classes = { "drop-target-none" }
+            css_classes = { "drop-target" }
         };
 
         motion_top_revealer = new Gtk.Revealer () {
-            transition_type = SLIDE_UP,
-            transition_duration = 150,
+            transition_type = SLIDE_DOWN,
+            transition_duration = TRANSITION_DURATION,
             child = motion_top_grid
         };
 
         motion_bottom_grid = new Adw.Bin () {
-            css_classes = { "drop-target-none" }
+            css_classes = { "drop-target" }
         };
 
         motion_bottom_revealer = new Gtk.Revealer () {
             transition_type = SLIDE_DOWN,
-            transition_duration = 150,
+            transition_duration = TRANSITION_DURATION,
             child = motion_bottom_grid
         };
 
@@ -113,24 +114,30 @@ public class Widgets.ReorderChild : Adw.Bin {
             var paintable = new Gtk.WidgetPaintable (widget);
             source.set_icon (paintable, 0, 0);
             drag_begin ();
+            print ("[ReorderChild] drag_begin\n");
         })] = drag_source;
 
         signal_map[drag_source.drag_end.connect ((source, drag, delete_data) => {
+            print ("[ReorderChild] drag_end\n");
             drag_end ();
         })] = drag_source;
 
         signal_map[drag_source.drag_cancel.connect ((source, drag, reason) => {
+            print ("[ReorderChild] drag_cancel reason=%s\n", reason.to_string ());
             drag_end ();
             return false;
         })] = drag_source;
 
+        // Single DropTarget on the row — avoids the animation gap issue
+        // where motion_top/bottom_grid height is still animating when drop fires
         drop_order_top_target = new Gtk.DropTarget (typeof (Widgets.ReorderChild), Gdk.DragAction.MOVE);
-        motion_top_grid.add_controller (drop_order_top_target);
-        signal_map[drop_order_top_target.drop.connect ((value, x, y) => on_drop (value, x, y, false))] = drop_order_top_target;
-
-        drop_order_bottom_target = new Gtk.DropTarget (typeof (Widgets.ReorderChild), Gdk.DragAction.MOVE);
-        motion_bottom_grid.add_controller (drop_order_bottom_target);
-        signal_map[drop_order_bottom_target.drop.connect ((value, x, y) => on_drop (value, x, y, true))] = drop_order_bottom_target;
+        row.add_controller (drop_order_top_target);
+        signal_map[drop_order_top_target.drop.connect ((value, x, y) => {
+            bool bottom = y >= row.get_height () / 2.0;
+            print ("[ReorderChild] drop x=%.0f y=%.0f row_h=%d bottom=%s\n",
+                x, y, row.get_height (), bottom.to_string ());
+            return on_drop (value, x, y, bottom);
+        })] = drop_order_top_target;
 
         drop_motion_ctrl = new Gtk.DropControllerMotion ();
         row.add_controller (drop_motion_ctrl);
@@ -139,16 +146,38 @@ public class Widgets.ReorderChild : Adw.Bin {
             var row_height = row.get_height ();
             bool is_top_half = (y < row_height / 2);
 
-            if (motion_top_revealer.reveal_child != is_top_half)
-                motion_top_revealer.reveal_child = is_top_half;
+            print ("[ReorderChild] motion x=%.0f y=%.0f row_h=%d is_top=%s top_revealed=%s bottom_revealed=%s top_grid_h=%d bottom_grid_h=%d\n",
+                x, y, row_height, is_top_half.to_string (),
+                motion_top_revealer.reveal_child.to_string (),
+                motion_bottom_revealer.reveal_child.to_string (),
+                motion_top_grid.get_height (),
+                motion_bottom_grid.get_height ());
 
-            if (motion_bottom_revealer.reveal_child != !is_top_half)
+            if (motion_top_revealer.reveal_child != is_top_half) {
+                motion_top_revealer.reveal_child = is_top_half;
+                if (is_top_half) {
+                    motion_top_grid.add_css_class ("drop-area");
+                } else {
+                    motion_top_grid.remove_css_class ("drop-area");
+                }
+            }
+
+            if (motion_bottom_revealer.reveal_child != !is_top_half) {
                 motion_bottom_revealer.reveal_child = !is_top_half;
+                if (!is_top_half) {
+                    motion_bottom_grid.add_css_class ("drop-area");
+                } else {
+                    motion_bottom_grid.remove_css_class ("drop-area");
+                }
+            }
         })] = drop_motion_ctrl;
 
         signal_map[drop_motion_ctrl.leave.connect (() => {
+            print ("[ReorderChild] leave\n");
             motion_top_revealer.reveal_child = false;
             motion_bottom_revealer.reveal_child = false;
+            motion_top_grid.remove_css_class ("drop-area");
+            motion_bottom_grid.remove_css_class ("drop-area");
         })] = drop_motion_ctrl;
     }
 
@@ -211,13 +240,12 @@ public class Widgets.ReorderChild : Adw.Bin {
             drag_source = null;
         }
 
-        if (drop_order_top_target != null && motion_top_grid != null) {
-            motion_top_grid.remove_controller (drop_order_top_target);
+        if (drop_order_top_target != null && row != null) {
+            row.remove_controller (drop_order_top_target);
             drop_order_top_target = null;
         }
 
-        if (drop_order_bottom_target != null && motion_bottom_grid != null) {
-            motion_bottom_grid.remove_controller (drop_order_bottom_target);
+        if (drop_order_bottom_target != null) {
             drop_order_bottom_target = null;
         }
 

--- a/src/Widgets/ReorderChild.vala
+++ b/src/Widgets/ReorderChild.vala
@@ -114,16 +114,13 @@ public class Widgets.ReorderChild : Adw.Bin {
             var paintable = new Gtk.WidgetPaintable (widget);
             source.set_icon (paintable, 0, 0);
             drag_begin ();
-            print ("[ReorderChild] drag_begin\n");
         })] = drag_source;
 
         signal_map[drag_source.drag_end.connect ((source, drag, delete_data) => {
-            print ("[ReorderChild] drag_end\n");
             drag_end ();
         })] = drag_source;
 
         signal_map[drag_source.drag_cancel.connect ((source, drag, reason) => {
-            print ("[ReorderChild] drag_cancel reason=%s\n", reason.to_string ());
             drag_end ();
             return false;
         })] = drag_source;
@@ -134,8 +131,6 @@ public class Widgets.ReorderChild : Adw.Bin {
         row.add_controller (drop_order_top_target);
         signal_map[drop_order_top_target.drop.connect ((value, x, y) => {
             bool bottom = y >= row.get_height () / 2.0;
-            print ("[ReorderChild] drop x=%.0f y=%.0f row_h=%d bottom=%s\n",
-                x, y, row.get_height (), bottom.to_string ());
             return on_drop (value, x, y, bottom);
         })] = drop_order_top_target;
 
@@ -145,13 +140,6 @@ public class Widgets.ReorderChild : Adw.Bin {
         signal_map[drop_motion_ctrl.motion.connect ((x, y) => {
             var row_height = row.get_height ();
             bool is_top_half = (y < row_height / 2);
-
-            print ("[ReorderChild] motion x=%.0f y=%.0f row_h=%d is_top=%s top_revealed=%s bottom_revealed=%s top_grid_h=%d bottom_grid_h=%d\n",
-                x, y, row_height, is_top_half.to_string (),
-                motion_top_revealer.reveal_child.to_string (),
-                motion_bottom_revealer.reveal_child.to_string (),
-                motion_top_grid.get_height (),
-                motion_bottom_grid.get_height ());
 
             if (motion_top_revealer.reveal_child != is_top_half) {
                 motion_top_revealer.reveal_child = is_top_half;
@@ -173,7 +161,6 @@ public class Widgets.ReorderChild : Adw.Bin {
         })] = drop_motion_ctrl;
 
         signal_map[drop_motion_ctrl.leave.connect (() => {
-            print ("[ReorderChild] leave\n");
             motion_top_revealer.reveal_child = false;
             motion_bottom_revealer.reveal_child = false;
             motion_top_grid.remove_css_class ("drop-area");


### PR DESCRIPTION
Fixes random drag failures and improves the drop indicator style — softer background, subtle border, and rounder corners using the accent color.

Before

https://github.com/user-attachments/assets/65612b99-25b2-4865-aff0-00a4b854912e


After

https://github.com/user-attachments/assets/6c582d75-e0ae-49da-860e-bda519600f8f


