### PR TITLE
fix: --background flag no longer exits immediately

### DIFF
--- a/src/App.vala
+++ b/src/App.vala
@@ -148,7 +148,9 @@ public class Planify : Adw.Application {
             main_window.maximize ();
         }
 
-        if (!run_in_background) {
+        if (run_in_background) {
+            hold ();
+        } else {
             main_window.show ();
         }
 

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -474,6 +474,7 @@ public class MainWindow : Adw.ApplicationWindow {
                 hide ();
                 return true;
             }
+            Planify.instance.release ();
             return false;
         });
     }


### PR DESCRIPTION
When launching Planify with `--background`, the application exited immediately because `Adw.Application` terminates as soon as no windows are visible. The `hold()`/`release()` calls were missing.

Closes: #2614
