### PR TITLE
feat: add calendar sources preferences page

### DIFF
--- a/core/Services/CalendarEvents/CalendarEvents.vala
+++ b/core/Services/CalendarEvents/CalendarEvents.vala
@@ -334,24 +334,6 @@ public class Services.CalendarEvents : Object {
         return sources;
     }
 
-    public void set_source_enabled (E.Source source, bool enabled) {
-        var uid = source.dup_uid ();
-        var disabled = Services.Settings.get_default ().settings.get_strv ("calendar-sources-disabled");
-        var list = new Gee.ArrayList<string>.wrap (disabled);
-
-        if (enabled) {
-            list.remove (uid);
-            add_source_async.begin (source);
-        } else {
-            if (!list.contains (uid)) {
-                list.add (uid);
-            }
-            remove_source (source);
-        }
-
-        Services.Settings.get_default ().settings.set_strv ("calendar-sources-disabled", list.to_array ());
-    }
-
     public bool is_source_enabled (E.Source source) {
         var disabled = Services.Settings.get_default ().settings.get_strv ("calendar-sources-disabled");
         return !(source.dup_uid () in disabled);

--- a/core/Services/CalendarEvents/CalendarEvents.vala
+++ b/core/Services/CalendarEvents/CalendarEvents.vala
@@ -84,9 +84,11 @@ public class Services.CalendarEvents : Object {
             registry.source_removed.connect (remove_source);
             registry.source_added.connect ((source) => add_source_async.begin (source));
 
+            var disabled_sources = Services.Settings.get_default ().settings.get_strv ("calendar-sources-disabled");
+
             registry.list_sources (E.SOURCE_EXTENSION_CALENDAR).foreach ((source) => {
                 E.SourceCalendar cal = (E.SourceCalendar) source.get_extension (E.SOURCE_EXTENSION_CALENDAR);
-                if (cal.selected == true && source.enabled == true) {
+                if (cal.selected == true && source.enabled == true && !(source.dup_uid () in disabled_sources)) {
                     add_source_async.begin (source);
                 }
             });
@@ -330,6 +332,29 @@ public class Services.CalendarEvents : Object {
         });
 
         return sources;
+    }
+
+    public void set_source_enabled (E.Source source, bool enabled) {
+        var uid = source.dup_uid ();
+        var disabled = Services.Settings.get_default ().settings.get_strv ("calendar-sources-disabled");
+        var list = new Gee.ArrayList<string>.wrap (disabled);
+
+        if (enabled) {
+            list.remove (uid);
+            add_source_async.begin (source);
+        } else {
+            if (!list.contains (uid)) {
+                list.add (uid);
+            }
+            remove_source (source);
+        }
+
+        Services.Settings.get_default ().settings.set_strv ("calendar-sources-disabled", list.to_array ());
+    }
+
+    public bool is_source_enabled (E.Source source) {
+        var disabled = Services.Settings.get_default ().settings.get_strv ("calendar-sources-disabled");
+        return !(source.dup_uid () in disabled);
     }
 
     private async ECal.Client? get_client (string source_uid) {

--- a/data/io.github.alainm23.planify.gschema.xml
+++ b/data/io.github.alainm23.planify.gschema.xml
@@ -245,6 +245,12 @@
             <description>Enable calendar integration to display tasks with due dates in calendar views and sync with system calendar</description>
         </key>
 
+        <key name="calendar-sources-disabled" type="as">
+            <default>[]</default>
+            <summary>Disabled calendar sources</summary>
+            <description>List of calendar source UIDs that are hidden from Planify's calendar views</description>
+        </key>
+
         <key name="views-order-visible" type="as">
             <default>['inbox', 'today', 'scheduled', 'labels']</default>
             <summary>Visible views and their order</summary>

--- a/src/Dialogs/Preferences/Pages/CalendarEvents.vala
+++ b/src/Dialogs/Preferences/Pages/CalendarEvents.vala
@@ -1,0 +1,119 @@
+/*
+ * Copyright © 2025 Alain M. (https://github.com/alainm23/planify)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA
+ *
+ * Authored by: Alain M. <alainmh23@gmail.com>
+ */
+
+public class Dialogs.Preferences.Pages.CalendarEvents : Dialogs.Preferences.Pages.BasePage {
+    public CalendarEvents (Adw.PreferencesDialog preferences_dialog) {
+        Object (
+            preferences_dialog: preferences_dialog,
+            title: _("Calendar Events")
+        );
+    }
+
+    ~CalendarEvents () {
+        debug ("Destroying - Dialogs.Preferences.Pages.CalendarEvents\n");
+    }
+
+    construct {
+        var calendar_enabled_switch = new Gtk.Switch () {
+            valign = Gtk.Align.CENTER,
+            active = Services.Settings.get_default ().settings.get_boolean ("calendar-enabled")
+        };
+
+        var calendar_enabled_row = new Adw.ActionRow ();
+        calendar_enabled_row.title = _("Show Calendar Events");
+        calendar_enabled_row.subtitle = _("Display events from your calendars in Planify");
+        calendar_enabled_row.set_activatable_widget (calendar_enabled_switch);
+        calendar_enabled_row.add_suffix (calendar_enabled_switch);
+
+        var enabled_group = new Adw.PreferencesGroup ();
+        enabled_group.add (calendar_enabled_row);
+
+        var sources_group = new Adw.PreferencesGroup ();
+        sources_group.title = _("Calendars");
+        sources_group.description = _("Choose which calendars to show in Planify");
+
+        var calendar_service = Services.CalendarEvents.get_default ();
+        foreach (E.Source source in calendar_service.get_all_sources ()) {
+            if (!source.has_extension (E.SOURCE_EXTENSION_CALENDAR)) {
+                continue;
+            }
+
+            E.SourceCalendar cal = (E.SourceCalendar) source.get_extension (E.SOURCE_EXTENSION_CALENDAR);
+            if (!cal.selected || !source.enabled) {
+                continue;
+            }
+
+            var source_switch = new Gtk.Switch () {
+                valign = Gtk.Align.CENTER,
+                active = calendar_service.is_source_enabled (source),
+                sensitive = calendar_enabled_switch.active
+            };
+
+            var color_dot = new Gtk.Image () {
+                pixel_size = 14
+            };
+            color_dot.add_css_class ("calendar-color-dot");
+
+            var source_row = new Adw.ActionRow ();
+            source_row.title = source.dup_display_name ();
+            source_row.set_activatable_widget (source_switch);
+            source_row.add_prefix (color_dot);
+            source_row.add_suffix (source_switch);
+
+            sources_group.add (source_row);
+
+            signal_map[source_switch.notify["active"].connect (() => {
+                calendar_service.set_source_enabled (source, source_switch.active);
+            })] = source_switch;
+        }
+
+        var content_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 12) {
+            margin_start = 12,
+            margin_end = 12,
+            margin_bottom = 12,
+            margin_top = 6
+        };
+        content_box.append (enabled_group);
+        content_box.append (sources_group);
+
+        var scrolled_window = new Gtk.ScrolledWindow () {
+            hscrollbar_policy = Gtk.PolicyType.NEVER,
+            hexpand = true,
+            vexpand = true,
+            child = content_box
+        };
+
+        var toolbar_view = new Adw.ToolbarView ();
+        toolbar_view.add_top_bar (new Adw.HeaderBar ());
+        toolbar_view.content = scrolled_window;
+
+        child = toolbar_view;
+
+        signal_map[calendar_enabled_switch.notify["active"].connect (() => {
+            Services.Settings.get_default ().settings.set_boolean ("calendar-enabled", calendar_enabled_switch.active);
+            sources_group.sensitive = calendar_enabled_switch.active;
+        })] = calendar_enabled_switch;
+
+        destroy.connect (() => {
+            clean_up ();
+        });
+    }
+}

--- a/src/Dialogs/Preferences/Pages/CalendarEvents.vala
+++ b/src/Dialogs/Preferences/Pages/CalendarEvents.vala
@@ -46,11 +46,8 @@ public class Dialogs.Preferences.Pages.CalendarEvents : Dialogs.Preferences.Page
         var enabled_group = new Adw.PreferencesGroup ();
         enabled_group.add (calendar_enabled_row);
 
-        var sources_group = new Adw.PreferencesGroup ();
-        sources_group.title = _("Calendars");
-        sources_group.description = _("Choose which calendars to show in Planify");
-
         var sources_map = new Gee.HashMap<string, Gtk.Switch> ();
+        var groups_map = new Gee.HashMap<string, Adw.PreferencesGroup> ();
 
         var calendar_service = Services.CalendarEvents.get_default ();
         var all_sources = calendar_service.get_all_sources ();
@@ -83,19 +80,20 @@ public class Dialogs.Preferences.Pages.CalendarEvents : Dialogs.Preferences.Page
             var source_row = new Adw.ActionRow ();
             source_row.title = source.dup_display_name ();
             source_row.use_markup = false;
-
-            var parent_uid = source.dup_parent ();
-            if (parent_uid != null) {
-                var parent = calendar_service.registry.ref_source (parent_uid);
-                if (parent != null) {
-                    source_row.subtitle = parent.dup_display_name ();
-                }
-            }
             source_row.set_activatable_widget (source_switch);
             source_row.add_prefix (color_grid);
             source_row.add_suffix (source_switch);
 
-            sources_group.add (source_row);
+            var parent_uid = source.dup_parent () ?? "";
+            if (!groups_map.has_key (parent_uid)) {
+                var group = new Adw.PreferencesGroup ();
+                var parent = calendar_service.registry.ref_source (parent_uid);
+                if (parent != null) {
+                    group.title = parent.dup_display_name ();
+                }
+                groups_map[parent_uid] = group;
+            }
+            groups_map[parent_uid].add (source_row);
 
             signal_map[source_switch.notify["active"].connect (() => {
                 string[] sources_disabled = {};
@@ -115,7 +113,11 @@ public class Dialogs.Preferences.Pages.CalendarEvents : Dialogs.Preferences.Page
             margin_top = 6
         };
         content_box.append (enabled_group);
-        content_box.append (sources_group);
+        var sorted_keys = new Gee.ArrayList<string>.wrap (groups_map.keys.to_array ());
+        sorted_keys.sort ((a, b) => groups_map[a].title.collate (groups_map[b].title));
+        foreach (var key in sorted_keys) {
+            content_box.append (groups_map[key]);
+        }
 
         var scrolled_window = new Gtk.ScrolledWindow () {
             hscrollbar_policy = Gtk.PolicyType.NEVER,
@@ -132,7 +134,9 @@ public class Dialogs.Preferences.Pages.CalendarEvents : Dialogs.Preferences.Page
 
         signal_map[calendar_enabled_switch.notify["active"].connect (() => {
             Services.Settings.get_default ().settings.set_boolean ("calendar-enabled", calendar_enabled_switch.active);
-            sources_group.sensitive = calendar_enabled_switch.active;
+            foreach (var group in groups_map.values) {
+                group.sensitive = calendar_enabled_switch.active;
+            }
         })] = calendar_enabled_switch;
 
         destroy.connect (() => {

--- a/src/Dialogs/Preferences/Pages/CalendarEvents.vala
+++ b/src/Dialogs/Preferences/Pages/CalendarEvents.vala
@@ -50,8 +50,11 @@ public class Dialogs.Preferences.Pages.CalendarEvents : Dialogs.Preferences.Page
         sources_group.title = _("Calendars");
         sources_group.description = _("Choose which calendars to show in Planify");
 
+        var sources_map = new Gee.HashMap<string, Gtk.Switch> ();
+
         var calendar_service = Services.CalendarEvents.get_default ();
-        foreach (E.Source source in calendar_service.get_all_sources ()) {
+        var all_sources = calendar_service.get_all_sources ();
+        foreach (E.Source source in all_sources) {
             if (!source.has_extension (E.SOURCE_EXTENSION_CALENDAR)) {
                 continue;
             }
@@ -63,25 +66,45 @@ public class Dialogs.Preferences.Pages.CalendarEvents : Dialogs.Preferences.Page
 
             var source_switch = new Gtk.Switch () {
                 valign = Gtk.Align.CENTER,
-                active = calendar_service.is_source_enabled (source),
+                active = !(source.dup_uid () in Services.Settings.get_default ().settings.get_strv ("calendar-sources-disabled")),
                 sensitive = calendar_enabled_switch.active
             };
 
-            var color_dot = new Gtk.Image () {
-                pixel_size = 14
+            sources_map[source.dup_uid ()] = source_switch;
+
+            var color_grid = new Gtk.Grid () {
+                width_request = 3,
+                height_request = 24,
+                valign = Gtk.Align.CENTER,
+                css_classes = { "event-bar" }
             };
-            color_dot.add_css_class ("calendar-color-dot");
+            Util.get_default ().set_widget_color (cal.dup_color (), color_grid);
 
             var source_row = new Adw.ActionRow ();
             source_row.title = source.dup_display_name ();
+            source_row.use_markup = false;
+
+            var parent_uid = source.dup_parent ();
+            if (parent_uid != null) {
+                var parent = calendar_service.registry.ref_source (parent_uid);
+                if (parent != null) {
+                    source_row.subtitle = parent.dup_display_name ();
+                }
+            }
             source_row.set_activatable_widget (source_switch);
-            source_row.add_prefix (color_dot);
+            source_row.add_prefix (color_grid);
             source_row.add_suffix (source_switch);
 
             sources_group.add (source_row);
 
             signal_map[source_switch.notify["active"].connect (() => {
-                calendar_service.set_source_enabled (source, source_switch.active);
+                string[] sources_disabled = {};
+                foreach (var entry in sources_map.entries) {
+                    if (!entry.value.active) {
+                        sources_disabled += entry.key;
+                    }
+                }
+                Services.Settings.get_default ().settings.set_strv ("calendar-sources-disabled", sources_disabled);
             })] = source_switch;
         }
 

--- a/src/Dialogs/Preferences/Pages/General.vala
+++ b/src/Dialogs/Preferences/Pages/General.vala
@@ -87,18 +87,6 @@ public class Dialogs.Preferences.Pages.General : Dialogs.Preferences.Pages.BaseP
         de_group.add (run_background_row);
         #endif
 
-        var calendar_events_switch = new Gtk.Switch () {
-            valign = Gtk.Align.CENTER,
-            active = Services.Settings.get_default ().settings.get_boolean ("calendar-enabled")
-        };
-
-        var calendar_events_row = new Adw.ActionRow ();
-        calendar_events_row.title = _("Calendar Events");
-        calendar_events_row.set_activatable_widget (calendar_events_switch);
-        calendar_events_row.add_suffix (calendar_events_switch);
-
-        de_group.add (calendar_events_row);
-
         var search_provider_row = new Adw.ActionRow ();
         search_provider_row.title = _("GNOME Shell Search");
         search_provider_row.subtitle = _("Search tasks and projects directly from GNOME Shell. Enable it in Settings → Search");
@@ -195,10 +183,6 @@ public class Dialogs.Preferences.Pages.General : Dialogs.Preferences.Pages.BaseP
 
         signal_map[run_on_startup_handler] = run_on_startup_switch;
 #endif
-
-        signal_map[calendar_events_switch.notify["active"].connect (() => {
-            Services.Settings.get_default ().settings.set_boolean ("calendar-enabled", calendar_events_switch.active);
-        })] = calendar_events_switch;
 
         signal_map[smart_date_recognition_switch.notify["active"].connect (() => {
             Services.Settings.get_default ().settings.set_boolean ("smart-date-recognition", smart_date_recognition_switch.active);

--- a/src/Dialogs/Preferences/PreferencesWindow.vala
+++ b/src/Dialogs/Preferences/PreferencesWindow.vala
@@ -71,17 +71,6 @@ public class Dialogs.Preferences.PreferencesWindow : Adw.PreferencesDialog {
             push_subpage (build_page ("home-view"));
         })] = home_page_row;
 
-        var calendar_events_row = new Adw.ActionRow () {
-            activatable = true,
-            title = _("Calendar Events"),
-            subtitle = _("Manage which calendars are shown")
-        };
-        calendar_events_row.add_prefix (generate_icon ("office-calendar-symbolic"));
-        calendar_events_row.add_suffix (generate_icon ("go-next-symbolic"));
-
-        signal_map[calendar_events_row.activated.connect (() => {
-            push_subpage (build_page ("calendar-events"));
-        })] = calendar_events_row;
 
         var general_row = new Adw.ActionRow ();
         general_row.activatable = true;
@@ -126,6 +115,18 @@ public class Dialogs.Preferences.PreferencesWindow : Adw.PreferencesDialog {
             push_subpage (build_page ("appearance"));
         })] = appearance_row;
 
+        var calendar_events_row = new Adw.ActionRow () {
+            activatable = true,
+            title = _("Calendar Events"),
+            subtitle = _("Manage which calendars are shown")
+        };
+        calendar_events_row.add_prefix (generate_icon ("month-symbolic"));
+        calendar_events_row.add_suffix (generate_icon ("go-next-symbolic"));
+
+        signal_map[calendar_events_row.activated.connect (() => {
+            push_subpage (build_page ("calendar-events"));
+        })] = calendar_events_row;
+
         var quick_add_row = new Adw.ActionRow ();
         quick_add_row.activatable = true;
         quick_add_row.add_prefix (generate_icon ("tab-new-symbolic"));
@@ -153,11 +154,11 @@ public class Dialogs.Preferences.PreferencesWindow : Adw.PreferencesDialog {
 
         var personalization_group = new Adw.PreferencesGroup ();
         personalization_group.add (home_page_row);
-        personalization_group.add (calendar_events_row);
         personalization_group.add (general_row);
         personalization_group.add (task_setting_row);
         personalization_group.add (sidebar_row);
         personalization_group.add (appearance_row);
+        personalization_group.add (calendar_events_row);
         personalization_group.add (quick_add_row);
         personalization_group.add (backups_row);
         personalization_group.add (tutorial_row);

--- a/src/Dialogs/Preferences/PreferencesWindow.vala
+++ b/src/Dialogs/Preferences/PreferencesWindow.vala
@@ -71,6 +71,18 @@ public class Dialogs.Preferences.PreferencesWindow : Adw.PreferencesDialog {
             push_subpage (build_page ("home-view"));
         })] = home_page_row;
 
+        var calendar_events_row = new Adw.ActionRow () {
+            activatable = true,
+            title = _("Calendar Events"),
+            subtitle = _("Manage which calendars are shown")
+        };
+        calendar_events_row.add_prefix (generate_icon ("office-calendar-symbolic"));
+        calendar_events_row.add_suffix (generate_icon ("go-next-symbolic"));
+
+        signal_map[calendar_events_row.activated.connect (() => {
+            push_subpage (build_page ("calendar-events"));
+        })] = calendar_events_row;
+
         var general_row = new Adw.ActionRow ();
         general_row.activatable = true;
         general_row.add_prefix (generate_icon ("settings-symbolic"));
@@ -141,6 +153,7 @@ public class Dialogs.Preferences.PreferencesWindow : Adw.PreferencesDialog {
 
         var personalization_group = new Adw.PreferencesGroup ();
         personalization_group.add (home_page_row);
+        personalization_group.add (calendar_events_row);
         personalization_group.add (general_row);
         personalization_group.add (task_setting_row);
         personalization_group.add (sidebar_row);
@@ -362,6 +375,9 @@ public class Dialogs.Preferences.PreferencesWindow : Adw.PreferencesDialog {
                 break;
             case "sidebar-page":
                 page_map[page] = new Dialogs.Preferences.Pages.Sidebar (this);
+                break;
+            case "calendar-events":
+                page_map[page] = new Dialogs.Preferences.Pages.CalendarEvents (this);
                 break;
             case "general-page":
                 page_map[page] = new Dialogs.Preferences.Pages.General (this);

--- a/src/Widgets/EventsList.vala
+++ b/src/Widgets/EventsList.vala
@@ -40,7 +40,13 @@ public class Widgets.EventsList : Adw.Bin {
 
     public bool has_items {
         get {
-            return event_hashmap.size > 0;
+            var disabled = Services.Settings.get_default ().settings.get_strv ("calendar-sources-disabled");
+            foreach (var entry in event_hashmap.entries) {
+                if (!(entry.value.source.dup_uid () in disabled)) {
+                    return true;
+                }
+            }
+            return false;
         }
     }
 
@@ -92,6 +98,11 @@ public class Widgets.EventsList : Adw.Bin {
         };
 
         listbox.set_sort_func (sort_event_function);
+        listbox.set_filter_func ((row) => {
+            var event_row = (Widgets.EventRow) row;
+            var disabled = Services.Settings.get_default ().settings.get_strv ("calendar-sources-disabled");
+            return !(event_row.source.dup_uid () in disabled);
+        });
         listbox.add_css_class ("listbox-background");
 
         var listbox_grid = new Gtk.Grid () {
@@ -118,6 +129,11 @@ public class Widgets.EventsList : Adw.Bin {
 
         signal_map[Services.Settings.get_default ().settings.changed["calendar-enabled"].connect (() => {
             main_revealer.reveal_child = Services.Settings.get_default ().settings.get_boolean ("calendar-enabled");
+        })] = Services.Settings.get_default ();
+
+        signal_map[Services.Settings.get_default ().settings.changed["calendar-sources-disabled"].connect (() => {
+            listbox.invalidate_filter ();
+            change ();
         })] = Services.Settings.get_default ();
     }
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -126,6 +126,7 @@ sources = files(
   'Dialogs/Preferences/Pages/Sidebar.vala',
   'Dialogs/Preferences/Pages/Appearance.vala',
   'Dialogs/Preferences/Pages/HomeView.vala',
+  'Dialogs/Preferences/Pages/CalendarEvents.vala',
   'Dialogs/Preferences/Pages/General.vala',
   'Dialogs/Preferences/Pages/TaskSetting.vala',
   'Dialogs/Preferences/Pages/QuickAdd.vala',


### PR DESCRIPTION
Add a new preferences page to manage which calendars are shown in Planify.

<img width="473" height="626" alt="image" src="https://github.com/user-attachments/assets/89bf9a59-bd6b-405a-9e30-52ea1bd3c74f" />
