### PR TITLE
feat(quickfind): description search, section+project name, result count footer, snippet highlight

### DIFF
--- a/src/Dialogs/QuickFind/QuickFind.vala
+++ b/src/Dialogs/QuickFind/QuickFind.vala
@@ -21,6 +21,8 @@
 
 public class Dialogs.QuickFind.QuickFind : Adw.Dialog {
     private Gtk.SearchEntry search_entry;
+    private Gtk.Label results_count_label;
+    private Gtk.Revealer results_count_revealer;
     private Gtk.ListView list_view;
     private Gtk.ScrolledWindow list_view_scrolled;
     private ListStore list_store;
@@ -30,6 +32,7 @@ public class Dialogs.QuickFind.QuickFind : Adw.Dialog {
     private Gtk.SignalListItemFactory list_item_factory;
     private Gtk.SignalListItemFactory header_factory;
     private Gtk.Stack stack;
+    private Adw.ToolbarView toolbar_view;
 
     public QuickFind () {
         Object (
@@ -52,6 +55,17 @@ public class Dialogs.QuickFind.QuickFind : Adw.Dialog {
 
         var cancel_button = new Gtk.Button.with_label (_ ("Cancel")) {
             css_classes = { "flat" }
+        };
+
+        results_count_label = new Gtk.Label (null) {
+            css_classes = { "caption", "dimmed" },
+            margin_top = 6,
+            margin_bottom = 6
+        };
+
+        results_count_revealer = new Gtk.Revealer () {
+            transition_type = Gtk.RevealerTransitionType.SLIDE_UP,
+            child = results_count_label
         };
 
         var headerbar_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 6) {
@@ -121,8 +135,12 @@ public class Dialogs.QuickFind.QuickFind : Adw.Dialog {
         stack.add_titled (get_placeholder (), "placeholder", "Placeholder");
         stack.add_titled (list_view_scrolled, "list", "List");
 
-        var toolbar_view = new Adw.ToolbarView ();
+        toolbar_view = new Adw.ToolbarView () {
+            bottom_bar_style = Adw.ToolbarStyle.RAISED_BORDER,
+            reveal_bottom_bars = false
+        };
         toolbar_view.add_top_bar (headerbar);
+        toolbar_view.add_bottom_bar (results_count_revealer);
         toolbar_view.content = stack;
 
         child = toolbar_view;
@@ -240,6 +258,11 @@ public class Dialogs.QuickFind.QuickFind : Adw.Dialog {
         var has_results = filter_model.get_n_items () > 0;
         stack.set_visible_child_name (has_results ? "list" : "placeholder");
 
+        var count = filter_model.get_n_items ();
+        results_count_label.label = ngettext ("%u result", "%u results", count).printf (count);
+        results_count_revealer.reveal_child = search_entry.text.strip () != "" && has_results;
+        toolbar_view.reveal_bottom_bars = search_entry.text.strip () != "" && has_results;
+
         if (has_results) {
             Idle.add (() => {
                 list_view_scrolled.vadjustment.set_value (0);
@@ -306,7 +329,18 @@ public class Dialogs.QuickFind.QuickFind : Adw.Dialog {
         } else if (base_object is Objects.Item) {
             var item_obj = (Objects.Item) base_object;
             var item_content = item_obj.content.down ();
-            matches = search_text_lower in item_content;
+            var item_description = item_obj.description.down ();
+            bool content_match = search_text_lower in item_content;
+            bool description_match = search_text_lower in item_description;
+            matches = content_match || description_match;
+            item.matched_description = !content_match && description_match;
+            if (item.matched_description) {
+                item.description_snippet = get_description_snippet (item_obj.description, search_text_lower);
+            }
+        } else if (base_object is Objects.Section) {
+            var section = (Objects.Section) base_object;
+            matches = search_text_lower in section.name.down () ||
+                      search_text_lower in section.project.name.down ();
         } else {
             matches = search_text_lower in base_object.name.down ();
         }
@@ -371,5 +405,18 @@ public class Dialogs.QuickFind.QuickFind : Adw.Dialog {
 
     private void hide_destroy () {
         close ();
+    }
+
+    private string get_description_snippet (string description, string pattern) {
+        var desc_lower = description.down ();
+        int idx = desc_lower.index_of (pattern);
+        if (idx < 0) return "";
+
+        int start = int.max (0, idx - 30);
+        int end = int.min (description.length, idx + pattern.length + 30);
+        var snippet = description.substring (start, end - start).strip ();
+        if (start > 0) snippet = "…" + snippet;
+        if (end < description.length) snippet = snippet + "…";
+        return snippet;
     }
 }

--- a/src/Dialogs/QuickFind/QuickFindFactory.vala
+++ b/src/Dialogs/QuickFind/QuickFindFactory.vala
@@ -168,6 +168,16 @@ public class Dialogs.QuickFind.QuickFindFactory : GLib.Object {
         main_grid.attach (checked_button, 0, 0, 1, 2);
         main_grid.attach (content_label, 1, 0, 1, 1);
         main_grid.attach (project_label, 1, 1, 1, 1);
+
+        if (item.matched_description && item.description_snippet != "") {
+            var snippet_label = new Gtk.Label (markup_string_with_search (item.description_snippet, item.pattern)) {
+                ellipsize = Pango.EllipsizeMode.END,
+                xalign = 0,
+                use_markup = true,
+                css_classes = { "dimmed", "caption" }
+            };
+            main_grid.attach (snippet_label, 1, 2, 1, 1);
+        }
     }
 
     private static void bind_label (QuickFindItem item, Gtk.Grid main_grid) {

--- a/src/Dialogs/QuickFind/QuickFindItem.vala
+++ b/src/Dialogs/QuickFind/QuickFindItem.vala
@@ -22,6 +22,8 @@
 public class Dialogs.QuickFind.QuickFindItem : GLib.Object {
     public Objects.BaseObject base_object { get; construct; }
     public string pattern { get; set; }
+    public bool matched_description { get; set; default = false; }
+    public string description_snippet { get; set; default = ""; }
 
     public QuickFindItem (Objects.BaseObject base_object, string pattern) {
         Object (base_object: base_object, pattern: pattern);

--- a/src/Layouts/ItemSidebarView.vala
+++ b/src/Layouts/ItemSidebarView.vala
@@ -45,6 +45,7 @@ public class Layouts.ItemSidebarView : Adw.Bin {
     private Widgets.ContextMenu.MenuItem duplicate_item;
     private Widgets.ContextMenu.MenuItem move_item;
     private Widgets.ContextMenu.MenuItem export_ics_item;
+    private Widgets.ContextMenu.MenuItem more_information_item;
 
     private Gee.HashMap<ulong, GLib.Object> signals_map = new Gee.HashMap<ulong, GLib.Object> ();
     private Gee.HashMap<ulong, weak GLib.Object> markdown_handlerses = new Gee.HashMap<ulong, weak GLib.Object> ();
@@ -465,6 +466,12 @@ public class Layouts.ItemSidebarView : Adw.Bin {
         deadline_button.sensitive = !item.completed;
         export_ics_item.visible = item.project.source_type == SourceType.CALDAV;
 
+        if (item.updated_at != "") {
+            more_information_item.subtitle = _("Updated: %s").printf (Utils.Datetime.get_relative_date_from_date (item.updated_datetime));
+        } else {
+            more_information_item.subtitle = _("Created: %s").printf (Utils.Datetime.get_relative_date_from_date (item.added_datetime));
+        }
+
         if (item.completed) {
             deadline_button.remove_error_style ();
         }
@@ -513,7 +520,7 @@ public class Layouts.ItemSidebarView : Adw.Bin {
         var delete_item = new Widgets.ContextMenu.MenuItem (_("Delete Task"), "user-trash-symbolic");
         delete_item.add_css_class ("menu-item-danger");
 
-        var more_information_item = new Widgets.ContextMenu.MenuItem (_("Change History"), "rotation-edit-symbolic");
+        more_information_item = new Widgets.ContextMenu.MenuItem (_("Change History"), "rotation-edit-symbolic");
 
         var popover = new Gtk.Popover () {
             has_arrow = false,


### PR DESCRIPTION
Improves QuickFind with 4 enhancements:

- Search in item description (in addition to title)
- Section search now includes parent project name
- Result count footer with slide-up animation (Adw.ToolbarView bottom bar)
- When match comes from description only, shows a 60-char snippet around 
  the match with bold highlight via markup_string_with_search
  
  
<img width="449" height="373" alt="image" src="https://github.com/user-attachments/assets/584b00a6-93dc-4e28-875d-5ace034cc478" />
