### PR TITLE
Fix description being overwritten during sync and sidebar editor visibility

### DIFF
--- a/src/Layouts/ItemSidebarView.vala
+++ b/src/Layouts/ItemSidebarView.vala
@@ -418,12 +418,17 @@ public class Layouts.ItemSidebarView : Adw.Bin {
     }
 
     public void update_request () {
-        content_textview.set_text (item.content);
+        if (!content_textview.has_focus || content_textview.get_text () == item.content) {
+            content_textview.set_text (item.content);
+        }
 
         if (markdown_editor != null) {
-            destroy_markdown_signals ();
-            markdown_editor.set_text (item.description);
-            build_markdown_signals ();   
+            var current_text = markdown_editor.get_text ().chomp ();
+            if (!markdown_editor.text_view.has_focus || current_text == item.description) {
+                destroy_markdown_signals ();
+                markdown_editor.set_text (item.description);
+                build_markdown_signals ();
+            }
         }     
 
         schedule_button.update_from_item (item);

--- a/src/Layouts/ItemSidebarView.vala
+++ b/src/Layouts/ItemSidebarView.vala
@@ -39,6 +39,7 @@ public class Layouts.ItemSidebarView : Adw.Bin {
     private Widgets.SubItems subitems;
     private Widgets.Attachments attachments;
 
+    private uint destroy_editor_timeout_id = 0;
     private Widgets.ContextMenu.MenuSwitch use_note_item;
     private Widgets.ContextMenu.MenuItem copy_clipboard_item;
     private Widgets.ContextMenu.MenuItem duplicate_item;
@@ -344,9 +345,7 @@ public class Layouts.ItemSidebarView : Adw.Bin {
         item = _item;
         update_id = Util.get_default ().generate_id ();
 
-        if (!always_show || markdown_editor == null) {
-            build_markdown_editor ();
-        }
+        build_markdown_editor ();
 
         label_button.source = item.project.source;
         update_request ();
@@ -706,6 +705,13 @@ public class Layouts.ItemSidebarView : Adw.Bin {
             return;
         }
 
+        // Cancel pending destroy timeout to prevent it from wiping the new editor
+        if (destroy_editor_timeout_id != 0) {
+            GLib.Source.remove (destroy_editor_timeout_id);
+            destroy_editor_timeout_id = 0;
+            markdown_editor_revealer.child = null;
+        }
+
         markdown_editor = new Widgets.MarkdownEditor () {
             project = item.project
         };
@@ -743,11 +749,17 @@ public class Layouts.ItemSidebarView : Adw.Bin {
         }
 
         destroy_markdown_signals ();
-        
+        markdown_editor = null;
+
+        if (destroy_editor_timeout_id != 0) {
+            GLib.Source.remove (destroy_editor_timeout_id);
+            destroy_editor_timeout_id = 0;
+        }
+
         markdown_editor_revealer.reveal_child = false;
-        Timeout.add (markdown_editor_revealer.transition_duration, () => {
+        destroy_editor_timeout_id = Timeout.add (markdown_editor_revealer.transition_duration, () => {
             markdown_editor_revealer.child = null;
-            markdown_editor = null;
+            destroy_editor_timeout_id = 0;
             return GLib.Source.REMOVE;
         });
     }

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -125,7 +125,7 @@ public class MainWindow : Adw.ApplicationWindow {
             min_sidebar_width = 360,
             content = views_stack,
             sidebar = item_sidebar_view,
-            show_sidebar = false
+            show_sidebar = Services.Settings.get_default ().settings.get_boolean ("always-show-details-sidebar")
         };
 
         toast_overlay = new Adw.ToastOverlay () {


### PR DESCRIPTION
- Fix description/content being wiped when background sync triggers while user is typing
- Fix markdown editor not showing when `always-show-details-sidebar` is enabled
- Fix sidebar not visible on startup when `always-show-details-sidebar` is enabled
- Fix race condition where destroy timeout would wipe newly created markdown editor

fixes: #2220
