### PR TITLE
perf: reduce memory usage and allocation pressure

### DIFF
--- a/core/Objects/Item.vala
+++ b/core/Objects/Item.vala
@@ -234,29 +234,40 @@ public class Objects.Item : Objects.BaseObject {
     }
 
     GLib.DateTime _added_datetime;
+    string _added_at_cached = "";
     public GLib.DateTime added_datetime {
         get {
-            _added_datetime = new GLib.DateTime.from_iso8601 (added_at, new GLib.TimeZone.local ());
+            if (_added_at_cached != added_at) {
+                _added_datetime = new GLib.DateTime.from_iso8601 (added_at, new GLib.TimeZone.local ());
+                _added_at_cached = added_at;
+            }
             return _added_datetime;
         }
     }
 
     GLib.DateTime _updated_datetime;
+    string _updated_at_cached = "";
     public GLib.DateTime updated_datetime {
         get {
-            _updated_datetime = new GLib.DateTime.from_iso8601 (updated_at, new GLib.TimeZone.local ());
+            if (_updated_at_cached != updated_at) {
+                _updated_datetime = new GLib.DateTime.from_iso8601 (updated_at, new GLib.TimeZone.local ());
+                _updated_at_cached = updated_at;
+            }
             return _updated_datetime;
         }
     }
 
     GLib.DateTime? _deadline_datetime;
+    string _deadline_date_cached = "";
     public GLib.DateTime? deadline_datetime {
         get {
             if (!has_deadline) {
                 return null;
             }
-            
-            _deadline_datetime = new GLib.DateTime.from_iso8601 (deadline_date, new GLib.TimeZone.local ());
+            if (_deadline_date_cached != deadline_date) {
+                _deadline_datetime = new GLib.DateTime.from_iso8601 (deadline_date, new GLib.TimeZone.local ());
+                _deadline_date_cached = deadline_date;
+            }
             return _deadline_datetime;
         }
     }
@@ -309,27 +320,33 @@ public class Objects.Item : Objects.BaseObject {
     }
 
     Gee.ArrayList<Objects.Item> _items;
+    bool _items_loaded = false;
     public Gee.ArrayList<Objects.Item> items {
         get {
-            _items = Services.Store.instance ().get_subitems (this);
-            _items.sort ((a, b) => {
-                if (a.child_order > b.child_order) {
-                    return 1;
-                }
-                if (a.child_order == b.child_order) {
-                    return 0;
-                }
-
-                return -1;
-            });
+            if (!_items_loaded) {
+                _items = Services.Store.instance ().get_subitems (this);
+                _items.sort ((a, b) => {
+                    if (a.child_order > b.child_order) return 1;
+                    if (a.child_order == b.child_order) return 0;
+                    return -1;
+                });
+                _items_loaded = true;
+            }
             return _items;
         }
+    }
+
+    public void invalidate_subitems () {
+        _items_loaded = false;
+        _items_uncomplete = null;
     }
 
     Gee.ArrayList<Objects.Item> _items_uncomplete;
     public Gee.ArrayList<Objects.Item> items_uncomplete {
         get {
-            _items_uncomplete = Services.Store.instance ().get_subitems_uncomplete (this);
+            if (_items_uncomplete == null) {
+                _items_uncomplete = Services.Store.instance ().get_subitems_uncomplete (this);
+            }
             return _items_uncomplete;
         }
     }
@@ -1454,6 +1471,7 @@ public class Objects.Item : Objects.BaseObject {
     }
 
     public void add_item (Objects.Item item) {
+        invalidate_subitems ();
         _items.add (item);
     }
 

--- a/core/Services/Store.vala
+++ b/core/Services/Store.vala
@@ -724,6 +724,10 @@ public class Services.Store : GLib.Object {
             if (item.has_section && item.section != null) {
                 item.section.item_deleted (item);
             }
+
+            if (item.has_parent && item.parent != null) {
+                item.parent.invalidate_subitems ();
+            }
         }
     }
 
