### PR TITLE
Fix Json-CRITICAL assertions when parsing empty JSON data

### DIFF
--- a/core/Objects/Source.vala
+++ b/core/Objects/Source.vala
@@ -252,15 +252,16 @@ public class Objects.SourceTodoistData : Objects.SourceData {
     public bool user_is_premium { get; set; default = false; }
     public string api_version { get; set; default = "v9"; }
 
-    public SourceTodoistData.from_json (string json) {
+        public SourceTodoistData.from_json (string json) {
         Json.Parser parser = new Json.Parser ();
-
         try {
             parser.load_from_data (json, -1);
-            var object = parser.get_root ().get_object ();
-
+            var root = parser.get_root ();
+            if (root == null || root.get_node_type () != Json.NodeType.OBJECT) {
+                return;
+            }
+            var object = root.get_object ();
             if (object.has_member ("access_token")) {
-                access_token = object.get_string_member ("access_token");
             }
 
             if (object.has_member ("sync_token")) {
@@ -397,11 +398,13 @@ public class Objects.SourceCalDAVData : Objects.SourceData {
 
     public SourceCalDAVData.from_json (string json) {
         Json.Parser parser = new Json.Parser ();
-
         try {
             parser.load_from_data (json, -1);
-            var object = parser.get_root ().get_object ();
-
+            var root = parser.get_root ();
+            if (root == null || root.get_node_type () != Json.NodeType.OBJECT) {
+                return;
+            }
+            var object = root.get_object ();
             if (object.has_member ("server_url")) {
                 server_url = object.get_string_member ("server_url");
             }

--- a/core/Utils/JsonUtils.vala
+++ b/core/Utils/JsonUtils.vala
@@ -27,9 +27,15 @@ public class Utils.JsonUtils {
             parser.load_from_data (data, -1);
         } catch (Error e) {
             debug (e.message);
+            return new Json.Object ();
         }
 
-        return parser.get_root ().get_object ();
+        var root = parser.get_root ();
+        if (root == null || root.get_node_type () != Json.NodeType.OBJECT) {
+            return new Json.Object ();
+        }
+
+        return root.get_object ();
     }
 
     public static Json.Object get_object_member (string data, string member) {


### PR DESCRIPTION
JsonUtils.get_object() and Source's from_json constructors called parser.get_root().get_object() without checking if get_root() returned a valid node. Empty string input parses without error but yields no root node, triggering GLib CRITICAL assertions on every fresh install before any account/backup data exists.

Tested on Arch (Omarchy), built from main. Reproduced with a fresh
rm -rf ~/.local/share/io.github.alainm23.planify ~/.config/io.github.alainm23.planify,
confirmed the CRITICAL lines are gone after this fix.