### PR TITLE
fix: read X-PINNED and X-APPLE-SORT-ORDER correctly from CalDAV

### DIFF
--- a/core/Objects/Item.vala
+++ b/core/Objects/Item.vala
@@ -577,7 +577,7 @@ public class Objects.Item : Objects.BaseObject {
             completed_at = "";
         }
 
-        ICal.Property ? sort_order_property = ical_vtodo.get_first_property (ICal.PropertyKind.from_string ("X-APPLE-SORT-ORDER"));
+        ICal.Property ? sort_order_property = find_x_property (ical_vtodo, "X-APPLE-SORT-ORDER");
         if (sort_order_property != null) {
             var sort_order_str = sort_order_property.get_value_as_string ();
             if (sort_order_str != null) {
@@ -595,7 +595,7 @@ public class Objects.Item : Objects.BaseObject {
             }
         }
 
-        ICal.Property ? pinned_property = ical_vtodo.get_first_property (ICal.PropertyKind.from_string ("X-PINNED"));
+        ICal.Property ? pinned_property = find_x_property (ical_vtodo, "X-PINNED");
         if (pinned_property != null) {
             var pinned_str = pinned_property.get_value_as_string ();
             if (pinned_str != null) {
@@ -617,6 +617,17 @@ public class Objects.Item : Objects.BaseObject {
         }
         #endif
         // TODO: Reimplement without ECAL
+    }
+
+    private static ICal.Property ? find_x_property (ICal.Component component, string x_name) {
+        ICal.Property ? prop = component.get_first_property (ICal.PropertyKind.X_PROPERTY);
+        while (prop != null) {
+            if (prop.get_x_name () == x_name) {
+                return prop;
+            }
+            prop = component.get_next_property (ICal.PropertyKind.X_PROPERTY);
+        }
+        return null;
     }
 
     private Gee.ArrayList<Objects.Label> get_caldav_categories (GLib.SList<string> categories_list) {


### PR DESCRIPTION
`ICal.PropertyKind.from_string()` does not resolve custom X-properties, so `get_first_property()` never found X-PINNED or X-APPLE-SORT-ORDER when reading from CalDAV servers like Radicale.

Replaced with iteration over `X_PROPERTY` kind and matching by `get_x_name()`, which is the correct way to look up X-properties in libical.

Tested with Radicale — pin status and sort order now persist across syncs.

Fixes #2540