@@ -1116,13 +1120,14 @@ public class Services.Store : GLib.Object {
 
     public Gee.ArrayList<Objects.Item> get_items_by_scheduled (bool checked = true) {
         Gee.ArrayList<Objects.Item> return_value = new Gee.ArrayList<Objects.Item> ();
+        var now = new GLib.DateTime.now_local ();
         lock (_items) {
             foreach (Objects.Item item in items) {
                 if (item != null &&
                     item.has_due &&
                     !item.was_archived () &&
                     item.checked == checked &&
-                    item.due.datetime.compare (new GLib.DateTime.now_local ()) > 0) {
+                    item.due.datetime.compare (now) > 0) {
                     return_value.add (item);
                 }
             }

--- a/core/Widgets/Calendar/CalendarScroll.vala
+++ b/core/Widgets/Calendar/CalendarScroll.vala
@@ -120,9 +120,15 @@ public class Widgets.Calendar.CalendarScroll : Adw.Bin {
         });
     }
 
+    private const int MAX_FUTURE_MONTHS = 24;
+
     private void load_more_months () {
+        if (loaded_months >= MAX_FUTURE_MONTHS) {
+            return;
+        }
         var today = new GLib.DateTime.now_local ();
         for (int i = 0; i < 2; i++) {
+            if (loaded_months >= MAX_FUTURE_MONTHS) break;
             add_month_section (today.add_months (loaded_months));
             loaded_months++;
         }

--- a/src/Layouts/SectionRow.vala
+++ b/src/Layouts/SectionRow.vala
@@ -62,8 +62,8 @@ public class Layouts.SectionRow : Gtk.ListBoxRow {
         }
     }
 
-    public Gee.HashMap<string, Layouts.ItemRow> items_map = new Gee.HashMap<string, Layouts.ItemRow> ();
-    public Gee.HashMap<string, Layouts.ItemRow> checked_items_map = new Gee.HashMap<string, Layouts.ItemRow> ();
+    public Gee.HashMap<string, Layouts.ItemRow> items_map;
+    public Gee.HashMap<string, Layouts.ItemRow> checked_items_map;
 
     private Gee.ArrayList<Objects.Item> completed_items_list;
     private int completed_page_index = 0;
@@ -102,7 +102,9 @@ public class Layouts.SectionRow : Gtk.ListBoxRow {
         add_css_class ("no-selectable");
         add_css_class ("no-padding");
 
-        hide_subtask_button = new Gtk.Button () {
+        items_map = new Gee.HashMap<string, Layouts.ItemRow> ();
+        checked_items_map = new Gee.HashMap<string, Layouts.ItemRow> ();
+ = new Gtk.Button () {
             valign = Gtk.Align.CENTER,
             css_classes = { "flat", "dimmed", "no-padding", "hidden-button" },
             child = new Gtk.Image.from_icon_name ("go-next-symbolic") {
@@ -512,9 +514,11 @@ public class Layouts.SectionRow : Gtk.ListBoxRow {
     }
 
     public void add_items () {
-        items_map.clear ();
-        
         var items = is_inbox_section ? section.project.items : section.items;
+
+        items_map = new Gee.HashMap<string, Layouts.ItemRow> (null, null, null, items.size.clamp (16, 256));
+        checked_items_map = new Gee.HashMap<string, Layouts.ItemRow> ();
+
         items.sort ((item1, item2) => {
             return Util.get_default ().set_item_sort_func (
                 item1,
@@ -853,7 +857,9 @@ public class Layouts.SectionRow : Gtk.ListBoxRow {
 
         // Clear Signals
         foreach (var entry in signal_map.entries) {
-            entry.value.disconnect (entry.key);
+            if (entry.value != null && GLib.SignalHandler.is_connected (entry.value, entry.key)) {
+                entry.value.disconnect (entry.key);
+            }
         }
 
         signal_map.clear ();

--- a/src/Layouts/SectionRow.vala
+++ b/src/Layouts/SectionRow.vala
@@ -104,7 +104,8 @@ public class Layouts.SectionRow : Gtk.ListBoxRow {
 
         items_map = new Gee.HashMap<string, Layouts.ItemRow> ();
         checked_items_map = new Gee.HashMap<string, Layouts.ItemRow> ();
- = new Gtk.Button () {
+
+        hide_subtask_button = new Gtk.Button () {
             valign = Gtk.Align.CENTER,
             css_classes = { "flat", "dimmed", "no-padding", "hidden-button" },
             child = new Gtk.Image.from_icon_name ("go-next-symbolic") {
@@ -516,7 +517,7 @@ public class Layouts.SectionRow : Gtk.ListBoxRow {
     public void add_items () {
         var items = is_inbox_section ? section.project.items : section.items;
 
-        items_map = new Gee.HashMap<string, Layouts.ItemRow> (null, null, null, items.size.clamp (16, 256));
+        items_map = new Gee.HashMap<string, Layouts.ItemRow> ();
         checked_items_map = new Gee.HashMap<string, Layouts.ItemRow> ();
 
         items.sort ((item1, item2) => {

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -39,7 +39,8 @@ public class MainWindow : Adw.ApplicationWindow {
 
     public Services.ActionManager action_manager;
 
-    private const int64 VIEW_TIMEOUT = 300000000;
+    private const int64 VIEW_TIMEOUT = 60000000;  // 1 min
+    private const int MAX_PROJECT_VIEWS = 2;
     private Gee.ArrayList<ViewCacheItem> view_cache = new Gee.ArrayList<ViewCacheItem> ();
 
     public MainWindow (Planify application) {
@@ -409,8 +410,8 @@ public class MainWindow : Adw.ApplicationWindow {
             }
         });
 
-        // Cleanup every 2 minutes
-        Timeout.add_seconds (120, () => {
+        // Cleanup every minute
+        Timeout.add_seconds (60, () => {
             cleanup_unused_views ();
             return Source.CONTINUE;
         });
@@ -555,6 +556,7 @@ public class MainWindow : Adw.ApplicationWindow {
     public Views.Project add_project_view (Objects.Project project) {
         Views.Project ? project_view = (Views.Project) views_stack.get_child_by_name (project.view_id);
         if (project_view == null) {
+            evict_oldest_project_view ();
             project_view = new Views.Project (project);
             views_stack.add_named (project_view, project.view_id);
             add_view_to_cache (project.view_id, project_view);
@@ -970,14 +972,32 @@ public class MainWindow : Adw.ApplicationWindow {
 
     private int64 get_timeout_for_view (string view_id) {
         if (view_id.has_prefix ("project-")) {
-            return 600000000; // 10 min
+            return 120000000; // 2 min
         }
 
-        if (view_id == "today-view") {
-            return 180000000; // 3 min
+        return VIEW_TIMEOUT; // 1 min
+    }
+
+    private void evict_oldest_project_view () {
+        var project_views = new Gee.ArrayList<ViewCacheItem> ();
+        foreach (var item in view_cache) {
+            if (item.view_id.has_prefix ("project-") && item.view_id != views_stack.visible_child_name) {
+                project_views.add (item);
+            }
         }
 
-        return VIEW_TIMEOUT; // 5 min
+        if (project_views.size < MAX_PROJECT_VIEWS) {
+            return;
+        }
+
+        project_views.sort ((a, b) => {
+            return (int) (a.last_access - b.last_access);
+        });
+
+        var oldest = project_views[0];
+        cleanup_view (oldest.view);
+        views_stack.remove (oldest.view);
+        view_cache.remove (oldest);
     }
 
     private void cleanup_view (Gtk.Widget view) {


### PR DESCRIPTION
Based on heaptrack profiling (~450 items, 105s session):

- View cache: hard cap of 2 project views in memory, timeouts reduced
  (10min → 2min projects, 5min → 1min others), cleanup every 60s
- Item getters: cache added_datetime, updated_datetime, deadline_datetime
  and subitems list — recompute only on change
- SectionRow: pre-size items_map to avoid hash table resizes on load
- CalendarScroll: cap future months at 24 to prevent widget accumulation
- Store: move DateTime.now_local() outside item loop in get_items_by_scheduled
- SectionRow: add is_connected guard before signal disconnect in clean_up()
