### PR TITLE
Allow archiving Nextcloud Deck projects

### DIFF
--- a/src/Layouts/ProjectRow.vala
+++ b/src/Layouts/ProjectRow.vala
@@ -733,10 +733,13 @@ public class Layouts.ProjectRow : Gtk.ListBoxRow {
         menu_box.append (share_email_item);
         menu_box.append (export_pdf_item);
 
-        if (!project.is_deck && !project.inbox_project) {
+        if (!project.inbox_project) {
             menu_box.append (new Widgets.ContextMenu.MenuSeparator ());
             menu_box.append (archive_item);
-            menu_box.append (delete_item);
+
+            if (!project.is_deck) {
+                menu_box.append (delete_item);
+            }
         }
 
         menu_popover = new Gtk.Popover () {


### PR DESCRIPTION
Deck projects were excluded from the archive option because the archived state can't be synced back to Nextcloud Deck via CalDAV. However, users may want to hide Deck boards they don't use from the sidebar.

This allows archiving Deck projects locally in Planify. The delete option remains blocked for Deck projects to prevent accidental remote data loss.

Closes: #2516