### PR TITLE
Fix todoist recurring tasks

### DIFF
--- a/core/Objects/DueDate.vala
+++ b/core/Objects/DueDate.vala
@@ -21,6 +21,7 @@
 
 public class Objects.DueDate : GLib.Object {
     public string date { get; set; default = ""; }
+    public string recurrence_string { get; set; default = ""; }
     public string time_zone { get; set; default = ""; }
     public string recurrency_weeks { get; set; default = ""; }
     public bool is_recurring { get; set; default = false; }
@@ -103,6 +104,10 @@ public class Objects.DueDate : GLib.Object {
             date = object.get_string_member ("date");
         }
 
+        if (object.has_member ("string")) {
+            recurrence_string = object.get_string_member ("string");
+        }
+
         if (object.has_member ("timezone")) {
             time_zone = object.get_string_member ("timezone");
         }
@@ -117,6 +122,9 @@ public class Objects.DueDate : GLib.Object {
         if (object.has_member ("date")) {
             date = object.get_string_member ("date");
         }
+        
+        if (object.has_member ("recurrence_string"))
+            recurrence_string = object.get_string_member ("recurrence_string");
 
         if (object.has_member ("timezone")) {
             time_zone = object.get_string_member ("timezone");
@@ -149,6 +157,7 @@ public class Objects.DueDate : GLib.Object {
 
     public void reset () {
         date = "";
+        recurrence_string = "";
         time_zone = "";
         recurrency_type = RecurrencyType.NONE;
         recurrency_interval = 0;
@@ -161,6 +170,9 @@ public class Objects.DueDate : GLib.Object {
 
         builder.set_member_name ("date");
         builder.add_string_value (date);
+        
+        builder.set_member_name ("recurrence_string");
+        builder.add_string_value (recurrence_string);
 
         builder.set_member_name ("timezone");
         builder.add_string_value (time_zone);
@@ -208,6 +220,7 @@ public class Objects.DueDate : GLib.Object {
     public Objects.DueDate duplicate () {
         var new_due = new Objects.DueDate ();
         new_due.date = date;
+        new_due.recurrence_string = recurrence_string;
         new_due.time_zone = time_zone;
         new_due.recurrency_weeks = recurrency_weeks;
         new_due.is_recurring = is_recurring;

--- a/core/Objects/DueDate.vala
+++ b/core/Objects/DueDate.vala
@@ -123,8 +123,9 @@ public class Objects.DueDate : GLib.Object {
             date = object.get_string_member ("date");
         }
         
-        if (object.has_member ("recurrence_string"))
+        if (object.has_member ("recurrence_string")) {
             recurrence_string = object.get_string_member ("recurrence_string");
+        }
 
         if (object.has_member ("timezone")) {
             time_zone = object.get_string_member ("timezone");

--- a/core/Objects/Item.vala
+++ b/core/Objects/Item.vala
@@ -719,10 +719,20 @@ public class Objects.Item : Objects.BaseObject {
         return get_update_json (uuid, temp_id);
     }
 
-    public string get_check_json (string uuid, string type) {
+    public string get_check_json (string uuid, string type, string? sync_token = null) {
         builder.reset ();
 
         builder.begin_object ();
+
+        if (sync_token != null) {
+            builder.set_member_name ("sync_token");
+            builder.add_string_value (sync_token);
+            builder.set_member_name ("resource_types");
+            builder.begin_array ();
+            builder.add_string_value ("items");
+            builder.end_array ();
+        }
+
         builder.set_member_name ("commands");
 
         builder.begin_array ();
@@ -1715,7 +1725,7 @@ public class Objects.Item : Objects.BaseObject {
             }
         }
 
-        return next_recurrency;
+        return due.datetime;
     }
 
     public void move (Objects.Project project, string _section_id, bool notify = true) {

--- a/core/Objects/Item.vala
+++ b/core/Objects/Item.vala
@@ -435,7 +435,7 @@ public class Objects.Item : Objects.BaseObject {
         }
 
         if (!node.get_object ().get_null_member ("due")) {
-            due.update_from_json (node.get_object ().get_object_member ("due"));
+            due.update_from_todoist_json (node.get_object ().get_object_member ("due"));
         } else {
             due.reset ();
         }
@@ -1133,6 +1133,9 @@ public class Objects.Item : Objects.BaseObject {
             builder.set_member_name ("due");
             builder.begin_object ();
 
+            builder.set_member_name ("string");
+            builder.add_string_value (Utils.Datetime.due_to_todoist_natural_language (due));
+
             builder.set_member_name ("date");
             builder.add_string_value (due.date);
 
@@ -1224,6 +1227,9 @@ public class Objects.Item : Objects.BaseObject {
 
             builder.set_member_name ("date");
             builder.add_string_value (due.date);
+            
+            builder.set_member_name ("string");
+            builder.add_string_value (Utils.Datetime.due_to_todoist_natural_language (due));
 
             builder.end_object ();
         } else {
@@ -1614,6 +1620,8 @@ public class Objects.Item : Objects.BaseObject {
             return;
         }
 
+        due.recurrence_string = "";
+
         if (duedate.recurrency_type == RecurrencyType.MINUTELY ||
             duedate.recurrency_type == RecurrencyType.HOURLY) {
             if (!has_due) {
@@ -1688,7 +1696,7 @@ public class Objects.Item : Objects.BaseObject {
             Services.Store.instance ().update_item (this);
         } else if (project.source_type == SourceType.TODOIST) {
             loading = true;
-            var response = yield Services.Todoist.get_default ().update (this);
+            var response = yield Services.Todoist.get_default ().close_item (this);
             loading = false;
             if (response.status) {
                 Services.Store.instance ().update_item (this);
@@ -1862,6 +1870,11 @@ public class Objects.Item : Objects.BaseObject {
     }
 
     public void update_due (Objects.DueDate duedate) {
+        if (!duedate.is_recurring || duedate.recurrency_type == RecurrencyType.NONE
+            || !due.is_recurrency_equal (duedate)) {
+            due.recurrence_string = "";
+        }
+        
         due.date = duedate.date;
         due.is_recurring = duedate.is_recurring;
         due.recurrency_type = duedate.recurrency_type;

--- a/core/Services/Database.vala
+++ b/core/Services/Database.vala
@@ -308,7 +308,7 @@ public class Services.Database : GLib.Object {
                 due                 TEXT,
                 mm_offset           INTEGER,
                 is_deleted          INTEGER,
-                FOREIGN KEY (item_id) REFERENCES Items (id) ON DELETE CASCADE
+                FOREIGN KEY (item_id) REFERENCES Items (id) ON DELETE CASCADE ON UPDATE CASCADE
             );
         """;
 
@@ -352,7 +352,7 @@ public class Services.Database : GLib.Object {
                 file_name       TEXT,
                 file_size       TEXT,
                 file_path       TEXT,
-                FOREIGN KEY (item_id) REFERENCES Items (id) ON DELETE CASCADE
+                FOREIGN KEY (item_id) REFERENCES Items (id) ON DELETE CASCADE ON UPDATE CASCADE
             );
         """;
 

--- a/core/Services/Database.vala
+++ b/core/Services/Database.vala
@@ -258,7 +258,7 @@ public class Services.Database : GLib.Object {
                 color           TEXT,
                 description     TEXT,
                 hidded          INTEGER,
-                FOREIGN KEY (project_id) REFERENCES Projects (id) ON DELETE CASCADE
+                FOREIGN KEY (project_id) REFERENCES Projects (id) ON DELETE CASCADE ON UPDATE CASCADE
             );
         """;
 
@@ -696,6 +696,12 @@ public class Services.Database : GLib.Object {
         add_text_column ("Projects", "markdown_setting", MarkdownSetting.GLOBAL_DEFAULT.to_string ());
         add_text_column ("Sections", "extra_data", "");
         add_text_column ("Queue", "source_id", "");
+
+        /*
+         * - Rebuild Sections, Reminders and Attachments so their foreign keys
+         *   use ON UPDATE CASCADE
+         */
+        migrate_foreign_keys_on_update_cascade ();
     }
 
     public void clear_database () {
@@ -2554,5 +2560,127 @@ public class Services.Database : GLib.Object {
                 warning ("Error: %d: %s", db.errcode (), db.errmsg ());
             }
         }
+    }
+
+    private bool table_has_on_update_cascade (string table) {
+        Sqlite.Statement stmt;
+
+        sql = """
+            SELECT sql FROM sqlite_master WHERE type = 'table' AND name = $name;
+        """;
+
+        db.prepare_v2 (sql, sql.length, out stmt);
+        set_parameter_str (stmt, "$name", table);
+
+        if (stmt.step () == Sqlite.ROW) {
+            return stmt.column_text (0).contains ("ON UPDATE CASCADE");
+        }
+
+        return true;
+    }
+
+    private void migrate_foreign_keys_on_update_cascade () {
+        bool migrate_sections = !table_has_on_update_cascade ("Sections");
+        bool migrate_reminders = !table_has_on_update_cascade ("Reminders");
+        bool migrate_attachments = !table_has_on_update_cascade ("Attachments");
+
+        if (!migrate_sections && !migrate_reminders && !migrate_attachments) {
+            return;
+        }
+
+        // PRAGMA foreign_keys is a no-op inside a transaction, so it must be
+        // toggled outside of it (SQLite docs, "Making Other Kinds Of Table
+        // Schema Changes").
+        db.exec ("PRAGMA foreign_keys = OFF;", null, null);
+
+        bool success = db.exec ("BEGIN TRANSACTION;", null, out errormsg) == Sqlite.OK;
+
+        if (success && migrate_sections) {
+            success = rebuild_table (
+                "Sections",
+                """
+                    CREATE TABLE Sections_new (
+                        id              TEXT PRIMARY KEY,
+                        name            TEXT,
+                        archived_at     TEXT,
+                        added_at        TEXT,
+                        project_id      TEXT,
+                        section_order   INTEGER,
+                        collapsed       INTEGER,
+                        is_deleted      INTEGER,
+                        is_archived     INTEGER,
+                        color           TEXT,
+                        description     TEXT,
+                        hidded          INTEGER,
+                        extra_data      TEXT,
+                        FOREIGN KEY (project_id) REFERENCES Projects (id) ON DELETE CASCADE ON UPDATE CASCADE
+                    );
+                """,
+                "id, name, archived_at, added_at, project_id, section_order, collapsed, is_deleted, is_archived, color, description, hidded, extra_data"
+            );
+        }
+
+        if (success && migrate_reminders) {
+            success = rebuild_table (
+                "Reminders",
+                """
+                    CREATE TABLE Reminders_new (
+                        id                  TEXT PRIMARY KEY,
+                        notify_uid          INTEGER,
+                        item_id             TEXT,
+                        service             TEXT,
+                        type                TEXT,
+                        due                 TEXT,
+                        mm_offset           INTEGER,
+                        is_deleted          INTEGER,
+                        FOREIGN KEY (item_id) REFERENCES Items (id) ON DELETE CASCADE ON UPDATE CASCADE
+                    );
+                """,
+                "id, notify_uid, item_id, service, type, due, mm_offset, is_deleted"
+            );
+        }
+
+        if (success && migrate_attachments) {
+            success = rebuild_table (
+                "Attachments",
+                """
+                    CREATE TABLE Attachments_new (
+                        id              TEXT PRIMARY KEY,
+                        item_id         TEXT,
+                        file_type       TEXT,
+                        file_name       TEXT,
+                        file_size       TEXT,
+                        file_path       TEXT,
+                        FOREIGN KEY (item_id) REFERENCES Items (id) ON DELETE CASCADE ON UPDATE CASCADE
+                    );
+                """,
+                "id, item_id, file_type, file_name, file_size, file_path"
+            );
+        }
+
+        if (success) {
+            success = db.exec ("COMMIT;", null, out errormsg) == Sqlite.OK;
+        }
+
+        if (!success) {
+            warning ("Foreign key migration failed, rolling back: %s", errormsg);
+            db.exec ("ROLLBACK;", null, null);
+        }
+
+        db.exec ("PRAGMA foreign_keys = ON;", null, null);
+    }
+
+    private bool rebuild_table (string table, string create_new_sql, string columns) {
+        sql = create_new_sql + """
+            INSERT INTO %s_new (%s) SELECT %s FROM %s;
+            DROP TABLE %s;
+            ALTER TABLE %s_new RENAME TO %s;
+        """.printf (table, columns, columns, table, table, table, table);
+
+        if (db.exec (sql, null, out errormsg) != Sqlite.OK) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/core/Services/Todoist/Todoist.vala
+++ b/core/Services/Todoist/Todoist.vala
@@ -68,6 +68,34 @@ public class Services.Todoist : GLib.Object {
      * Sync
      */
 
+    private void process_item_node (Json.Node _node) {
+        Objects.Item ? item = Services.Store.instance ().get_item (_node.get_object ().get_string_member ("id"));
+        if (item != null) {
+            if (_node.get_object ().get_boolean_member ("is_deleted")) {
+                Services.Store.instance ().delete_item (item);
+            } else {
+                string old_project_id = item.project_id;
+                string old_section_id = item.section_id;
+                string old_parent_id = item.parent_id;
+                bool old_checked = item.checked;
+
+                item.update_from_json (_node);
+                Services.Store.instance ().update_item (item);
+
+                if (old_project_id != item.project_id || old_section_id != item.section_id ||
+                    old_parent_id != item.parent_id) {
+                    Services.EventBus.get_default ().item_moved (item, old_project_id, old_section_id, old_parent_id);
+                }
+
+                if (old_checked != item.checked) {
+                    Services.Store.instance ().complete_item (item, old_checked);
+                }
+            }
+        } else {
+            add_item_if_not_exists (_node);
+        }
+    }
+
     public async void sync (Objects.Source source) {
         if (source.todoist_data.access_token == null) {
             return;
@@ -175,31 +203,7 @@ public class Services.Todoist : GLib.Object {
                 // Items
                 unowned Json.Array items = parser.get_root ().get_object ().get_array_member (ITEMS_COLLECTION);
                 foreach (unowned Json.Node _node in items.get_elements ()) {
-                    Objects.Item ? item = Services.Store.instance ().get_item (_node.get_object ().get_string_member ("id"));
-                    if (item != null) {
-                        if (_node.get_object ().get_boolean_member ("is_deleted")) {
-                            Services.Store.instance ().delete_item (item);
-                        } else {
-                            string old_project_id = item.project_id;
-                            string old_section_id = item.section_id;
-                            string old_parent_id = item.parent_id;
-                            bool old_checked = item.checked;
-
-                            item.update_from_json (_node);
-                            Services.Store.instance ().update_item (item);
-
-                            if (old_project_id != item.project_id || old_section_id != item.section_id ||
-                                old_parent_id != item.parent_id) {
-                                Services.EventBus.get_default ().item_moved (item, old_project_id, old_section_id, old_parent_id);
-                            }
-
-                            if (old_checked != item.checked) {
-                                Services.Store.instance ().complete_item (item, old_checked);
-                            }
-                        }
-                    } else {
-                        add_item_if_not_exists (_node);
-                    }
+                    process_item_node (_node);
                 }
 
                 // Reminders
@@ -256,7 +260,7 @@ public class Services.Todoist : GLib.Object {
             return;
         }
 
-        string json = get_queue_json (queue_collection);
+        string json = get_queue_json (queue_collection, source.todoist_data.sync_token);
         Services.LogService.get_default ().info ("Todoist", "Flushing queue: %d items".printf (queue_collection.size));
         Services.LogService.get_default ().debug ("Todoist", "Queue JSON: %s".printf (json));
 
@@ -325,6 +329,11 @@ public class Services.Todoist : GLib.Object {
                     Services.Database.get_default ().remove_queue (q.uuid);
                 }
             }
+            if (node.has_member ("items")) {
+                foreach (unowned Json.Node _node in node.get_array_member ("items").get_elements ()) {
+                    process_item_node (_node);
+                }
+            }
         } catch (Error e) {
             debug (e.message);
         }
@@ -355,9 +364,17 @@ public class Services.Todoist : GLib.Object {
         builder.end_object ();
     }
 
-    public string get_queue_json (Gee.ArrayList<Objects.Queue ?> queue) {
+    public string get_queue_json (Gee.ArrayList<Objects.Queue ?> queue, string sync_token) {
         var builder = new Json.Builder ();
         builder.begin_object ();
+
+        builder.set_member_name ("sync_token");
+        builder.add_string_value (sync_token);
+        builder.set_member_name ("resource_types");
+        builder.begin_array ();
+        builder.add_string_value ("items");
+        builder.end_array ();
+
         builder.set_member_name ("commands");
         builder.begin_array ();
 

--- a/core/Services/Todoist/Todoist.vala
+++ b/core/Services/Todoist/Todoist.vala
@@ -277,6 +277,7 @@ public class Services.Todoist : GLib.Object {
                 Services.LogService.get_default ().debug ("Todoist", "Processing queue item — query: %s, uuid: %s, object_id: %s".printf (q.query, q.uuid, q.object_id));
                 if (uuid_member.get_node_type () == Json.NodeType.VALUE) {
                     var temp_id_mapping = node.get_object_member ("temp_id_mapping");
+                    var success = true;
 
                     if (q.query == "project_add") {
                         if (temp_id_mapping.has_member (q.temp_id)) {
@@ -285,6 +286,7 @@ public class Services.Todoist : GLib.Object {
                             Services.Database.get_default ().remove_CurTempIds (q.object_id);
                         } else {
                             Services.LogService.get_default ().warn ("Todoist", "temp_id_mapping missing for project_add: %s".printf (q.temp_id));
+                            success = false;
                         }
                     }
 
@@ -295,6 +297,7 @@ public class Services.Todoist : GLib.Object {
                             Services.Database.get_default ().remove_CurTempIds (q.object_id);
                         } else {
                             Services.LogService.get_default ().warn ("Todoist", "temp_id_mapping missing for section_add: %s".printf (q.temp_id));
+                            success = false;
                         }
                     }
 
@@ -305,10 +308,12 @@ public class Services.Todoist : GLib.Object {
                             Services.Database.get_default ().remove_CurTempIds (q.object_id);
                         } else {
                             Services.LogService.get_default ().warn ("Todoist", "temp_id_mapping missing for item_add: %s".printf (q.temp_id));
+                            success = false;
                         }
                     }
-
-                    Services.Database.get_default ().remove_queue (q.uuid);
+                    if (success) {
+                        Services.Database.get_default ().remove_queue (q.uuid);
+                    }
                 } else {
                     var sync_status = node.get_object_member ("sync_status");
                     if (sync_status.has_member (q.uuid)) {
@@ -316,8 +321,9 @@ public class Services.Todoist : GLib.Object {
                         Services.LogService.get_default ().warn ("Todoist",
                             "Queue item failed — query: %s, error: %s".printf (
                                 q.query, error_obj.get_string_member ("error")));
+                    } else {
+                        Services.Database.get_default ().remove_queue (q.uuid);
                     }
-                    Services.Database.get_default ().remove_queue (q.uuid);
                 }
             }
         } catch (Error e) {
@@ -411,6 +417,15 @@ public class Services.Todoist : GLib.Object {
                 if (parent_id != "") {
                     builder.set_member_name ("parent_id"); builder.add_string_value (parent_id);
                 }
+                if (Utils.JsonUtils.is_null_member (q.args, "due")) {
+                    builder.set_member_name ("due"); builder.add_null_value ();
+                } else {
+                    builder.set_member_name ("due");
+                    builder.begin_object ();
+                    builder.set_member_name ("date"); builder.add_string_value (Utils.JsonUtils.get_object_member (q.args, "due").get_string_member ("date"));
+                    builder.set_member_name ("string"); builder.add_string_value (Utils.JsonUtils.get_object_member (q.args, "due").get_string_member ("string"));
+                    builder.end_object ();
+                }
                 end_command (builder);
             } else if (q.query == "item_update") {
                 begin_command (builder, "item_update", q.uuid);
@@ -424,6 +439,7 @@ public class Services.Todoist : GLib.Object {
                     builder.set_member_name ("due");
                     builder.begin_object ();
                     builder.set_member_name ("date"); builder.add_string_value (Utils.JsonUtils.get_object_member (q.args, "due").get_string_member ("date"));
+                    builder.set_member_name ("string"); builder.add_string_value (Utils.JsonUtils.get_object_member (q.args, "due").get_string_member ("string"));
                     builder.end_object ();
                 }
                 end_command (builder);
@@ -437,7 +453,7 @@ public class Services.Todoist : GLib.Object {
                 string move_type = Utils.JsonUtils.get_string (q.args, "type");
                 builder.set_member_name (move_type); builder.add_string_value (resolve_id (Utils.JsonUtils.get_string (q.args, move_type)));
                 end_command (builder);
-            } else if (q.query == "item_complete" || q.query == "item_uncomplete") {
+            } else if (q.query == "item_complete" || q.query == "item_uncomplete" || q.query == "item_close") {
                 begin_command (builder, q.query, q.uuid);
                 builder.set_member_name ("id"); builder.add_string_value (resolve_id (Utils.JsonUtils.get_string (q.args, "id")));
                 end_command (builder);
@@ -486,6 +502,10 @@ public class Services.Todoist : GLib.Object {
 
     public async HttpResponse complete_item (Objects.Item item) {
         return yield _items.complete_item (item);
+    }
+    
+    public async HttpResponse close_item (Objects.Item item) {
+        return yield _items.close_item (item);
     }
 
     public async HttpResponse move_item (Objects.Item item, string type, string id) {

--- a/core/Services/Todoist/Todoist.vala
+++ b/core/Services/Todoist/Todoist.vala
@@ -321,9 +321,8 @@ public class Services.Todoist : GLib.Object {
                         Services.LogService.get_default ().warn ("Todoist",
                             "Queue item failed — query: %s, error: %s".printf (
                                 q.query, error_obj.get_string_member ("error")));
-                    } else {
-                        Services.Database.get_default ().remove_queue (q.uuid);
                     }
+                    Services.Database.get_default ().remove_queue (q.uuid);
                 }
             }
         } catch (Error e) {

--- a/core/Services/Todoist/TodoistItems.vala
+++ b/core/Services/Todoist/TodoistItems.vala
@@ -226,6 +226,69 @@ public class Services.TodoistItems : GLib.Object {
 
         return response;
     }
+    
+    public async HttpResponse close_item (Objects.Item item) {
+        HttpResponse response = new HttpResponse ();
+
+        if (item.source.needs_migration ()) {
+            response.status = false;
+            response.error = MIGRATE_MESSAGE;
+            response.error_code = 410;
+            return response;
+        }
+
+        string uuid = Util.get_default ().generate_string ();
+        string json = item.get_check_json (uuid, "item_close");
+        Objects.Source source = item.source;
+
+        var message = new Soup.Message ("POST", TODOIST_SYNC_URL);
+        message.request_headers.append ("Authorization", "Bearer %s".printf (source.todoist_data.access_token));
+        message.set_request_body_from_bytes ("application/json", new Bytes (json.data));
+
+        try {
+            GLib.Bytes stream = yield session.send_and_read_async (message, GLib.Priority.HIGH, null);
+            var parser = new Json.Parser ();
+            parser.load_from_data ((string) stream.get_data ());
+
+            if (Services.Todoist.get_default ().is_todoist_error (message.status_code)) {
+                response.from_error_json (parser.get_root ());
+                debug_error (message.status_code, Services.Todoist.get_default ().get_todoist_error (message.status_code));
+            } else {
+                var sync_status = parser.get_root ().get_object ().get_object_member ("sync_status");
+                var uuid_member = sync_status.get_member (uuid);
+
+                if (uuid_member.get_node_type () == Json.NodeType.VALUE) {
+                    source.todoist_data.sync_token = parser.get_root ().get_object ().get_string_member ("sync_token");
+                    response.status = true;
+                    source.last_sync = new GLib.DateTime.now_local ().to_string ();
+                    source.save ();
+                } else {
+                    response.error = sync_status.get_object_member (uuid).get_string_member ("error");
+                    debug_error (
+                        (uint) sync_status.get_object_member (uuid).get_int_member ("http_code"),
+                        sync_status.get_object_member (uuid).get_string_member ("error")
+                    );
+                }
+            }
+        } catch (Error e) {
+            if (Services.Todoist.get_default ().is_todoist_error (message.status_code)) {
+                response.error = e.message;
+                debug_error (message.status_code, e.message);
+            } else {
+                var queue = new Objects.Queue ();
+                queue.uuid = uuid;
+                queue.object_id = item.id;
+                queue.query = "item_close";
+                queue.args = item.to_json ();
+                queue.source_id = item.source.id;
+
+                Services.Database.get_default ().insert_queue (queue);
+                response.status = true;
+            }
+        }
+
+        return response;
+    }
 
     public async HttpResponse complete_item (Objects.Item item) {
         HttpResponse response = new HttpResponse ();
@@ -411,7 +474,7 @@ public class Services.TodoistItems : GLib.Object {
             if (item.has_due) {
                 builder.set_member_name ("due");
                 builder.begin_object ();
-                builder.set_member_name ("date"); builder.add_string_value (item.due.date);
+                builder.set_member_name ("string"); builder.add_string_value (Utils.Datetime.due_to_todoist_natural_language (item.due));
                 builder.end_object ();
             } else {
                 builder.set_member_name ("due"); builder.add_null_value ();

--- a/core/Services/Todoist/TodoistItems.vala
+++ b/core/Services/Todoist/TodoistItems.vala
@@ -238,7 +238,7 @@ public class Services.TodoistItems : GLib.Object {
         }
 
         string uuid = Util.get_default ().generate_string ();
-        string json = item.get_check_json (uuid, "item_close");
+        string json = item.get_check_json (uuid, "item_close", item.source.todoist_data.sync_token);
         Objects.Source source = item.source;
 
         var message = new Soup.Message ("POST", TODOIST_SYNC_URL);
@@ -260,6 +260,21 @@ public class Services.TodoistItems : GLib.Object {
                 if (uuid_member.get_node_type () == Json.NodeType.VALUE) {
                     source.todoist_data.sync_token = parser.get_root ().get_object ().get_string_member ("sync_token");
                     response.status = true;
+
+                    var root = parser.get_root ().get_object ();
+
+                    if (root.has_member ("items")) {
+                        unowned Json.Array items = root.get_array_member ("items");
+                        foreach (unowned Json.Node node in items.get_elements ()) {
+                            if (node.get_object ().get_string_member ("id") == item.id) {
+                                if (!node.get_object ().get_null_member ("due")) {
+                                    item.due.update_from_todoist_json (node.get_object ().get_object_member ("due"));
+                                }
+                                break;
+                            }
+                        }
+                    }
+
                     source.last_sync = new GLib.DateTime.now_local ().to_string ();
                     source.save ();
                 } else {

--- a/core/Services/Todoist/TodoistProjects.vala
+++ b/core/Services/Todoist/TodoistProjects.vala
@@ -183,7 +183,7 @@ public class Services.TodoistProjects : GLib.Object {
             if (item.has_due) {
                 builder.set_member_name ("due");
                 builder.begin_object ();
-                builder.set_member_name ("date"); builder.add_string_value (item.due.date);
+                builder.set_member_name ("string"); builder.add_string_value (Utils.Datetime.due_to_todoist_natural_language (item.due));
                 builder.end_object ();
             }
 

--- a/core/Utils/Datetime.vala
+++ b/core/Utils/Datetime.vala
@@ -145,9 +145,39 @@ public class Utils.Datetime {
     }
 
     public static void parse_todoist_recurrency (Objects.DueDate duedate, Json.Object object) {
-        if (object.has_member ("lang") && object.get_string_member ("lang") != "en") {
+        if (object.has_member ("lang") && object.get_string_member ("lang") != "en" && object.get_string_member ("lang") != "es") {
             duedate.recurrence_supported = false;
             return;
+        }
+        var lang = object.has_member ("lang") ? object.get_string_member ("lang") : "en";
+        var chrono = new Chrono.Core (lang);
+
+        var result = chrono.parse (duedate.recurrence_string, true);
+        if (result == null || result.recurrence == null) {
+            duedate.recurrence_supported = false;
+            duedate.recurrency_type = RecurrencyType.NONE;
+            duedate.recurrency_interval = 0;
+            duedate.recurrency_weeks = "";
+            return;
+        }
+        
+        duedate.recurrence_supported = true;
+        duedate.is_recurring = true;
+        duedate.recurrency_interval = result.recurrence.interval;
+        switch (result.recurrence.recurrence_type) {
+            case Chrono.RecurrenceType.DAILY:   duedate.recurrency_type = RecurrencyType.EVERY_DAY; break;
+            case Chrono.RecurrenceType.WEEKLY:  duedate.recurrency_type = RecurrencyType.EVERY_WEEK; break;
+            case Chrono.RecurrenceType.MONTHLY: duedate.recurrency_type = RecurrencyType.EVERY_MONTH; break;
+            case Chrono.RecurrenceType.YEARLY:  duedate.recurrency_type = RecurrencyType.EVERY_YEAR; break;
+        }
+
+        if (result.recurrence.days_of_week != null) {
+            string weeks = "";
+            foreach (var day in result.recurrence.days_of_week) {
+                if (day == 0) day = 7;
+                weeks += day.to_string () + ",";
+            }
+            duedate.recurrency_weeks = weeks.substring (0, weeks.length - 1);
         }
     }
 
@@ -483,6 +513,76 @@ public class Utils.Datetime {
             returned = date.format ("%F");
         }
 
+        return returned;
+    }
+
+    private static Regex? _iso_due_regex;
+
+    private static bool is_iso_due_date (string date) {
+        if (date == null || date == "") return false;
+        try {
+            if (_iso_due_regex == null) {
+                _iso_due_regex = new Regex ("^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2})?$");
+            }
+            return _iso_due_regex.match (date);
+        } catch (RegexError e) {
+            return false;
+        }
+    }
+
+    public static string due_to_todoist_natural_language (Objects.DueDate due) {
+        if (due.recurrence_string != "" && due.is_recurring) {
+            return due.recurrence_string;
+        }
+        
+        if (due.date != "" && !is_iso_due_date (due.date)) {
+            return due.date;
+        }
+
+        if (due.is_recurring == false || due.recurrency_type == 0 || due.recurrency_type == 6) {
+            if (due.datetime != null) {
+                return get_todoist_datetime_format (due.datetime);
+            } else {
+                return "";
+            }
+        }
+
+        string[] recurrency_types = {"hour", "day", "week", "month", "year"};
+        string[] days = {"mon,", "tue,", "wed,", "thu,", "fri,", "sat,", "sun,"};
+        string returned = "every ";
+        if (due.recurrency_interval > 1) {
+            returned += due.recurrency_interval.to_string() + " ";
+            returned += recurrency_types[due.recurrency_type - 1];
+            returned += "s ";
+        } else if (!(due.recurrency_type == 3 && due.recurrency_weeks != "")){
+            returned += recurrency_types[due.recurrency_type - 1] + " ";
+        }
+        if (due.recurrency_type == 3 && due.recurrency_weeks != "") {
+            if (due.recurrency_weeks == "1,2,3,4,5") {
+                returned += "weekday";
+                if (due.recurrency_interval > 1) {
+                    returned += "s";
+                }
+                returned += " ";
+            } else {
+                var selected_days = due.recurrency_weeks.split (",");
+                foreach (var day in selected_days) {
+                    returned += days[int.parse (day) - 1];
+                }
+                returned = returned[0:-1] + " ";
+            }
+        }
+
+        if (has_time (due.datetime)) {
+            returned += "at ";
+            var time = due.datetime.format ("%T");
+            returned += time[0:-3];
+        }
+
+        if (due.recurrency_end != "") {
+            returned += "until ";
+            returned += due.end_datetime.format ("%F");
+        }        
         return returned;
     }
 

--- a/core/Utils/Datetime.vala
+++ b/core/Utils/Datetime.vala
@@ -169,15 +169,19 @@ public class Utils.Datetime {
             case Chrono.RecurrenceType.WEEKLY: duedate.recurrency_type = RecurrencyType.EVERY_WEEK; break;
             case Chrono.RecurrenceType.MONTHLY: duedate.recurrency_type = RecurrencyType.EVERY_MONTH; break;
             case Chrono.RecurrenceType.YEARLY: duedate.recurrency_type = RecurrencyType.EVERY_YEAR; break;
+            default: duedate.recurrency_type = RecurrencyType.EVERY_DAY; break;
         }
 
+        duedate.recurrency_weeks = "";
         if (result.recurrence.days_of_week != null) {
             string weeks = "";
             foreach (var day in result.recurrence.days_of_week) {
                 if (day == 0) day = 7;
                 weeks += day.to_string () + ",";
             }
-            duedate.recurrency_weeks = weeks.substring (0, weeks.length - 1);
+            if (weeks.length > 0) {
+                duedate.recurrency_weeks = weeks.substring (0, weeks.length - 1);
+            }
         }
     }
 
@@ -539,7 +543,7 @@ public class Utils.Datetime {
             return due.date;
         }
 
-        if (due.is_recurring == false || due.recurrency_type == 0 || due.recurrency_type == 6) {
+        if (due.is_recurring == false || due.recurrency_type < RecurrencyType.HOURLY || due.recurrency_type > RecurrencyType.EVERY_YEAR) {
             if (due.datetime != null) {
                 return get_todoist_datetime_format (due.datetime);
             } else {
@@ -547,17 +551,26 @@ public class Utils.Datetime {
             }
         }
 
-        string[] recurrency_types = {"hour", "day", "week", "month", "year"};
+        var recurrency_type_string = "";
+        switch (due.recurrency_type) {
+            case RecurrencyType.HOURLY: recurrency_type_string = "hour"; break;
+            case RecurrencyType.EVERY_DAY: recurrency_type_string = "day"; break;
+            case RecurrencyType.EVERY_WEEK: recurrency_type_string = "week"; break;
+            case RecurrencyType.EVERY_MONTH: recurrency_type_string = "month"; break;
+            case RecurrencyType.EVERY_YEAR: recurrency_type_string = "year"; break;
+            default: recurrency_type_string = "day"; break;
+        }
+
         string[] days = {"mon,", "tue,", "wed,", "thu,", "fri,", "sat,", "sun,"};
         string returned = "every ";
         if (due.recurrency_interval > 1) {
             returned += due.recurrency_interval.to_string () + " ";
-            returned += recurrency_types[due.recurrency_type - 1];
+            returned += recurrency_type_string;
             returned += "s ";
-        } else if (!(due.recurrency_type == 3 && due.recurrency_weeks != "")) {
-            returned += recurrency_types[due.recurrency_type - 1] + " ";
+        } else if (!(due.recurrency_type == RecurrencyType.EVERY_WEEK && due.recurrency_weeks != "")) { 
+            returned += recurrency_type_string + " ";
         }
-        if (due.recurrency_type == 3 && due.recurrency_weeks != "") {
+        if (due.recurrency_type == RecurrencyType.EVERY_WEEK && due.recurrency_weeks != "") {
             if (due.recurrency_weeks == "1,2,3,4,5") {
                 returned += "weekday";
                 if (due.recurrency_interval > 1) {
@@ -567,13 +580,15 @@ public class Utils.Datetime {
             } else {
                 var selected_days = due.recurrency_weeks.split (",");
                 foreach (var day in selected_days) {
-                    returned += days[int.parse (day) - 1];
+                    int dayint = int.parse (day);
+                    if (dayint > 7 || dayint < 1) continue;
+                    returned += days[dayint - 1];
                 }
                 returned = returned[0:-1] + " ";
             }
         }
 
-        if (has_time (due.datetime)) {
+        if (due.datetime != null && has_time (due.datetime)) {
             returned += "at ";
             var time = due.datetime.format ("%T");
             returned += time[0:-3];

--- a/core/Utils/Datetime.vala
+++ b/core/Utils/Datetime.vala
@@ -165,10 +165,10 @@ public class Utils.Datetime {
         duedate.is_recurring = true;
         duedate.recurrency_interval = result.recurrence.interval;
         switch (result.recurrence.recurrence_type) {
-            case Chrono.RecurrenceType.DAILY:   duedate.recurrency_type = RecurrencyType.EVERY_DAY; break;
-            case Chrono.RecurrenceType.WEEKLY:  duedate.recurrency_type = RecurrencyType.EVERY_WEEK; break;
+            case Chrono.RecurrenceType.DAILY: duedate.recurrency_type = RecurrencyType.EVERY_DAY; break;
+            case Chrono.RecurrenceType.WEEKLY: duedate.recurrency_type = RecurrencyType.EVERY_WEEK; break;
             case Chrono.RecurrenceType.MONTHLY: duedate.recurrency_type = RecurrencyType.EVERY_MONTH; break;
-            case Chrono.RecurrenceType.YEARLY:  duedate.recurrency_type = RecurrencyType.EVERY_YEAR; break;
+            case Chrono.RecurrenceType.YEARLY: duedate.recurrency_type = RecurrencyType.EVERY_YEAR; break;
         }
 
         if (result.recurrence.days_of_week != null) {
@@ -551,10 +551,10 @@ public class Utils.Datetime {
         string[] days = {"mon,", "tue,", "wed,", "thu,", "fri,", "sat,", "sun,"};
         string returned = "every ";
         if (due.recurrency_interval > 1) {
-            returned += due.recurrency_interval.to_string() + " ";
+            returned += due.recurrency_interval.to_string () + " ";
             returned += recurrency_types[due.recurrency_type - 1];
             returned += "s ";
-        } else if (!(due.recurrency_type == 3 && due.recurrency_weeks != "")){
+        } else if (!(due.recurrency_type == 3 && due.recurrency_weeks != "")) {
             returned += recurrency_types[due.recurrency_type - 1] + " ";
         }
         if (due.recurrency_type == 3 && due.recurrency_weeks != "") {


### PR DESCRIPTION
This fixes #1584 and Todoist recurring tasks integration in general.
### Planify -> Todoist recurring task creation and update:
#### What was:
Recurrence information wasn't sent as Todoist expected a NL string for recurring tasks which wasn't generated.
#### Whats now:
Generates NL string in English that successful creates an equivalent recurring task at Todoist. uses item_close instead of item_complete or item_update as Todoist recommends and item_close automatically triggers a reschedule at Todoist
#### Whats still not fixed:
there are recurrence rules that Planify support and Todoist doesn't and vice versa.
### Todoist -> Planify recurring task creation:
#### What was:
Recurrence information was simply ignored despite chrono being able to parse NL into Planify properties.
#### Whats now:
App now stores the recurrence string, uses chrono to parse it and successfully generates an equivalent recurring task.
#### Whats still not fixed:
chrono is not perfect
### Zombie tasks with reminders:
#### What was:
Tasks with reminders that were created while offline would create zombie tasks that would return after deletion after each restart.
#### Whats now:
Added on update cascade to tables now they work properly. touched queue logic now retries on temp_id failures
#### Whats still now fixed:
Requires a database recreation to take effect.

### Additional notes:
#### AI disclosure:
This is my first time touching vala so i heavily relied on ai guidance and code may not be perfect. None of the code was directly ai generated but none of it is also fully free of it.
