### PR TITLE
feat: project filter in Completed view

### DIFF
--- a/core/Widgets/IconColorProject.vala
+++ b/core/Widgets/IconColorProject.vala
@@ -51,6 +51,7 @@ public class Widgets.IconColorProject : Adw.Bin {
             pixel_size = 16,
             valign = CENTER,
             halign = CENTER,
+            css_classes = { "view-icon" }
         };
 
         stack = new Gtk.Stack () {
@@ -74,6 +75,7 @@ public class Widgets.IconColorProject : Adw.Bin {
         emoji_label.label = project.emoji;
 
         if (project.is_inbox_project) {
+            Util.get_default ().set_widget_color (Objects.Filters.Inbox.get_default ().theme_color (), inbox_icon);
             stack.visible_child_name = "inbox";
             return;
         }

--- a/core/Widgets/LabelPicker/LabelRow.vala
+++ b/core/Widgets/LabelPicker/LabelRow.vala
@@ -91,10 +91,10 @@ public class Widgets.LabelPicker.LabelRow : Gtk.ListBoxRow {
         };
 
         content_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 6) {
-            margin_start = 6,
-            margin_top = 6,
-            margin_end = 6,
-            margin_bottom = 6
+            margin_start = 3,
+            margin_top = 3,
+            margin_end = 3,
+            margin_bottom = 3
         };
         content_box.append (checked_button);
         content_box.append (color_grid);

--- a/core/Widgets/ProjectPicker/ProjectPickerCore.vala
+++ b/core/Widgets/ProjectPicker/ProjectPickerCore.vala
@@ -21,19 +21,30 @@
 
 public class Widgets.ProjectPickerCore : Adw.Bin {
     public Objects.Source ? source { get; construct; }
+    public bool multiselect { get; construct; default = false; }
 
     private Gtk.ListBox listbox;
     private Gtk.Revealer search_entry_revealer;
     private Objects.Project _selected_project;
+    private Gee.ArrayList<string> _selected_ids = new Gee.ArrayList<string> ();
 
     private Gee.HashMap<ulong, weak GLib.Object> signal_map = new Gee.HashMap<ulong, weak GLib.Object> ();
 
     public signal void selected (Objects.Project project);
+    public signal void multiselect_changed (Gee.ArrayList<string> ids);
     public signal void close ();
 
     public ProjectPickerCore (Objects.Source ? source = null) {
         Object (
-            source: source
+            source: source,
+            multiselect: false
+        );
+    }
+
+    public ProjectPickerCore.with_multiselect (Objects.Source ? source = null) {
+        Object (
+            source: source,
+            multiselect: true
         );
     }
 
@@ -44,10 +55,8 @@ public class Widgets.ProjectPickerCore : Adw.Bin {
     construct {
         var search_entry = new Gtk.SearchEntry () {
             placeholder_text = _("Type a search"),
-            margin_top = 12,
             margin_start = 12,
-            margin_end = 12,
-            margin_bottom = 12
+            margin_end = 12
         };
 
         search_entry_revealer = new Gtk.Revealer () {
@@ -61,7 +70,9 @@ public class Widgets.ProjectPickerCore : Adw.Bin {
             css_classes = { "listbox-background" },
             margin_start = 12,
             margin_end = 12,
-            margin_bottom = 12
+            margin_bottom = 12,
+            margin_top = 6,
+            selection_mode = multiselect ? Gtk.SelectionMode.NONE : Gtk.SelectionMode.SINGLE
         };
 
         listbox.set_sort_func (sort_source_function);
@@ -94,11 +105,14 @@ public class Widgets.ProjectPickerCore : Adw.Bin {
             listbox.invalidate_filter ();
         })] = search_entry;
 
-        signal_map[listbox.row_activated.connect ((row) => {
-            update_selected_project (((Widgets.ProjectPicker.ProjectPickerRow) row).project);
-            selected (_selected_project);
-            close ();
-        })] = listbox;
+        if (!multiselect) {
+            signal_map[listbox.row_activated.connect ((row) => {
+                var project_row = (Widgets.ProjectPicker.ProjectPickerRow) row;
+                update_selected_project (project_row.project);
+                selected (_selected_project);
+                close ();
+            })] = listbox;
+        }
 
         var listbox_controller_key = new Gtk.EventControllerKey ();
         listbox.add_controller (listbox_controller_key);
@@ -192,12 +206,23 @@ public class Widgets.ProjectPickerCore : Adw.Bin {
     }
 
     private Gtk.Widget build_project_row (Objects.Project project) {
-        var row = new Widgets.ProjectPicker.ProjectPickerRow (project);
+        var row = new Widgets.ProjectPicker.ProjectPickerRow (project, multiselect);
 
         signal_map[row.selected.connect (() => {
-            update_selected_project (row.project);
-            selected (_selected_project);
-            close ();
+            if (multiselect) {
+                if (_selected_ids.contains (row.project.id)) {
+                    _selected_ids.remove (row.project.id);
+                    row.is_selected = false;
+                } else {
+                    _selected_ids.add (row.project.id);
+                    row.is_selected = true;
+                }
+                multiselect_changed (_selected_ids);
+            } else {
+                update_selected_project (row.project);
+                selected (_selected_project);
+                close ();
+            }
         })] = row;
 
         return row;
@@ -223,16 +248,30 @@ public class Widgets.ProjectPickerCore : Adw.Bin {
         }
 
         var row = (Widgets.ProjectPicker.ProjectPickerRow) lbrow;
-        
+
         if (row.project.is_inbox_project) {
             row.margin_top = 6;
             row.margin_bottom = 6;
             row.set_header (null);
             return;
         }
-        
+
         if (lbbefore != null && lbbefore is Widgets.ProjectPicker.ProjectPickerRow) {
             var before = (Widgets.ProjectPicker.ProjectPickerRow) lbbefore;
+
+            if (source != null) {
+                if (before.project.is_inbox_project) {
+                    row.set_header (get_header_box (_("Projects")));
+                } else {
+                    row.set_header (null);
+                }
+                return;
+            }
+
+            if (before.project.is_inbox_project) {
+                row.set_header (get_header_box (row.project.source.header_text));
+                return;
+            }
 
             if (row.project.source.id == before.project.source.id) {
                 row.set_header (null);
@@ -240,7 +279,7 @@ public class Widgets.ProjectPickerCore : Adw.Bin {
             }
         }
 
-        row.set_header (get_header_box (row.project.source.header_text));
+        row.set_header (get_header_box (source != null ? _("Projects") : row.project.source.header_text));
     }
 
     private Gtk.Widget get_header_box (string title) {
@@ -251,11 +290,15 @@ public class Widgets.ProjectPickerCore : Adw.Bin {
         };
 
         var header_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 6) {
-            margin_top = 12,
+            margin_top = 3,
             margin_bottom = 6
         };
 
         header_box.append (header_label);
+        header_box.append (new Gtk.Separator (Gtk.Orientation.HORIZONTAL) {
+            margin_start = 3,
+            margin_end = 6
+        });
 
         return header_box;
     }
@@ -271,6 +314,14 @@ public class Widgets.ProjectPickerCore : Adw.Bin {
 
     public void set_selected_project (Objects.Project project) {
         update_selected_project (project);
+    }
+
+    public void set_selected_ids (Gee.ArrayList<string> ids) {
+        _selected_ids = ids;
+        foreach (unowned Gtk.Widget child in Util.get_default ().get_children (listbox)) {
+            var row = (Widgets.ProjectPicker.ProjectPickerRow) child;
+            row.is_selected = _selected_ids.contains (row.project.id);
+        }
     }
 
     public void clean_up () {

--- a/core/Widgets/ProjectPicker/ProjectPickerPopover.vala
+++ b/core/Widgets/ProjectPicker/ProjectPickerPopover.vala
@@ -38,7 +38,9 @@ public class Widgets.ProjectPicker.ProjectPickerPopover : Gtk.Popover {
     }
 
     construct {
-        project_picker_core = new Widgets.ProjectPickerCore ();
+        project_picker_core = new Widgets.ProjectPickerCore () {
+            margin_top = 12
+        };
 
         child = project_picker_core;
         add_css_class ("popover-contents");

--- a/core/Widgets/ProjectPicker/ProjectPickerRow.vala
+++ b/core/Widgets/ProjectPicker/ProjectPickerRow.vala
@@ -21,20 +21,23 @@
 
 public class Widgets.ProjectPicker.ProjectPickerRow : Gtk.ListBoxRow {
     public Objects.Project project { get; construct; }
+    public bool show_checkbox { get; construct; default = false; }
     public bool is_selected { get; set; default = false; }
 
     private Gtk.Label name_label;
     private Gtk.Revealer main_revealer;
     private Gtk.Revealer selected_revealer;
     private Widgets.IconColorProject icon_project;
+    private Gtk.CheckButton checkbox;
 
     public signal void selected ();
 
     private Gee.HashMap<ulong, weak GLib.Object> signal_map = new Gee.HashMap<ulong, weak GLib.Object> ();
 
-    public ProjectPickerRow (Objects.Project project) {
+    public ProjectPickerRow (Objects.Project project, bool show_checkbox = false) {
         Object (
-            project: project
+            project: project,
+            show_checkbox: show_checkbox
         );
     }
 
@@ -43,7 +46,8 @@ public class Widgets.ProjectPicker.ProjectPickerRow : Gtk.ListBoxRow {
     }
 
     construct {
-        css_classes = { "row", "no-padding" };
+        add_css_class ("border-radius-6");
+        add_css_class ("no-padding");
 
         icon_project = new Widgets.IconColorProject (20);
         icon_project.project = project;
@@ -52,14 +56,20 @@ public class Widgets.ProjectPicker.ProjectPickerRow : Gtk.ListBoxRow {
         name_label.valign = Gtk.Align.CENTER;
         name_label.ellipsize = Pango.EllipsizeMode.END;
 
+        checkbox = new Gtk.CheckButton () {
+            valign = CENTER,
+            active = is_selected,
+            can_target = false
+        };
+
         var selected_icon = new Gtk.Image.from_icon_name ("checkmark-small-symbolic") {
             pixel_size = 16,
             hexpand = true,
             valign = Gtk.Align.CENTER,
             halign = Gtk.Align.END,
-            margin_end = 3
+            margin_end = 3,
+            css_classes = { "color-primary" }
         };
-        selected_icon.add_css_class ("color-primary");
 
         selected_revealer = new Gtk.Revealer () {
             transition_type = Gtk.RevealerTransitionType.CROSSFADE,
@@ -73,9 +83,15 @@ public class Widgets.ProjectPicker.ProjectPickerRow : Gtk.ListBoxRow {
             margin_top = 6,
             margin_bottom = 6
         };
+
+        if (show_checkbox) {
+            content_box.append (checkbox);
+        }
         content_box.append (icon_project);
         content_box.append (name_label);
-        content_box.append (selected_revealer);
+        if (!show_checkbox) {
+            content_box.append (selected_revealer);
+        }
 
         main_revealer = new Gtk.Revealer () {
             transition_type = Gtk.RevealerTransitionType.SLIDE_DOWN,
@@ -101,7 +117,11 @@ public class Widgets.ProjectPicker.ProjectPickerRow : Gtk.ListBoxRow {
         })] = this;
 
         notify["is-selected"].connect (() => {
-            selected_revealer.reveal_child = is_selected;
+            if (show_checkbox) {
+                checkbox.active = is_selected;
+            } else {
+                selected_revealer.reveal_child = is_selected;
+            }
         });
     }
 

--- a/src/Dialogs/ProjectPicker.vala
+++ b/src/Dialogs/ProjectPicker.vala
@@ -36,8 +36,8 @@ public class Dialogs.ProjectPicker.ProjectPicker : Adw.Dialog {
         Object (
             source: source,
             title: _("Move"),
-            content_width: 400,
-            content_height: 550
+            content_width: 350,
+            content_height: 420
         );
     }
 
@@ -45,8 +45,8 @@ public class Dialogs.ProjectPicker.ProjectPicker : Adw.Dialog {
         Object (
             source: null,
             title: _("Move"),
-            content_width: 400,
-            content_height: 550
+            content_width: 350,
+            content_height: 420
         );
     }
 

--- a/src/Views/Filter.vala
+++ b/src/Views/Filter.vala
@@ -31,6 +31,10 @@ public class Views.Filter : Adw.Bin {
     private Gtk.Revealer view_setting_revealer;
     private Gtk.Button load_more_button;
     private Gtk.Revealer load_more_button_revealer;
+    private Gtk.MenuButton project_filter_button;
+    private Gtk.Revealer project_filter_revealer;
+    private Adw.StatusPage listbox_placeholder;
+    private Gee.ArrayList<string> selected_project_ids = new Gee.ArrayList<string> ();
 
     private Gee.HashMap<string, Layouts.ItemRow> items = new Gee.HashMap<string, Layouts.ItemRow> ();
     private Gee.HashMap<ulong, weak GLib.Object> signal_map = new Gee.HashMap<ulong, weak GLib.Object> ();
@@ -42,6 +46,17 @@ public class Views.Filter : Adw.Bin {
     private bool has_items {
         get {
             return items_list != null && items_list.size > 0;
+        }
+    }
+
+    private bool has_visible_items {
+        get {
+            if (items_list == null || items_list.size == 0) return false;
+            if (selected_project_ids.size == 0) return true;
+            foreach (var item in items_list) {
+                if (selected_project_ids.contains (item.project_id)) return true;
+            }
+            return false;
         }
     }
 
@@ -75,6 +90,40 @@ public class Views.Filter : Adw.Bin {
 
         title_box.append (title_icon);
         title_box.append (title_label);
+
+        var project_picker_core = new Widgets.ProjectPickerCore.with_multiselect () {
+            margin_top = 12
+        };
+
+        var project_picker_popover = new Gtk.Popover () {
+            has_arrow = false,
+            position = BOTTOM,
+            width_request = 260,
+            height_request = 300,
+            child = project_picker_core,
+            css_classes = { "popover-contents" }
+        };
+
+        project_filter_button = new Gtk.MenuButton () {
+            label = _("All Projects"),
+            popover = project_picker_popover,
+            css_classes = { "flat", "suggestion-chip" },
+            margin_start = 30,
+            margin_top = 12,
+            halign = START
+        };
+
+        project_picker_core.multiselect_changed.connect ((ids) => {
+            selected_project_ids = ids;
+            update_project_filter_label ();
+            listbox.invalidate_filter ();
+            validate_placeholder ();
+        });
+
+        project_filter_revealer = new Gtk.Revealer () {
+            transition_type = SLIDE_DOWN,
+            child = project_filter_button
+        };
 
         var view_setting_button = new Gtk.MenuButton () {
             valign = Gtk.Align.CENTER,
@@ -120,15 +169,11 @@ public class Views.Filter : Adw.Bin {
         listbox_box.append (listbox);
         listbox_box.append (load_more_button_revealer);
 
-        var listbox_placeholder = new Adw.StatusPage ();
-        listbox_placeholder.icon_name = "check-round-outline-symbolic";
-        listbox_placeholder.title = _("Add Some Tasks");
-        listbox_placeholder.description = _("Press 'a' to create a new task");
-        
-        if (filter is Objects.Filters.Completed) {
-            listbox_placeholder.title = _("All tasks completed!");
-            listbox_placeholder.description = _("Great job, nothing left to do 🎉");
-        }
+        listbox_placeholder = new Adw.StatusPage () {
+            icon_name = "check-round-outline-symbolic",
+            title = _("Add Some Tasks"),
+            description = _("Press 'a' to create a new task")
+        };
 
         listbox_stack = new Gtk.Stack () {
             hexpand = true,
@@ -145,6 +190,7 @@ public class Views.Filter : Adw.Bin {
         };
 
         content.append (title_box);
+        content.append (project_filter_revealer);
         content.append (listbox_stack);
 
         var content_clamp = new Adw.Clamp () {
@@ -174,6 +220,11 @@ public class Views.Filter : Adw.Bin {
             content = content_overlay
         };
         toolbar_view.add_top_bar (headerbar);
+
+        listbox.set_filter_func ((row) => {
+            if (selected_project_ids.size == 0) return true;
+            return selected_project_ids.contains (((Layouts.ItemRow) row).item.project_id);
+        });
 
         child = toolbar_view;
         update_request ();
@@ -272,6 +323,7 @@ public class Views.Filter : Adw.Bin {
 
         headerbar.title = title_label.label;
         view_setting_revealer.reveal_child = filter is Objects.Filters.Completed;
+        project_filter_revealer.reveal_child = filter is Objects.Filters.Completed;
     }
 
     private void add_items () {
@@ -563,7 +615,17 @@ public class Views.Filter : Adw.Bin {
     }
 
     private void validate_placeholder () {
-        listbox_stack.visible_child_name = has_items ? "listbox" : "placeholder";
+        if (!has_visible_items && selected_project_ids.size > 0) {
+            listbox_placeholder.title = _("No completed tasks");
+            listbox_placeholder.description = _("No tasks found for the selected projects");
+        } else if (filter is Objects.Filters.Completed) {
+            listbox_placeholder.title = _("All tasks completed!");
+            listbox_placeholder.description = _("Great job, nothing left to do 🎉");
+        } else {
+            listbox_placeholder.title = _("Add Some Tasks");
+            listbox_placeholder.description = _("Press 'a' to create a new task");
+        }
+        listbox_stack.visible_child_name = has_visible_items ? "listbox" : "placeholder";
         invalidate_listbox ();
     }
 
@@ -580,6 +642,7 @@ public class Views.Filter : Adw.Bin {
         };
 
         header_box.append (header_label);
+        header_box.append (new Gtk.Separator (Gtk.Orientation.HORIZONTAL));
 
         if (Services.Settings.get_default ().settings.get_boolean ("attention-at-one")) {
             ulong handler_id = Services.EventBus.get_default ().dim_content.connect ((active, focused_item_id) => {
@@ -592,6 +655,15 @@ public class Views.Filter : Adw.Bin {
         }
 
         return header_box;
+    }
+
+    private void update_project_filter_label () {
+        if (selected_project_ids.size == 0) {
+            project_filter_button.label = _("All Projects");
+        } else {
+            project_filter_button.label = ngettext ("%d Project", "%d Projects", selected_project_ids.size)
+                .printf (selected_project_ids.size);
+        }
     }
 
     private Gtk.Popover build_view_setting_popover () {

--- a/src/Views/Filter.vala
+++ b/src/Views/Filter.vala
@@ -43,12 +43,6 @@ public class Views.Filter : Adw.Bin {
     private int page_index = 0;
     private const int PAGE_SIZE = Constants.COMPLETED_PAGE_SIZE;
 
-    private bool has_items {
-        get {
-            return items_list != null && items_list.size > 0;
-        }
-    }
-
     private bool has_visible_items {
         get {
             if (items_list == null || items_list.size == 0) return false;
@@ -615,7 +609,7 @@ public class Views.Filter : Adw.Bin {
     }
 
     private void validate_placeholder () {
-        if (!has_visible_items && selected_project_ids.size > 0) {
+        if (filter is Objects.Filters.Completed && !has_visible_items && selected_project_ids.size > 0) {
             listbox_placeholder.title = _("No completed tasks");
             listbox_placeholder.description = _("No tasks found for the selected projects");
         } else if (filter is Objects.Filters.Completed) {


### PR DESCRIPTION
Add multi-select project filter to the Completed view.

- Add "All Projects" menu button with ProjectPickerCore in multiselect mode
- Toggle project selection without closing the popover
- Filter listbox rows by selected project_ids using set_filter_func
- Show contextual placeholder when filter has no results
- Button label updates to reflect selection count ("N Projects")

<img width="908" height="455" alt="image" src="https://github.com/user-attachments/assets/5607bd08-e7a0-4286-be03-cf1a4c494691" />
