### PR TITLE
fix: date picker shows wrong date for Today/Tomorrow after midnight

### DIFF
--- a/core/Widgets/DateTimePicker/DateTimePicker.vala
+++ b/core/Widgets/DateTimePicker/DateTimePicker.vala
@@ -160,7 +160,18 @@ public class Widgets.DateTimePicker.DateTimePicker : Gtk.Popover {
             placeholder_text = _("Type a date…")
         };
 
+        var suggested_date_box = new Adw.WrapBox () {
+            child_spacing = 6,
+            line_spacing = 6,
+            margin_bottom = 6
+        };
+
         show.connect (() => {
+            while (suggested_date_box.get_first_child () != null) {
+                suggested_date_box.remove (suggested_date_box.get_first_child ());
+            }
+            add_default_suggestions (suggested_date_box);
+
             Timeout.add (100, () => {
                 search_entry.grab_focus ();
                 return GLib.Source.REMOVE;
@@ -177,12 +188,6 @@ public class Widgets.DateTimePicker.DateTimePicker : Gtk.Popover {
 
             return false;
         });
-
-        var suggested_date_box = new Adw.WrapBox () {
-            child_spacing = 6,
-            line_spacing = 6,
-            margin_bottom = 6
-        };
 
         calendar_view = new Widgets.Calendar.CalendarMonth ();
 
@@ -247,7 +252,6 @@ public class Widgets.DateTimePicker.DateTimePicker : Gtk.Popover {
 
         child = main_stack;
         add_css_class ("popover-contents");
-        add_default_suggestions (suggested_date_box);
 
         time_option_button.clicked.connect (() => {
             show_revealer (time_option_revealer);


### PR DESCRIPTION
Fixes an issue where the "Today", "Tomorrow", and "Next week" suggestions in the date picker showed stale dates if Planify was left open overnight.

Fixes: #2557
