### PR TITLE
feat: UI improvements for SectionRow and Scheduled views

### DIFF
--- a/data/resources/stylesheet/stylesheet.css
+++ b/data/resources/stylesheet/stylesheet.css
@@ -537,7 +537,7 @@ checkbutton.theme-selector radio:checked {
 .drop-target:drop(active) {
     border-radius: 12px;
     background-color: alpha(@accent_color, 0.12);
-    border: 1px solid alpha(@accent_color, 0.35);
+    outline: 1px solid alpha(@accent_color, 0.35);
 }
 
 .drop-target-none:drop(active) {

--- a/src/Layouts/SectionRow.vala
+++ b/src/Layouts/SectionRow.vala
@@ -36,6 +36,7 @@ public class Layouts.SectionRow : Gtk.ListBoxRow {
     private Adw.Bin handle_grid;
     private Widgets.LoadingButton add_button;
     private Gtk.Button hide_subtask_button;
+    private Gtk.Revealer hide_subtask_revealer;
 
     public bool is_inbox_section {
         get {
@@ -113,6 +114,12 @@ public class Layouts.SectionRow : Gtk.ListBoxRow {
             }
         };
 
+        hide_subtask_revealer = new Gtk.Revealer () {
+            transition_type = Gtk.RevealerTransitionType.CROSSFADE,
+            reveal_child = false,
+            child = hide_subtask_button
+        };
+
         name_label = new Gtk.Label (section.name) {
             halign = START,
             css_classes = { "font-bold" },
@@ -150,16 +157,32 @@ public class Layouts.SectionRow : Gtk.ListBoxRow {
             margin_start = 3
         };
 
-        sectionrow_box.append (hide_subtask_button);
+        sectionrow_box.append (hide_subtask_revealer);
         sectionrow_box.append (name_label);
         sectionrow_box.append (count_label);
         sectionrow_box.append (actions_box_revealer);
+
+        var sectionrow_separator = new Gtk.Separator (Gtk.Orientation.HORIZONTAL) {
+            visible = !is_inbox_section,
+            margin_start = 36,
+            margin_end = 12,
+            margin_top = 3
+        };
 
         var sectionrow_revealer = new Gtk.Revealer () {
             transition_type = Gtk.RevealerTransitionType.SLIDE_DOWN,
             reveal_child = !is_inbox_section,
             child = sectionrow_box
         };
+
+        var motion_controller = new Gtk.EventControllerMotion ();
+        sectionrow_box.add_controller (motion_controller);
+        motion_controller.enter.connect ((x, y) => {
+            hide_subtask_revealer.reveal_child = true;
+        });
+        motion_controller.leave.connect (() => {
+            hide_subtask_revealer.reveal_child = false;
+        });
 
         handle_grid = new Adw.Bin () {
             css_classes = { "transition", "drop-target" },
@@ -191,7 +214,7 @@ public class Layouts.SectionRow : Gtk.ListBoxRow {
             css_classes = { "listbox-background" }
         };
 
-        load_more_button = new Gtk.Button.with_label ("Cargar más") {
+        load_more_button = new Gtk.Button.with_label (_("Load more")) {
             margin_start = 9,
             halign = START,
         };
@@ -260,6 +283,7 @@ public class Layouts.SectionRow : Gtk.ListBoxRow {
         };
 
         content_box.append (handle_grid);
+        content_box.append (sectionrow_separator);
         content_box.append (bottom_revealer);
 
         content_revealer = new Gtk.Revealer () {
@@ -628,7 +652,7 @@ public class Layouts.SectionRow : Gtk.ListBoxRow {
             load_more_button.label = "+%d %s".printf (to_show, _ ("completed tasks"));
             load_more_button_revealer.reveal_child = true;
         } else {
-            load_more_button.set_label ("No more tasks");
+            load_more_button.set_label (_("No more tasks"));
             load_more_button_revealer.reveal_child = false;
         }
     }

--- a/src/Views/Scheduled/Scheduled.vala
+++ b/src/Views/Scheduled/Scheduled.vala
@@ -23,7 +23,7 @@ public class Views.Scheduled.Scheduled : Adw.Bin {
     private Gtk.Revealer indicator_revealer;
     Widgets.ContextMenu.MenuCheckPicker priority_filter;
     private Gtk.ListBox listbox;
-    private Gtk.ScrolledWindow scrolled_window;
+    private Widgets.ScrolledWindow scrolled_window;
 
     public Gee.HashMap<string, Layouts.ItemRow> items;
     private Gee.HashMap<ulong, weak GLib.Object> signal_map = new Gee.HashMap<ulong, weak GLib.Object> ();
@@ -135,13 +135,7 @@ public class Views.Scheduled.Scheduled : Adw.Bin {
             child = content
         };
 
-        scrolled_window = new Gtk.ScrolledWindow () {
-            hscrollbar_policy = Gtk.PolicyType.NEVER,
-            hexpand = true,
-            vexpand = true
-        };
-
-        scrolled_window.child = content_clamp;
+        scrolled_window = new Widgets.ScrolledWindow (content_clamp);
 
         var magic_button = new Widgets.MagicButton ();
 

--- a/src/Views/Scheduled/ScheduledDay.vala
+++ b/src/Views/Scheduled/ScheduledDay.vala
@@ -23,6 +23,7 @@ public class Views.Scheduled.ScheduledDay : Views.Scheduled.ScheduledSection {
     public GLib.DateTime date { get; construct; }
 
     private Gtk.Box header_content;
+    private Adw.Bin header_content_wraper;
 
     public ScheduledDay (GLib.DateTime date) {
         Object (
@@ -61,6 +62,11 @@ public class Views.Scheduled.ScheduledDay : Views.Scheduled.ScheduledSection {
         setup_events (header_content);
         #endif
 
+        header_content_wraper = new Adw.Bin () {
+            child = header_content,
+            margin_start = 24 
+        };
+
         listbox = new Gtk.ListBox () {
             valign = Gtk.Align.START,
             activate_on_single_click = true,
@@ -88,7 +94,7 @@ public class Views.Scheduled.ScheduledDay : Views.Scheduled.ScheduledSection {
             margin_bottom = 32,
         };
 
-        content.append (header_content);
+        content.append (header_content_wraper);
         content.append (listbox_revealer);
 
         child = content;
@@ -96,6 +102,7 @@ public class Views.Scheduled.ScheduledDay : Views.Scheduled.ScheduledSection {
         setup_listbox ();
         setup_item_signals ();
         add_items ();
+        build_drag_and_drop ();
 
         Timeout.add (listbox_revealer.transition_duration, () => {
             listbox_revealer.reveal_child = has_items;
@@ -113,6 +120,50 @@ public class Views.Scheduled.ScheduledDay : Views.Scheduled.ScheduledSection {
         signal_map[Services.EventBus.get_default ().dim_content.connect ((active, focused_item_id) => {
             header_content.sensitive = !active;
         })] = Services.EventBus.get_default ();
+    }
+
+    private void build_drag_and_drop () {
+        var drop_target = new Gtk.DropTarget (typeof (Widgets.MagicButton), Gdk.DragAction.MOVE);
+        header_content_wraper.add_controller (drop_target);
+
+        drop_target.enter.connect ((x, y) => {
+            header_content_wraper.add_css_class ("drop-target");
+            return Gdk.DragAction.MOVE;
+        });
+
+        drop_target.leave.connect (() => {
+            header_content_wraper.remove_css_class ("drop-target");
+        });
+
+        drop_target.drop.connect ((val, x, y) => {
+            header_content_wraper.remove_css_class ("drop-target");
+            var dialog = new Dialogs.QuickAdd ();
+            dialog.set_due (Utils.Datetime.get_date_only (date));
+            dialog.present (Planify._instance.main_window);
+            return true;
+        });
+    }
+
+    protected override Gtk.Popover build_header_context_menu () {
+        var add_item = new Widgets.ContextMenu.MenuItem (_("Add Task"), "plus-large-symbolic");
+
+        var menu_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 0);
+        menu_box.margin_top = menu_box.margin_bottom = 3;
+        menu_box.append (add_item);
+
+        var popover = new Gtk.Popover () {
+            has_arrow = false,
+            child = menu_box,
+            position = Gtk.PositionType.BOTTOM,
+            width_request = 250
+        };
+
+        add_item.clicked.connect (() => {
+            popover.popdown ();
+            open_quick_add (date);
+        });
+
+        return popover;
     }
 
     protected override void add_items () {

--- a/src/Views/Scheduled/ScheduledMonth.vala
+++ b/src/Views/Scheduled/ScheduledMonth.vala
@@ -23,6 +23,7 @@ public class Views.Scheduled.ScheduledMonth : Views.Scheduled.ScheduledSection {
     public GLib.DateTime date { get; construct; }
 
     private Gtk.Box header_content;
+    private Adw.Bin header_content_wraper;
 
     public ScheduledMonth (GLib.DateTime date) {
         Object (
@@ -54,6 +55,11 @@ public class Views.Scheduled.ScheduledMonth : Views.Scheduled.ScheduledSection {
         setup_events (header_content);
         #endif
 
+        header_content_wraper = new Adw.Bin () {
+            child = header_content,
+            margin_start = 24
+        };
+
         listbox = new Gtk.ListBox () {
             valign = Gtk.Align.START,
             activate_on_single_click = true,
@@ -79,7 +85,7 @@ public class Views.Scheduled.ScheduledMonth : Views.Scheduled.ScheduledSection {
             valign = Gtk.Align.START,
             margin_bottom = 32
         };
-        content.append (header_content);
+        content.append (header_content_wraper);
         content.append (listbox_revealer);
 
         child = content;
@@ -92,6 +98,7 @@ public class Views.Scheduled.ScheduledMonth : Views.Scheduled.ScheduledSection {
         setup_listbox ();
         setup_item_signals ();
         add_items ();
+        build_drag_and_drop ();
 
         signal_map[Services.EventBus.get_default ().item_moved.connect ((item) => {
             if (items.has_key (item.id)) {
@@ -102,6 +109,50 @@ public class Views.Scheduled.ScheduledMonth : Views.Scheduled.ScheduledSection {
         signal_map[Services.EventBus.get_default ().dim_content.connect ((active, focused_item_id) => {
             header_content.sensitive = !active;
         })] = Services.EventBus.get_default ();
+    }
+
+    private void build_drag_and_drop () {
+        var drop_target = new Gtk.DropTarget (typeof (Widgets.MagicButton), Gdk.DragAction.MOVE);
+        header_content_wraper.add_controller (drop_target);
+
+        drop_target.enter.connect ((x, y) => {
+            header_content_wraper.add_css_class ("drop-target");
+            return Gdk.DragAction.MOVE;
+        });
+
+        drop_target.leave.connect (() => {
+            header_content_wraper.remove_css_class ("drop-target");
+        });
+
+        drop_target.drop.connect ((val, x, y) => {
+            header_content_wraper.remove_css_class ("drop-target");
+            var dialog = new Dialogs.QuickAdd ();
+            dialog.set_due (Utils.Datetime.get_date_only (date));
+            dialog.present (Planify._instance.main_window);
+            return true;
+        });
+    }
+
+    protected override Gtk.Popover build_header_context_menu () {
+        var add_item = new Widgets.ContextMenu.MenuItem (_("Add Task"), "plus-large-symbolic");
+
+        var menu_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 0);
+        menu_box.margin_top = menu_box.margin_bottom = 3;
+        menu_box.append (add_item);
+
+        var popover = new Gtk.Popover () {
+            has_arrow = false,
+            child = menu_box,
+            position = Gtk.PositionType.BOTTOM,
+            width_request = 250
+        };
+
+        add_item.clicked.connect (() => {
+            popover.popdown ();
+            open_quick_add (date);
+        });
+
+        return popover;
     }
 
     protected override void add_items () {

--- a/src/Views/Scheduled/ScheduledRange.vala
+++ b/src/Views/Scheduled/ScheduledRange.vala
@@ -24,6 +24,7 @@ public class Views.Scheduled.ScheduledRange : Views.Scheduled.ScheduledSection {
     public GLib.DateTime end_date { get; construct; }
 
     private Gtk.Box header_content;
+    private Adw.Bin header_content_wraper;
 
     public ScheduledRange (GLib.DateTime start_date, GLib.DateTime end_date) {
         Object (
@@ -63,6 +64,11 @@ public class Views.Scheduled.ScheduledRange : Views.Scheduled.ScheduledSection {
         setup_events (header_content);
         #endif
 
+        header_content_wraper = new Adw.Bin () {
+            child = header_content,
+            margin_start = 24
+        };
+
         listbox = new Gtk.ListBox () {
             valign = Gtk.Align.START,
             activate_on_single_click = true,
@@ -89,7 +95,7 @@ public class Views.Scheduled.ScheduledRange : Views.Scheduled.ScheduledSection {
             margin_bottom = 32
         };
 
-        content.append (header_content);
+        content.append (header_content_wraper);
         content.append (listbox_revealer);
 
         child = content;
@@ -102,6 +108,7 @@ public class Views.Scheduled.ScheduledRange : Views.Scheduled.ScheduledSection {
         setup_listbox ();
         setup_item_signals ();
         add_items ();
+        build_drag_and_drop ();
 
         signal_map[Services.EventBus.get_default ().item_moved.connect ((item) => {
             if (items.has_key (item.id)) {
@@ -112,6 +119,50 @@ public class Views.Scheduled.ScheduledRange : Views.Scheduled.ScheduledSection {
         signal_map[Services.EventBus.get_default ().dim_content.connect ((active, focused_item_id) => {
             header_content.sensitive = !active;
         })] = Services.EventBus.get_default ();
+    }
+
+    private void build_drag_and_drop () {
+        var drop_target = new Gtk.DropTarget (typeof (Widgets.MagicButton), Gdk.DragAction.MOVE);
+        header_content_wraper.add_controller (drop_target);
+
+        drop_target.enter.connect ((x, y) => {
+            header_content_wraper.add_css_class ("drop-target");
+            return Gdk.DragAction.MOVE;
+        });
+
+        drop_target.leave.connect (() => {
+            header_content_wraper.remove_css_class ("drop-target");
+        });
+
+        drop_target.drop.connect ((val, x, y) => {
+            header_content_wraper.remove_css_class ("drop-target");
+            var dialog = new Dialogs.QuickAdd ();
+            dialog.set_due (Utils.Datetime.get_date_only (start_date));
+            dialog.present (Planify._instance.main_window);
+            return true;
+        });
+    }
+
+    protected override Gtk.Popover build_header_context_menu () {
+        var add_item = new Widgets.ContextMenu.MenuItem (_("Add Task"), "plus-large-symbolic");
+
+        var menu_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 0);
+        menu_box.margin_top = menu_box.margin_bottom = 3;
+        menu_box.append (add_item);
+
+        var popover = new Gtk.Popover () {
+            has_arrow = false,
+            child = menu_box,
+            position = Gtk.PositionType.BOTTOM,
+            width_request = 250
+        };
+
+        add_item.clicked.connect (() => {
+            popover.popdown ();
+            open_quick_add (start_date);
+        });
+
+        return popover;
     }
 
     protected override void add_items () {

--- a/src/Views/Scheduled/ScheduledSection.vala
+++ b/src/Views/Scheduled/ScheduledSection.vala
@@ -115,21 +115,56 @@ public abstract class Views.Scheduled.ScheduledSection : Gtk.ListBoxRow {
 #endif
 
 
+    protected Gtk.MenuButton header_menu_button;
+
     protected Gtk.Box create_header (Gtk.Widget title_widget) {
+        header_menu_button = new Gtk.MenuButton () {
+            valign = Gtk.Align.CENTER,
+            halign = Gtk.Align.CENTER,
+            popover = build_header_context_menu (),
+            icon_name = "view-more-symbolic",
+            css_classes = { "flat" }
+        };
+
+        var title_row = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0) {
+            hexpand = true
+        };
+        title_row.append (title_widget);
+        title_row.append (header_menu_button);
+
         var header = new Gtk.Box (Gtk.Orientation.VERTICAL, 0) {
             hexpand = true,
             valign = Gtk.Align.START,
-            margin_start = 30,
-            margin_end = 24
+            margin_top = 6,
+            margin_start = 6,
+            margin_end = 6,
+            margin_bottom = 6
         };
 
-        header.append (title_widget);
+        header.append (title_row);
         header.append (new Gtk.Separator (Gtk.Orientation.HORIZONTAL) {
-            margin_top = 6,
-            margin_bottom = 3
+            margin_top = 3
         });
 
         return header;
+    }
+
+    protected void open_quick_add (GLib.DateTime date) {
+        var dialog = new Dialogs.QuickAdd ();
+        dialog.set_due (Utils.Datetime.get_date_only (date));
+        dialog.present (Planify._instance.main_window);
+    }
+
+    protected virtual Gtk.Popover build_header_context_menu () {
+        var menu_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 0);
+        menu_box.margin_top = menu_box.margin_bottom = 3;
+
+        return new Gtk.Popover () {
+            has_arrow = false,
+            child = menu_box,
+            position = Gtk.PositionType.BOTTOM,
+            width_request = 250
+        };
     }
 
     protected void add_item (Objects.Item item) {


### PR DESCRIPTION
- Add `DropTarget` on section headers (`ScheduledDay`, `ScheduledRange`, `ScheduledMonth`)
- Dragging `MagicButton` and dropping on a section header opens `QuickAdd` with the section date pre-filled
- Add context menu button (`header_menu_button`) on each scheduled section header
- "Add Task" menu option opens `QuickAdd` with the corresponding date
- Extract `open_quick_add()` helper in `ScheduledSection` base class to avoid duplication



https://github.com/user-attachments/assets/a811d39b-7f3b-4069-9c32-6c3328d9db83

