### PR TITLE
feat: improve date picker UX and item row interactions

### DIFF
--- a/core/Widgets/DateTimePicker/DateTimePicker.vala
+++ b/core/Widgets/DateTimePicker/DateTimePicker.vala
@@ -828,7 +828,7 @@ public class Widgets.DateTimePicker.DateTimePicker : Gtk.Popover {
 
             button = new Gtk.Button () {
                 child = date_box,
-                css_classes = { "card" },
+                css_classes = { "suggestion-chip" },
             };
 
             button.clicked.connect (() => clicked ());

--- a/core/Widgets/DeadlineButton.vala
+++ b/core/Widgets/DeadlineButton.vala
@@ -325,10 +325,6 @@ public class Widgets.DeadlineButton : Adw.Bin {
     }
 
     private Gtk.Button build_suggestion (string title, GLib.DateTime date) {
-        string icon_name = Utils.Datetime.is_tomorrow (date) ? "today-calendar-symbolic" : "month-symbolic";
-
-        var icon = new Gtk.Image.from_icon_name (icon_name);
-
         var label = new Gtk.Label (title);
 
         var box = new Gtk.Box (HORIZONTAL, 6) {
@@ -337,12 +333,11 @@ public class Widgets.DeadlineButton : Adw.Bin {
             margin_top = 6,
             margin_bottom = 6
         };
-        box.append (icon);
         box.append (label);
 
         var button = new Gtk.Button () {
             child = box,
-            css_classes = { "card" },
+            css_classes = { "suggestion-chip" },
             tooltip_text = Utils.Datetime.get_relative_date_from_date (date)
         };
 

--- a/core/Widgets/LabelPicker/LabelRow.vala
+++ b/core/Widgets/LabelPicker/LabelRow.vala
@@ -87,10 +87,15 @@ public class Widgets.LabelPicker.LabelRow : Gtk.ListBoxRow {
         loading_revealer = new Gtk.Revealer () {
             child = new Adw.Spinner (),
             hexpand = true,
-            halign = END
+            halign = END,
         };
 
-        content_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 6);
+        content_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 6) {
+            margin_start = 6,
+            margin_top = 6,
+            margin_end = 6,
+            margin_bottom = 6
+        };
         content_box.append (checked_button);
         content_box.append (color_grid);
         content_box.append (name_label);

--- a/core/Widgets/LabelPicker/LabelsPickerCore.vala
+++ b/core/Widgets/LabelPicker/LabelsPickerCore.vala
@@ -127,10 +127,7 @@ public class Widgets.LabelsPickerCore : Adw.Bin {
             valign = Gtk.Align.START
         };
         listbox.add_css_class ("listbox-background");
-        listbox.add_css_class ("listbox-separator-6");
-
         listbox.set_placeholder (get_placeholder ());
-
         listbox.set_sort_func ((row1, row2) => {
             Objects.Label item1 = ((Widgets.LabelPicker.LabelRow) row1).label;
             Objects.Label item2 = ((Widgets.LabelPicker.LabelRow) row2).label;

--- a/core/Widgets/PinButton.vala
+++ b/core/Widgets/PinButton.vala
@@ -32,6 +32,12 @@ public class Widgets.PinButton : Gtk.Button {
         }
     }
 
+    public int icon_size {
+        set {
+            pinned_image.pixel_size = value;
+        }
+    }
+
     public signal void changed ();
 
     public PinButton () {

--- a/data/resources/stylesheet/stylesheet.css
+++ b/data/resources/stylesheet/stylesheet.css
@@ -797,3 +797,14 @@ checkbutton.theme-selector radio:checked {
     outline: 2px solid @accent_color;
     outline-offset: -2px;
 }
+
+.suggestion-chip {
+    background-color: @popover_bg_color;
+    border: 1px solid @item_border_color;
+    border-radius: 9px;
+    padding: 0;
+}
+
+.suggestion-chip:hover {
+    background-color: mix(@item_border_color, @popover_bg_color, 0.4);
+}

--- a/src/Dialogs/DatePicker.vala
+++ b/src/Dialogs/DatePicker.vala
@@ -23,6 +23,9 @@ public class Dialogs.DatePicker : Adw.Dialog {
     private Gtk.Revealer clear_revealer;
     private Widgets.Calendar.Calendar calendar_view;
     private Widgets.ContextMenu.MenuItem no_date_item;
+    private Chrono.Core chrono;
+    private uint search_timeout_id = 0;
+    private GLib.DateTime _last_parsed = null;
 
     private GLib.DateTime _datetime = null;
     public GLib.DateTime datetime {
@@ -59,36 +62,33 @@ public class Dialogs.DatePicker : Adw.Dialog {
     }
 
     construct {
-        var today_item = new Widgets.ContextMenu.MenuItem (_("Today"), "star-outline-thick-symbolic");
-        today_item.secondary_text = new GLib.DateTime.now_local ().format ("%a");
-        today_item.margin_top = 6;
+        chrono = new Chrono.Core ();
 
-        var tomorrow_item = new Widgets.ContextMenu.MenuItem (_("Tomorrow"), "today-calendar-symbolic");
-        tomorrow_item.secondary_text = new GLib.DateTime.now_local ().add_days (1).format ("%a");
+        var search_entry = new Gtk.SearchEntry () {
+            placeholder_text = _("Type a date\u2026"),
+            margin_start = 12,
+            margin_end = 12,
+            margin_top = 6,
+            margin_bottom = 6
+        };
 
-        var next_week_item = new Widgets.ContextMenu.MenuItem (_("Next Week"), "work-week-symbolic");
-        next_week_item.secondary_text = Utils.Datetime.get_relative_date_from_date (
-            Utils.Datetime.get_date_only (new GLib.DateTime.now_local ().add_days (7))
-        );
+        var suggested_date_box = new Adw.WrapBox () {
+            child_spacing = 6,
+            line_spacing = 6,
+            margin_start = 12,
+            margin_end = 12,
+            margin_bottom = 12,
+            margin_top = 6
+        };
 
         no_date_item = new Widgets.ContextMenu.MenuItem (_("No Date"), "cross-large-circle-filled-symbolic");
         no_date_item.margin_bottom = 6;
 
         clear_revealer = new Gtk.Revealer () {
-            child = no_date_item
-        };
-
-        var items_card = new Gtk.Box (Gtk.Orientation.VERTICAL, 0) {
+            child = no_date_item,
             margin_start = 12,
-            margin_end = 12,
-            margin_bottom = 12,
-            css_classes = { "card" }
+            margin_end = 12
         };
-
-        items_card.append (today_item);
-        items_card.append (tomorrow_item);
-        items_card.append (next_week_item);
-        items_card.append (clear_revealer);
 
         calendar_view = new Widgets.Calendar.Calendar () {
             margin_top = 6,
@@ -117,7 +117,8 @@ public class Dialogs.DatePicker : Adw.Dialog {
             width_request = 225
         };
 
-        content_box.append (items_card);
+        content_box.append (suggested_date_box);
+        content_box.append (clear_revealer);
         content_box.append (calendar_card);
         content_box.append (done_button);
 
@@ -130,24 +131,18 @@ public class Dialogs.DatePicker : Adw.Dialog {
             content = content_clamp
         };
 
+        var search_bar = new Gtk.Box (Gtk.Orientation.VERTICAL, 0);
+        search_bar.append (search_entry);
+
         toolbar_view.add_top_bar (new Adw.HeaderBar () {
             css_classes = { "flat" }
         });
+        toolbar_view.add_top_bar (search_bar);
 
         child = toolbar_view;
         Services.EventBus.get_default ().disconnect_typing_accel ();
 
-        signal_map[today_item.activate_item.connect (() => {
-            set_date (new DateTime.now_local ());
-        })] = today_item;
-
-        signal_map[tomorrow_item.activate_item.connect (() => {
-            set_date (new DateTime.now_local ().add_days (1));
-        })] = tomorrow_item;
-
-        signal_map[next_week_item.activate_item.connect (() => {
-            set_date (new DateTime.now_local ().add_days (7));
-        })] = next_week_item;
+        add_default_suggestions (suggested_date_box);
 
         signal_map[no_date_item.activate_item.connect (() => {
             _datetime = null;
@@ -165,10 +160,88 @@ public class Dialogs.DatePicker : Adw.Dialog {
             close ();
         })] = done_button;
 
+        search_entry.activate.connect (() => {
+            if (_last_parsed != null) {
+                set_date (_last_parsed);
+            }
+        });
+
+        search_entry.search_changed.connect (() => {
+            if (search_timeout_id != 0) {
+                GLib.Source.remove (search_timeout_id);
+            }
+
+            search_timeout_id = Timeout.add (300, () => {
+                search_timeout_id = 0;
+
+                while (suggested_date_box.get_first_child () != null) {
+                    suggested_date_box.remove (suggested_date_box.get_first_child ());
+                }
+
+                var text = search_entry.text.strip ();
+                if (text.length == 0) {
+                    _last_parsed = null;
+                    add_default_suggestions (suggested_date_box);
+                    return GLib.Source.REMOVE;
+                }
+
+                var result = chrono.parse (text);
+                if (result != null && result.date != null) {
+                    _last_parsed = Utils.Datetime.get_date_only (result.date);
+                    calendar_view.date = _last_parsed;
+                    var chip = build_suggestion_chip (_last_parsed);
+                    suggested_date_box.append (chip);
+                } else {
+                    _last_parsed = null;
+                }
+
+                return GLib.Source.REMOVE;
+            });
+        });
+
         closed.connect (() => {
             clean_up ();
             Services.EventBus.get_default ().connect_typing_accel ();
         });
+    }
+
+    private void add_default_suggestions (Adw.WrapBox box) {
+        add_suggestion (box, _("Today"), "star-outline-thick-symbolic", new GLib.DateTime.now_local ());
+        add_suggestion (box, _("Tomorrow"), "today-calendar-symbolic", new GLib.DateTime.now_local ().add_days (1));
+        add_suggestion (box, _("Next Week"), "work-week-symbolic", new GLib.DateTime.now_local ().add_days (7));
+    }
+
+    private void add_suggestion (Adw.WrapBox box, string label, string icon, GLib.DateTime date) {
+        var chip = build_suggestion_chip (date, label, icon);
+        box.append (chip);
+    }
+
+    private Gtk.Button build_suggestion_chip (GLib.DateTime date, string? label = null, string? icon = null) {
+        var icon_widget = new Gtk.Image.from_icon_name (icon ?? "month-symbolic");
+
+        var label_widget = new Gtk.Label (label ?? Utils.Datetime.get_relative_date_from_date (date)) {
+            ellipsize = END
+        };
+
+        var box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 6) {
+            margin_start = 9,
+            margin_end = 9,
+            margin_top = 6,
+            margin_bottom = 6
+        };
+        box.append (icon_widget);
+        box.append (label_widget);
+
+        var chip = new Gtk.Button () {
+            child = box,
+            css_classes = { "suggestion-chip" }
+        };
+
+        chip.clicked.connect (() => {
+            set_date (date);
+        });
+
+        return chip;
     }
 
     private void set_date (DateTime ? date) {

--- a/src/Layouts/ItemRow.vala
+++ b/src/Layouts/ItemRow.vala
@@ -421,7 +421,8 @@ public class Layouts.ItemRow : Layouts.ItemBase {
 
         pin_button = new Widgets.PinButton () {
             sensitive = !item.completed,
-            no_padding = true
+            no_padding = true,
+            icon_size = 13
         };
 
         hide_loading_button = new Widgets.LoadingButton.with_icon ("go-up-symbolic", 16) {
@@ -839,6 +840,10 @@ public class Layouts.ItemRow : Layouts.ItemBase {
             subitems.prepare_new_item ();
         })] = add_subitem_gesture;
 
+        signals_map[add_subtasks_button.clicked.connect (() => {
+            subitems.prepare_new_item ();
+        })] = add_subtasks_button;
+
         signals_map[item.loading_change.connect (() => {
             is_loading = item.loading;
         })] = item;
@@ -1246,6 +1251,8 @@ public class Layouts.ItemRow : Layouts.ItemBase {
         var tomorrow_item = new Widgets.ContextMenu.MenuItem (_ ("Tomorrow"), "month-symbolic");
         tomorrow_item.secondary_text = new GLib.DateTime.now_local ().add_days (1).format ("%a");
 
+        var pick_date_item = new Widgets.ContextMenu.MenuItem (_ ("Pick a Date"), "month-symbolic");
+
         pinboard_item = new Widgets.ContextMenu.MenuItem (item.pinned ? _ ("Unpin") : _ ("Pin"), "pin-symbolic");
 
         no_date_item = new Widgets.ContextMenu.MenuItem (_ ("No Date"), "cross-large-circle-filled-symbolic");
@@ -1270,6 +1277,7 @@ public class Layouts.ItemRow : Layouts.ItemBase {
         menu_box.append (new Widgets.ContextMenu.MenuSeparator ());
         menu_box.append (today_item);
         menu_box.append (tomorrow_item);
+        menu_box.append (pick_date_item);
         menu_box.append (no_date_item);
         menu_box.append (new Widgets.ContextMenu.MenuSeparator ());
         menu_box.append (pinboard_item);
@@ -1289,6 +1297,20 @@ public class Layouts.ItemRow : Layouts.ItemBase {
         signals_map[tomorrow_item.activate_item.connect (() => {
             update_date (Utils.Datetime.get_date_only (new DateTime.now_local ().add_days (1)));
         })] = tomorrow_item;
+
+        signals_map[pick_date_item.activate_item.connect (() => {
+            var dialog = new Dialogs.DatePicker (_("Pick a Date"));
+            if (item.has_due) {
+                dialog.datetime = item.due.datetime;
+            }
+            dialog.present (Planify._instance.main_window);
+            signals_map[dialog.date_changed.connect (() => {
+                if (dialog.datetime != null) {
+                    update_date (Utils.Datetime.get_date_only (dialog.datetime));
+                }
+                dialog.clean_up ();
+            })] = dialog;
+        })] = pick_date_item;
 
         signals_map[pinboard_item.activate_item.connect (() => {
             item.update_pin (!item.pinned);


### PR DESCRIPTION
Several UX improvements across the date picker dialog and item row context menu.

### DatePicker
- Added search entry at the top that parses natural language dates using `Chrono`
- Replaced static quick-pick items with a `suggested_date_box` using `Adw.WrapBox` chips
- Default suggestions: Today, Tomorrow, Next Week
- When Chrono parses a result, replaces suggestions with the parsed date chip and moves the calendar to that date
- Press Enter to confirm parsed date directly
- Pre-selects the item's existing due date when opening the picker
