### PR TITLE
Add "Date Modified" sort option and subtitle support in context menu

### DIFF
--- a/core/Enum.vala
+++ b/core/Enum.vala
@@ -648,6 +648,7 @@ public enum SortedByType {
     NAME,
     DUE_DATE,
     ADDED_DATE,
+    UPDATED_DATE,
     PRIORITY;
 
     public string to_string () {
@@ -663,6 +664,9 @@ public enum SortedByType {
 
             case ADDED_DATE:
                 return "added-date";
+
+            case UPDATED_DATE:
+                return "updated-date";
 
             case PRIORITY:
                 return "priority";
@@ -685,6 +689,9 @@ public enum SortedByType {
 
             case "added-date":
                 return SortedByType.ADDED_DATE;
+
+            case "updated-date":
+                return SortedByType.UPDATED_DATE;
 
             case "priority":
                 return SortedByType.PRIORITY;

--- a/core/Utils/Util.vala
+++ b/core/Utils/Util.vala
@@ -1162,6 +1162,10 @@ We hope you’ll enjoy using Planify!""");
             }
         } else if (sorted_by == SortedByType.ADDED_DATE) {
             result = item1.added_datetime.compare (item2.added_datetime);
+        } else if (sorted_by == SortedByType.UPDATED_DATE) {
+            var date1 = item1.updated_at != "" ? item1.updated_datetime : item1.added_datetime;
+            var date2 = item2.updated_at != "" ? item2.updated_datetime : item2.added_datetime;
+            result = date1.compare (date2);
         } else if (sorted_by == SortedByType.PRIORITY) {
             result = item2.priority - item1.priority;
             if (result == 0) {

--- a/core/Widgets/ContextMenu/MenuItem.vala
+++ b/core/Widgets/ContextMenu/MenuItem.vala
@@ -23,6 +23,8 @@ public class Widgets.ContextMenu.MenuItem : Gtk.Button {
     private Gtk.Image menu_icon;
     private Gtk.Revealer menu_icon_revealer;
     private Gtk.Label menu_title;
+    private Gtk.Label subtitle_label;
+    private Gtk.Revealer subtitle_revealer;
     private Gtk.Label secondary_label;
     private Gtk.Label badge_label;
     private Gtk.Revealer loading_revealer;
@@ -72,6 +74,13 @@ public class Widgets.ContextMenu.MenuItem : Gtk.Button {
             secondary_label.label = value;
             secondary_label.tooltip_text = value;
             secondary_label_revealer.reveal_child = value.length > 0;
+        }
+    }
+
+    public string subtitle {
+        set {
+            subtitle_label.label = value;
+            subtitle_revealer.reveal_child = value.length > 0;
         }
     }
 
@@ -148,7 +157,19 @@ public class Widgets.ContextMenu.MenuItem : Gtk.Button {
 
         menu_title = new Gtk.Label (null) {
             use_markup = true,
-            ellipsize = Pango.EllipsizeMode.END
+            ellipsize = Pango.EllipsizeMode.END,
+            halign = START
+        };
+
+        subtitle_label = new Gtk.Label (null) {
+            css_classes = { "caption", "dimmed" },
+            ellipsize = Pango.EllipsizeMode.END,
+            xalign = 0
+        };
+
+        subtitle_revealer = new Gtk.Revealer () {
+            transition_type = Gtk.RevealerTransitionType.SLIDE_DOWN,
+            child = subtitle_label
         };
 
         select_revealer = new Gtk.Revealer () {
@@ -206,8 +227,14 @@ public class Widgets.ContextMenu.MenuItem : Gtk.Button {
             hexpand = true
         };
 
+        var title_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 0) {
+            valign = CENTER
+        };
+        title_box.append (menu_title);
+        title_box.append (subtitle_revealer);
+
         content_box.append (menu_icon_revealer);
-        content_box.append (menu_title);
+        content_box.append (title_box);
         content_box.append (end_box);
 
         child = content_box;

--- a/src/Layouts/ItemRow.vala
+++ b/src/Layouts/ItemRow.vala
@@ -1380,6 +1380,11 @@ public class Layouts.ItemRow : Layouts.ItemBase {
         delete_item.add_css_class ("menu-item-danger");
 
         var more_information_item = new Widgets.ContextMenu.MenuItem (_ ("Change History"), "rotation-edit-symbolic");
+        if (item.updated_at != "") {
+            more_information_item.subtitle = _("Updated: %s").printf (Utils.Datetime.get_relative_date_from_date (item.updated_datetime));
+        } else {
+            more_information_item.subtitle = _("Created: %s").printf (Utils.Datetime.get_relative_date_from_date (item.added_datetime));
+        }
 
         var popover = new Gtk.Popover () {
             has_arrow = false,

--- a/src/Layouts/SectionRow.vala
+++ b/src/Layouts/SectionRow.vala
@@ -331,9 +331,10 @@ public class Layouts.SectionRow : Gtk.ListBoxRow {
             if (items_map.has_key (item.id)) {
                 if (items_map[item.id].update_id != update_id) {
                     items_map[item.id].update_request ();
-                    if (section.project.sorted_by != SortedByType.MANUAL) {
-                        update_sort ();
-                    }
+                }
+
+                if (section.project.sorted_by != SortedByType.MANUAL) {
+                    update_sort ();
                 }
 
                 if (checked_items_map.has_key (item.id)) {

--- a/src/Views/Project/Project.vala
+++ b/src/Views/Project/Project.vala
@@ -544,6 +544,7 @@ public class Views.Project : Adw.Bin {
         sorted_by_item.add_item (_("Alphabetically"), SortedByType.NAME.to_string ());
         sorted_by_item.add_item (_("Due Date"), SortedByType.DUE_DATE.to_string ());
         sorted_by_item.add_item (_("Date Added"), SortedByType.ADDED_DATE.to_string ());
+        sorted_by_item.add_item (_("Date Modified"), SortedByType.UPDATED_DATE.to_string ());
         sorted_by_item.add_item (_("Priority"), SortedByType.PRIORITY.to_string ());
 
         var sort_order_item = new Widgets.ContextMenu.MenuSwitch (_ ("Ascending Order"), "view-sort-ascending-rtl-symbolic") {

--- a/src/Views/Scheduled/Scheduled.vala
+++ b/src/Views/Scheduled/Scheduled.vala
@@ -238,6 +238,7 @@ public class Views.Scheduled.Scheduled : Adw.Bin {
         sorted_by_item.add_item (_("Alphabetically"), SortedByType.NAME.to_string ());
         sorted_by_item.add_item (_("Due Date"), SortedByType.DUE_DATE.to_string ());
         sorted_by_item.add_item (_("Date Added"), SortedByType.ADDED_DATE.to_string ());
+        sorted_by_item.add_item (_("Date Modified"), SortedByType.UPDATED_DATE.to_string ());
         sorted_by_item.add_item (_("Priority"), SortedByType.PRIORITY.to_string ());
 
         // Filters

--- a/src/Views/Today.vala
+++ b/src/Views/Today.vala
@@ -724,6 +724,7 @@ public class Views.Today : Adw.Bin {
         sorted_by_item.add_item (_("Alphabetically"), SortedByType.NAME.to_string ());
         sorted_by_item.add_item (_("Due Date"), SortedByType.DUE_DATE.to_string ());
         sorted_by_item.add_item (_("Date Added"), SortedByType.ADDED_DATE.to_string ());
+        sorted_by_item.add_item (_("Date Modified"), SortedByType.UPDATED_DATE.to_string ());
         sorted_by_item.add_item (_("Priority"), SortedByType.PRIORITY.to_string ());
 
         // Filters


### PR DESCRIPTION
- **Sort by Date Modified**: Added `UPDATED_DATE` to `SortedByType` enum, available in Project, Today, and Scheduled views. Falls back to `added_datetime` for items that have never been edited.

- **MenuItem subtitle property**: New `subtitle` property on `Widgets.ContextMenu.MenuItem` that displays text below the primary label (vertical layout) with `caption` + `dimmed` styling.

- **Change History subtitle**: The "Change History" context menu item now shows "Updated: \<relative date\>" or "Created: \<relative date\>" as subtitle, respecting the user's 12h/24h clock-format preference.

Fixes: #2539
