### PR TITLE
fix: Do not prepend https:// to app links.

### DIFF
--- a/core/Widgets/MarkdownEditor.vala
+++ b/core/Widgets/MarkdownEditor.vala
@@ -1698,15 +1698,15 @@ public class Widgets.MarkdownEditor : Adw.Bin {
     
     private string normalize_url (string url) {
         var trimmed_url = url.strip ();
-        
-        if (trimmed_url.contains ("://")) {
+
+        if (Regex.match_simple ("^[a-zA-Z][a-zA-Z0-9+.-]*:", trimmed_url)) {
             return trimmed_url;
         }
-        
+
         if (trimmed_url.contains (".") && !trimmed_url.contains (" ")) {
             return "https://" + trimmed_url;
         }
-        
+
         return trimmed_url;
     }
     

--- a/core/Widgets/MarkdownEditor.vala
+++ b/core/Widgets/MarkdownEditor.vala
@@ -1699,7 +1699,7 @@ public class Widgets.MarkdownEditor : Adw.Bin {
     private string normalize_url (string url) {
         var trimmed_url = url.strip ();
 
-        if (Regex.match_simple ("^[a-zA-Z][a-zA-Z0-9+.-]*:", trimmed_url)) {
+        if (GLib.Uri.parse_scheme (trimmed_url) != null) {
             return trimmed_url;
         }
 


### PR DESCRIPTION
Fixes an issue where app links don't work.

When links are clicked in markdown, the URL gets normalized. The normalize function will work for an app link like `planify://`, but it clobber a link like `mailto:`, or `mid:` because it only looks for a `://`.

`tel:` links technically already work because if the app link does _not_ contain a `.`, it will pass the link through unchanged. This is not the case for `mailto:` and `mid:`.

This PR adjusts the Regex to more accurately normalize URLs that better supports app links.

fixes #2551 

## Security

As far as I can tell this does not expose any new attack surfaces.

URLs are still parsed all the same by `extract_url_from_link()`, it's the markdown normalizing that is changed. The only concern would be `javascript:` links, but those actually already worked if you didn't use a `.`. And they're not as big a concern when the web browser is going to open them in a new tab. (In comparison to bookmarklet links clicked inside a web browser, which run on top of the current web page)

## Testing

I tested locally with GNOME Builder to confirm `mid:` links are now working. Regular web links still work.

This PR is most easily tested using a `mailto:` link, since `mid:` might be a bit tricky to get set up.

If you add a link like `mailto:test@gmail.com` and then click on it. On `main` that link will be altered by Planify and it will just send you to "gmail.com" in the web browser. On this PR, clicking the `mailto:` link should open an email program to draft a new email.

## Logs

When I put the cursor on a link in markdown, I do see this error:

```vala
(io.github.alainm23.planify.Devel:2): Gtk-WARNING **: 18:03:06.246: Invalid text buffer iterator: either the iterator is uninitialized, or the characters/paintables/widgets in the buffer have been modified since the iterator was created.
You must use marks, character numbers, or line numbers to preserve a position across buffer modifications.
You can apply tags and insert marks without invalidating your iterators, but any mutation that affects 'indexable' buffer contents (contents that can be referred to by character offset) will invalidate all outstanding iterators

(io.github.alainm23.planify.Devel:2): Gtk-CRITICAL **: 18:03:06.246: gtk_text_view_get_iter_location: assertion 'gtk_text_iter_get_buffer (iter) == get_buffer (text_view)' failed

```

However, I see that same error on `main` as well. Opening the links does not show any errors. As far as I can tell, no new errors are introduced.

## AI

Claude helped with triage and some coding. This PR description is human written.