### PR TITLE
feat: sort and filter options in All Tasks view

### DIFF
--- a/core/Utils/Util.vala
+++ b/core/Utils/Util.vala
@@ -1136,6 +1136,39 @@ We hope you’ll enjoy using Planify!""");
         }
     }
 
+    /**
+     * Compares two items for a view that groups tasks by project: by project name, then by
+     * project id so two projects sharing a name never interleave, and finally by priority
+     * (highest first, ties broken by date added) inside a group.
+     *
+     * sort_order flips the grouping only. Priority stays highest first in both directions,
+     * because the toggle controls the grouping, not the ranking inside it.
+     */
+    public int set_item_project_sort_func (Objects.Item item1, Objects.Item item2, SortOrderType sort_order) {
+        // A project may be missing for an orphaned task, so fall back to empty values
+        // rather than dereferencing null while sorting.
+        Objects.Project ? project1 = item1.project;
+        Objects.Project ? project2 = item2.project;
+
+        int result = (project1 == null ? "" : project1.name).collate (
+            project2 == null ? "" : project2.name
+        );
+
+        if (result == 0) {
+            // Opaque identifiers: compare bytes, not locale collation.
+            result = strcmp (
+                project1 == null ? "" : project1.id,
+                project2 == null ? "" : project2.id
+            );
+        }
+
+        if (result != 0) {
+            return sort_order == SortOrderType.ASC ? result : -result;
+        }
+
+        return set_item_sort_func (item1, item2, SortedByType.PRIORITY, SortOrderType.ASC);
+    }
+
     public int set_item_sort_func (Objects.Item item1, Objects.Item item2, SortedByType sorted_by, SortOrderType sort_order) {
         int result = 0;
         

--- a/data/io.github.alainm23.planify.gschema.xml
+++ b/data/io.github.alainm23.planify.gschema.xml
@@ -197,12 +197,6 @@
             <description>Active filters in the All Tasks view, each stored as "type:value"</description>
         </key>
 
-        <key name="all-items-show-completed" type="b">
-            <default>false</default>
-            <summary>Show completed tasks in the All Tasks view</summary>
-            <description>Display completed tasks in the All Tasks view alongside pending ones</description>
-        </key>
-
         <key name="scheduled-sort-order" type="s">
             <default>"name"</default>
             <summary>Scheduled view sort order</summary>

--- a/data/io.github.alainm23.planify.gschema.xml
+++ b/data/io.github.alainm23.planify.gschema.xml
@@ -179,6 +179,30 @@
             <description>Controls how tasks are sorted in the Today view</description>
         </key>
 
+        <key name="all-items-sort-order" type="s">
+            <default>"project"</default>
+            <summary>All Tasks view sort order</summary>
+            <description>Controls how tasks are sorted in the All Tasks view</description>
+        </key>
+
+        <key name="all-items-sort-ascending" type="b">
+            <default>true</default>
+            <summary>All Tasks view sort direction</summary>
+            <description>Sort the All Tasks view in ascending order</description>
+        </key>
+
+        <key name="all-items-filters" type="as">
+            <default>[]</default>
+            <summary>All Tasks view active filters</summary>
+            <description>Active filters in the All Tasks view, each stored as "type:value"</description>
+        </key>
+
+        <key name="all-items-show-completed" type="b">
+            <default>false</default>
+            <summary>Show completed tasks in the All Tasks view</summary>
+            <description>Display completed tasks in the All Tasks view alongside pending ones</description>
+        </key>
+
         <key name="scheduled-sort-order" type="s">
             <default>"name"</default>
             <summary>Scheduled view sort order</summary>

--- a/src/Views/Filter.vala
+++ b/src/Views/Filter.vala
@@ -32,11 +32,9 @@ public class Views.Filter : Adw.Bin {
     private const string SORT_ORDER_KEY = "all-items-sort-order";
     private const string SORT_ASCENDING_KEY = "all-items-sort-ascending";
     private const string FILTERS_KEY = "all-items-filters";
-    private const string SHOW_COMPLETED_KEY = "all-items-show-completed";
 
     private Widgets.ContextMenu.MenuPicker due_date_item;
     private Widgets.ContextMenu.MenuCheckPicker priority_filter;
-    private Widgets.ContextMenu.MenuSwitch show_completed_item;
     private Gtk.Revealer indicator_revealer;
     private uint rebuild_idle_id = 0;
 
@@ -78,15 +76,9 @@ public class Views.Filter : Adw.Bin {
             if (items_list == null || items_list.size == 0) return false;
             if (selected_project_ids.size == 0 && filter.filters.size == 0) return true;
             foreach (var item in items_list) {
-                if (selected_project_ids.size > 0 && !selected_project_ids.contains (item.project_id)) {
-                    continue;
+                if (item_matches_filters (item)) {
+                    return true;
                 }
-
-                if (sorting_supported && !Utils.TaskUtils.items_filter_func (item, filter.filters)) {
-                    continue;
-                }
-
-                return true;
             }
             return false;
         }
@@ -148,8 +140,7 @@ public class Views.Filter : Adw.Bin {
         project_picker_core.multiselect_changed.connect ((ids) => {
             selected_project_ids = ids;
             update_project_filter_label ();
-            listbox.invalidate_filter ();
-            validate_placeholder ();
+            rebuild_list ();
         });
 
         project_filter_revealer = new Gtk.Revealer () {
@@ -181,7 +172,6 @@ public class Views.Filter : Adw.Bin {
             halign = END,
             valign = START,
             sensitive = false,
-            reveal_child = false
         };
 
         var view_setting_overlay = new Gtk.Overlay () {
@@ -296,17 +286,7 @@ public class Views.Filter : Adw.Bin {
         toolbar_view.add_top_bar (headerbar);
 
         listbox.set_filter_func ((row) => {
-            var item = ((Layouts.ItemRow) row).item;
-
-            if (selected_project_ids.size > 0 && !selected_project_ids.contains (item.project_id)) {
-                return false;
-            }
-
-            if (sorting_supported && !Utils.TaskUtils.items_filter_func (item, filter.filters)) {
-                return false;
-            }
-
-            return true;
+            return item_matches_filters (((Layouts.ItemRow) row).item);
         });
 
         child = toolbar_view;
@@ -359,12 +339,12 @@ public class Views.Filter : Adw.Bin {
 
         if (sorting_supported) {
             signal_map[Services.Settings.get_default ().settings.changed[SORT_ORDER_KEY].connect (() => {
-                apply_sort_changed ();
+                rebuild_list ();
                 check_default_filters ();
             })] = Services.Settings.get_default ().settings;
 
             signal_map[Services.Settings.get_default ().settings.changed[SORT_ASCENDING_KEY].connect (() => {
-                apply_sort_changed ();
+                rebuild_list ();
                 check_default_filters ();
             })] = Services.Settings.get_default ().settings;
 
@@ -392,17 +372,17 @@ public class Views.Filter : Adw.Bin {
 
     private void apply_filters_changed () {
         save_filters ();
-        listbox.invalidate_filter ();
-        validate_placeholder ();
+        rebuild_list ();
         check_default_filters ();
     }
 
     /**
-     * Re-sorts and re-pages the list after the sort settings change. The whole list
-     * has to be rebuilt rather than merely invalidated, because pagination decides
-     * which items are loaded at all from the sorted backing list.
+     * Re-sorts, re-filters and re-pages the list after the sort or filter settings change.
+     * The whole list has to be rebuilt rather than merely invalidated, because pagination
+     * decides which items are loaded at all from the sorted and filtered backing list —
+     * invalidating the loaded rows alone would leave matches beyond the first page unreachable.
      */
-    private void apply_sort_changed () {
+    private void rebuild_list () {
         // Deferred to an idle callback rather than run inline. Rebuilding tears down and
         // frees every ItemRow, and this runs from inside a signal emission (a GSettings
         // "changed" handler) that can still touch those rows once we return — which shows
@@ -479,6 +459,22 @@ public class Views.Filter : Adw.Bin {
         project_filter_revealer.reveal_child = filter is Objects.Filters.Completed;
     }
 
+    /**
+     * Whether an item survives the view's active filters — the project picker of the
+     * Completed view and the sort/filter menu of the All Tasks view.
+     */
+    private bool item_matches_filters (Objects.Item item) {
+        if (selected_project_ids.size > 0 && !selected_project_ids.contains (item.project_id)) {
+            return false;
+        }
+
+        if (sorting_supported && !Utils.TaskUtils.items_filter_func (item, filter.filters)) {
+            return false;
+        }
+
+        return true;
+    }
+
     private void add_items () {
         foreach (Layouts.ItemRow row in items.values) {
             row.clean_up ();
@@ -526,13 +522,20 @@ public class Views.Filter : Adw.Bin {
             foreach (Objects.Item item in Services.Store.instance ().get_items_no_parent (false)) {
                 items_list.add (item);
             }
+        }
 
-            if (show_completed ()) {
-                foreach (Objects.Item item in Services.Store.instance ().get_items_no_parent (true)) {
-                    items_list.add (item);
-                }
+        // The filters have to be applied to the backing list, not merely to the loaded rows:
+        // pagination decides which items are loaded at all, so filtering afterwards would
+        // hide the first page and never reach the matches behind it. Keeping the backing
+        // list filtered also keeps the "Load more" count honest.
+        var filtered_list = new Gee.ArrayList<Objects.Item> ();
+        foreach (Objects.Item item in items_list) {
+            if (item_matches_filters (item)) {
+                filtered_list.add (item);
             }
         }
+
+        items_list = filtered_list;
 
         if (filter is Objects.Filters.Completed) {
             items_list.sort ((a, b) => {
@@ -615,7 +618,7 @@ public class Views.Filter : Adw.Bin {
             should_add = true;
         }
 
-        if (should_add) {
+        if (should_add && item_matches_filters (item)) {
             items_list.add (item);
             add_item (item);
             update_load_more_button_label ();
@@ -716,8 +719,7 @@ public class Views.Filter : Adw.Bin {
             filter is Objects.Filters.AllItems
         ) {
             if (!old_checked) {
-                // Keep the row in place when the view is explicitly showing completed tasks.
-                if (items.has_key (item.id) && item.completed && !show_completed ()) {
+                if (items.has_key (item.id) && item.completed) {
                     items[item.id].hide_destroy ();
                     items.unset (item.id);
                     Services.EventBus.get_default ().unfocus_item ();
@@ -946,11 +948,6 @@ public class Views.Filter : Adw.Bin {
             arrow = true
         };
 
-        show_completed_item = new Widgets.ContextMenu.MenuSwitch (_("Show Completed"), "check-round-outline-symbolic") {
-            active = Services.Settings.get_default ().settings.get_boolean (SHOW_COMPLETED_KEY),
-            tooltip_text = _("Display completed tasks in the list")
-        };
-
         var menu_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 0);
         menu_box.margin_top = menu_box.margin_bottom = 3;
         menu_box.append (new Gtk.Label (_("Sort By")) {
@@ -973,8 +970,6 @@ public class Views.Filter : Adw.Bin {
         menu_box.append (due_date_item);
         menu_box.append (priority_filter);
         menu_box.append (labels_filter);
-        menu_box.append (new Widgets.ContextMenu.MenuSeparator ());
-        menu_box.append (show_completed_item);
 
         var popover = new Gtk.Popover () {
             has_arrow = false,
@@ -1008,12 +1003,6 @@ public class Views.Filter : Adw.Bin {
         signal_map[labels_filter.activate_item.connect (() => {
             show_labels_filter_dialog ();
         })] = labels_filter;
-
-        signal_map[show_completed_item.activate_item.connect (() => {
-            Services.Settings.get_default ().settings.set_boolean (SHOW_COMPLETED_KEY, show_completed_item.active);
-            apply_sort_changed ();
-            check_default_filters ();
-        })] = show_completed_item;
 
         return popover;
     }
@@ -1190,24 +1179,16 @@ public class Views.Filter : Adw.Bin {
         Services.Settings.get_default ().settings.set_strv (FILTERS_KEY, stored);
     }
 
-    private bool show_completed () {
-        return sorting_supported && Services.Settings.get_default ().settings.get_boolean (SHOW_COMPLETED_KEY);
-    }
-
     /**
      * Reveals the dot on the view-settings button whenever the view is not showing
      * its default sort and no filters, mirroring the project view's affordance.
      */
     private void check_default_filters () {
-        if (indicator_revealer == null) {
-            return;
-        }
-
         bool has_filters = filter.filters.size > 0;
         bool default_sort = sorted_by_project () &&
             Services.Settings.get_default ().settings.get_boolean (SORT_ASCENDING_KEY);
 
-        indicator_revealer.reveal_child = has_filters || !default_sort || show_completed ();
+        indicator_revealer.reveal_child = has_filters || !default_sort;
     }
 
     private SortOrderType get_sort_order () {

--- a/src/Views/Filter.vala
+++ b/src/Views/Filter.vala
@@ -22,6 +22,24 @@
 public class Views.Filter : Adw.Bin {
     public Objects.BaseObject filter { get; construct; }
 
+    /**
+     * Sort key used to group tasks by their parent project. This is the historical
+     * (and default) ordering of the All Tasks view, and has no SortedByType member
+     * because it is only meaningful in a view that spans several projects.
+     */
+    private const string SORT_BY_PROJECT = "project";
+
+    private const string SORT_ORDER_KEY = "all-items-sort-order";
+    private const string SORT_ASCENDING_KEY = "all-items-sort-ascending";
+    private const string FILTERS_KEY = "all-items-filters";
+    private const string SHOW_COMPLETED_KEY = "all-items-show-completed";
+
+    private Widgets.ContextMenu.MenuPicker due_date_item;
+    private Widgets.ContextMenu.MenuCheckPicker priority_filter;
+    private Widgets.ContextMenu.MenuSwitch show_completed_item;
+    private Gtk.Revealer indicator_revealer;
+    private uint rebuild_idle_id = 0;
+
     private Layouts.HeaderBar headerbar;
     private Gtk.Image title_icon;
     private Gtk.Label title_label;
@@ -33,6 +51,7 @@ public class Views.Filter : Adw.Bin {
     private Gtk.Revealer load_more_button_revealer;
     private Gtk.MenuButton project_filter_button;
     private Gtk.Revealer project_filter_revealer;
+    private Widgets.FilterFlowBox ? filters_flowbox;
     private Adw.StatusPage listbox_placeholder;
     private Gee.ArrayList<string> selected_project_ids = new Gee.ArrayList<string> ();
 
@@ -43,12 +62,31 @@ public class Views.Filter : Adw.Bin {
     private int page_index = 0;
     private const int PAGE_SIZE = Constants.COMPLETED_PAGE_SIZE;
 
+    /**
+     * Whether this filter view offers the sort menu. Only All Tasks does for now;
+     * when the Label view gains the same menu the settings keys above should become
+     * a per-view prefix rather than constants.
+     */
+    private bool sorting_supported {
+        get {
+            return filter is Objects.Filters.AllItems;
+        }
+    }
+
     private bool has_visible_items {
         get {
             if (items_list == null || items_list.size == 0) return false;
-            if (selected_project_ids.size == 0) return true;
+            if (selected_project_ids.size == 0 && filter.filters.size == 0) return true;
             foreach (var item in items_list) {
-                if (selected_project_ids.contains (item.project_id)) return true;
+                if (selected_project_ids.size > 0 && !selected_project_ids.contains (item.project_id)) {
+                    continue;
+                }
+
+                if (sorting_supported && !Utils.TaskUtils.items_filter_func (item, filter.filters)) {
+                    continue;
+                }
+
+                return true;
             }
             return false;
         }
@@ -129,9 +167,31 @@ public class Views.Filter : Adw.Bin {
             tooltip_text = _("View Option Menu")
         };
 
+        var indicator_grid = new Gtk.Grid () {
+            width_request = 9,
+            height_request = 9,
+            margin_top = 6,
+            margin_end = 6,
+            css_classes = { "indicator" }
+        };
+
+        indicator_revealer = new Gtk.Revealer () {
+            transition_type = Gtk.RevealerTransitionType.CROSSFADE,
+            child = indicator_grid,
+            halign = END,
+            valign = START,
+            sensitive = false,
+            reveal_child = false
+        };
+
+        var view_setting_overlay = new Gtk.Overlay () {
+            child = view_setting_button
+        };
+        view_setting_overlay.add_overlay (indicator_revealer);
+
         view_setting_revealer = new Gtk.Revealer () {
             transition_type = Gtk.RevealerTransitionType.CROSSFADE,
-            child = view_setting_button
+            child = view_setting_overlay
         };
 
         headerbar = new Layouts.HeaderBar ();
@@ -185,6 +245,26 @@ public class Views.Filter : Adw.Bin {
 
         content.append (title_box);
         content.append (project_filter_revealer);
+
+        // Removable chips for the active filters, the same affordance the project views offer.
+        // The widget renders the current bag on assignment and then keeps itself in sync from
+        // BaseObject's filter signals, so it needs no wiring beyond the base_object.
+        if (sorting_supported) {
+            filters_flowbox = new Widgets.FilterFlowBox () {
+                valign = Gtk.Align.START,
+                vexpand = false,
+                vexpand_set = true,
+                base_object = filter
+            };
+
+            filters_flowbox.flowbox.margin_start = 30;
+            filters_flowbox.flowbox.margin_top = 12;
+            filters_flowbox.flowbox.margin_end = 12;
+            filters_flowbox.flowbox.margin_bottom = 3;
+
+            content.append (filters_flowbox);
+        }
+
         content.append (listbox_stack);
 
         var content_clamp = new Adw.Clamp () {
@@ -216,8 +296,17 @@ public class Views.Filter : Adw.Bin {
         toolbar_view.add_top_bar (headerbar);
 
         listbox.set_filter_func ((row) => {
-            if (selected_project_ids.size == 0) return true;
-            return selected_project_ids.contains (((Layouts.ItemRow) row).item.project_id);
+            var item = ((Layouts.ItemRow) row).item;
+
+            if (selected_project_ids.size > 0 && !selected_project_ids.contains (item.project_id)) {
+                return false;
+            }
+
+            if (sorting_supported && !Utils.TaskUtils.items_filter_func (item, filter.filters)) {
+                return false;
+            }
+
+            return true;
         });
 
         child = toolbar_view;
@@ -262,7 +351,74 @@ public class Views.Filter : Adw.Bin {
 
         signal_map[Services.EventBus.get_default ().dim_content.connect ((active, focused_item_id) => {
             title_box.sensitive = !active;
+
+            if (filters_flowbox != null) {
+                filters_flowbox.sensitive = !active;
+            }
         })] = Services.EventBus.get_default ();
+
+        if (sorting_supported) {
+            signal_map[Services.Settings.get_default ().settings.changed[SORT_ORDER_KEY].connect (() => {
+                apply_sort_changed ();
+                check_default_filters ();
+            })] = Services.Settings.get_default ().settings;
+
+            signal_map[Services.Settings.get_default ().settings.changed[SORT_ASCENDING_KEY].connect (() => {
+                apply_sort_changed ();
+                check_default_filters ();
+            })] = Services.Settings.get_default ().settings;
+
+            signal_map[filter.filter_added.connect (() => {
+                apply_filters_changed ();
+            })] = filter;
+
+            signal_map[filter.filter_removed.connect ((filter_item) => {
+                if (filter_item.filter_type == FilterItemType.PRIORITY) {
+                    priority_filter.unchecked (filter_item);
+                } else if (filter_item.filter_type == FilterItemType.DUE_DATE) {
+                    due_date_item.update_selected ("0");
+                }
+
+                apply_filters_changed ();
+            })] = filter;
+
+            signal_map[filter.filter_updated.connect (() => {
+                apply_filters_changed ();
+            })] = filter;
+
+            check_default_filters ();
+        }
+    }
+
+    private void apply_filters_changed () {
+        save_filters ();
+        listbox.invalidate_filter ();
+        validate_placeholder ();
+        check_default_filters ();
+    }
+
+    /**
+     * Re-sorts and re-pages the list after the sort settings change. The whole list
+     * has to be rebuilt rather than merely invalidated, because pagination decides
+     * which items are loaded at all from the sorted backing list.
+     */
+    private void apply_sort_changed () {
+        // Deferred to an idle callback rather than run inline. Rebuilding tears down and
+        // frees every ItemRow, and this runs from inside a signal emission (a GSettings
+        // "changed" handler) that can still touch those rows once we return — which shows
+        // up as GTK_IS_LABEL/GTK_IS_WIDGET assertions on freed widgets. The idle source
+        // also coalesces a burst of rapid filter clicks into a single rebuild.
+        if (rebuild_idle_id != 0) {
+            return;
+        }
+
+        rebuild_idle_id = Idle.add (() => {
+            rebuild_idle_id = 0;
+            update_header_func ();
+            add_items ();
+            validate_placeholder ();
+            return GLib.Source.REMOVE;
+        });
     }
 
     public void prepare_new_item (string content = "") {
@@ -296,7 +452,7 @@ public class Views.Filter : Adw.Bin {
             Util.get_default ().set_widget_color (priority.color, title_icon);
             
             title_label.label = priority.title;
-            listbox.set_header_func (header_project_function);
+            update_header_func ();
             magic_button.visible = true;
         } else {
             title_icon.icon_name = filter.icon_name;
@@ -306,17 +462,20 @@ public class Views.Filter : Adw.Bin {
 
             if (filter is Objects.Filters.Completed) {
                 magic_button.visible = false;
-                listbox.set_header_func (header_completed_function);
                 listbox.set_sort_func ((row1, row2) => {
                     return sort_completed_function (((Layouts.ItemRow) row1).item, ((Layouts.ItemRow) row2).item);
                 });
-            } else {
-                listbox.set_header_func (header_project_function);
+            } else if (sorting_supported) {
+                listbox.set_sort_func ((row1, row2) => {
+                    return sort_items_function (((Layouts.ItemRow) row1).item, ((Layouts.ItemRow) row2).item);
+                });
             }
-        } 
+
+            update_header_func ();
+        }
 
         headerbar.title = title_label.label;
-        view_setting_revealer.reveal_child = filter is Objects.Filters.Completed;
+        view_setting_revealer.reveal_child = filter is Objects.Filters.Completed || sorting_supported;
         project_filter_revealer.reveal_child = filter is Objects.Filters.Completed;
     }
 
@@ -367,11 +526,24 @@ public class Views.Filter : Adw.Bin {
             foreach (Objects.Item item in Services.Store.instance ().get_items_no_parent (false)) {
                 items_list.add (item);
             }
+
+            if (show_completed ()) {
+                foreach (Objects.Item item in Services.Store.instance ().get_items_no_parent (true)) {
+                    items_list.add (item);
+                }
+            }
         }
 
         if (filter is Objects.Filters.Completed) {
             items_list.sort ((a, b) => {
                 return sort_completed_function (a, b);
+            });
+        } else if (sorting_supported) {
+            // The list is paginated, so the backing list has to carry the sort too:
+            // otherwise the first page would be chosen by the old order and only
+            // re-sorted among itself.
+            items_list.sort ((a, b) => {
+                return sort_items_function (a, b);
             });
         } else {
             items_list.sort ((a, b) => {
@@ -544,7 +716,8 @@ public class Views.Filter : Adw.Bin {
             filter is Objects.Filters.AllItems
         ) {
             if (!old_checked) {
-                if (items.has_key (item.id) && item.completed) {
+                // Keep the row in place when the view is explicitly showing completed tasks.
+                if (items.has_key (item.id) && item.completed && !show_completed ()) {
                     items[item.id].hide_destroy ();
                     items.unset (item.id);
                     Services.EventBus.get_default ().unfocus_item ();
@@ -605,7 +778,8 @@ public class Views.Filter : Adw.Bin {
             }
         }
 
-        row.set_header (get_header_box (row.item.project.name));
+        Objects.Project ? project = row.item.project;
+        row.set_header (get_header_box (project == null ? "" : project.name));
     }
 
     private void validate_placeholder () {
@@ -615,6 +789,9 @@ public class Views.Filter : Adw.Bin {
         } else if (filter is Objects.Filters.Completed) {
             listbox_placeholder.title = _("All tasks completed!");
             listbox_placeholder.description = _("Great job, nothing left to do 🎉");
+        } else if (sorting_supported && !has_visible_items && filter.filters.size > 0) {
+            listbox_placeholder.title = _("No tasks found");
+            listbox_placeholder.description = _("No tasks match the selected filters");
         } else {
             listbox_placeholder.title = _("Add Some Tasks");
             listbox_placeholder.description = _("Press 'a' to create a new task");
@@ -661,6 +838,10 @@ public class Views.Filter : Adw.Bin {
     }
 
     private Gtk.Popover build_view_setting_popover () {
+        if (sorting_supported) {
+            return build_sort_setting_popover ();
+        }
+
         var delete_all_completed = new Widgets.ContextMenu.MenuItem (_("Delete All Completed Tasks"), "user-trash-symbolic");
         delete_all_completed.add_css_class ("menu-item-danger");
 
@@ -709,6 +890,364 @@ public class Views.Filter : Adw.Bin {
         return popover;
     }
 
+    private Gtk.Popover build_sort_setting_popover () {
+        var sorted_by_item = new Widgets.ContextMenu.MenuPicker (_("Sorting"), "vertical-arrows-long-symbolic") {
+            selected = Services.Settings.get_default ().settings.get_string (SORT_ORDER_KEY)
+        };
+
+        sorted_by_item.add_item (_("Project"), SORT_BY_PROJECT);
+        sorted_by_item.add_item (_("Alphabetically"), SortedByType.NAME.to_string ());
+        sorted_by_item.add_item (_("Due Date"), SortedByType.DUE_DATE.to_string ());
+        sorted_by_item.add_item (_("Date Added"), SortedByType.ADDED_DATE.to_string ());
+        sorted_by_item.add_item (_("Date Modified"), SortedByType.UPDATED_DATE.to_string ());
+        sorted_by_item.add_item (_("Priority"), SortedByType.PRIORITY.to_string ());
+
+        var sort_order_item = new Widgets.ContextMenu.MenuSwitch (_("Ascending Order"), "vertical-arrows-long-symbolic") {
+            active = Services.Settings.get_default ().settings.get_boolean (SORT_ASCENDING_KEY)
+        };
+
+        due_date_item = new Widgets.ContextMenu.MenuPicker (_("Duedate"), "month-symbolic") {
+            selected = "0"
+        };
+        due_date_item.add_item (_("All (default)"), "0");
+        due_date_item.add_item (_("Today"), "1");
+        due_date_item.add_item (_("This Week"), "2");
+        due_date_item.add_item (_("Next 7 Days"), "3");
+        due_date_item.add_item (_("This Month"), "4");
+        due_date_item.add_item (_("Next 30 Days"), "5");
+        due_date_item.add_item (_("No Date"), "6");
+
+        var priority_items = new Gee.ArrayList<Objects.Filters.FilterItem> ();
+        priority_items.add (new Objects.Filters.FilterItem () {
+            filter_type = FilterItemType.PRIORITY,
+            name = _("P1"),
+            value = Constants.PRIORITY_1.to_string ()
+        });
+        priority_items.add (new Objects.Filters.FilterItem () {
+            filter_type = FilterItemType.PRIORITY,
+            name = _("P2"),
+            value = Constants.PRIORITY_2.to_string ()
+        });
+        priority_items.add (new Objects.Filters.FilterItem () {
+            filter_type = FilterItemType.PRIORITY,
+            name = _("P3"),
+            value = Constants.PRIORITY_3.to_string ()
+        });
+        priority_items.add (new Objects.Filters.FilterItem () {
+            filter_type = FilterItemType.PRIORITY,
+            name = _("P4"),
+            value = Constants.PRIORITY_4.to_string ()
+        });
+
+        priority_filter = new Widgets.ContextMenu.MenuCheckPicker (_("Priority"), "flag-outline-thick-symbolic");
+        priority_filter.set_items (priority_items);
+
+        var labels_filter = new Widgets.ContextMenu.MenuItem (_("Filter by Labels"), "tag-outline-symbolic") {
+            arrow = true
+        };
+
+        show_completed_item = new Widgets.ContextMenu.MenuSwitch (_("Show Completed"), "check-round-outline-symbolic") {
+            active = Services.Settings.get_default ().settings.get_boolean (SHOW_COMPLETED_KEY),
+            tooltip_text = _("Display completed tasks in the list")
+        };
+
+        var menu_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 0);
+        menu_box.margin_top = menu_box.margin_bottom = 3;
+        menu_box.append (new Gtk.Label (_("Sort By")) {
+            css_classes = { "heading", "h4" },
+            margin_start = 6,
+            margin_top = 6,
+            margin_bottom = 6,
+            halign = Gtk.Align.START
+        });
+        menu_box.append (sorted_by_item);
+        menu_box.append (sort_order_item);
+        menu_box.append (new Widgets.ContextMenu.MenuSeparator ());
+        menu_box.append (new Gtk.Label (_("Filter By")) {
+            css_classes = { "heading", "h4" },
+            margin_start = 6,
+            margin_top = 6,
+            margin_bottom = 6,
+            halign = Gtk.Align.START
+        });
+        menu_box.append (due_date_item);
+        menu_box.append (priority_filter);
+        menu_box.append (labels_filter);
+        menu_box.append (new Widgets.ContextMenu.MenuSeparator ());
+        menu_box.append (show_completed_item);
+
+        var popover = new Gtk.Popover () {
+            has_arrow = false,
+            position = Gtk.PositionType.BOTTOM,
+            child = menu_box,
+            width_request = 250
+        };
+
+        restore_filters ();
+
+        signal_map[sorted_by_item.notify["selected"].connect (() => {
+            Services.Settings.get_default ().settings.set_string (SORT_ORDER_KEY, sorted_by_item.selected);
+        })] = sorted_by_item;
+
+        signal_map[sort_order_item.activate_item.connect (() => {
+            Services.Settings.get_default ().settings.set_boolean (SORT_ASCENDING_KEY, sort_order_item.active);
+        })] = sort_order_item;
+
+        signal_map[due_date_item.notify["selected"].connect (() => {
+            update_due_date_filter (int.parse (due_date_item.selected));
+        })] = due_date_item;
+
+        signal_map[priority_filter.filter_change.connect ((filter_item, active) => {
+            if (active) {
+                filter.add_filter (filter_item);
+            } else {
+                filter.remove_filter (filter_item);
+            }
+        })] = priority_filter;
+
+        signal_map[labels_filter.activate_item.connect (() => {
+            show_labels_filter_dialog ();
+        })] = labels_filter;
+
+        signal_map[show_completed_item.activate_item.connect (() => {
+            Services.Settings.get_default ().settings.set_boolean (SHOW_COMPLETED_KEY, show_completed_item.active);
+            apply_sort_changed ();
+            check_default_filters ();
+        })] = show_completed_item;
+
+        return popover;
+    }
+
+    private void update_due_date_filter (int selected) {
+        Objects.Filters.FilterItem ? due_filter = filter.get_filter (FilterItemType.DUE_DATE.to_string ());
+
+        if (selected <= 0) {
+            if (due_filter != null) {
+                filter.remove_filter (due_filter);
+            }
+
+            return;
+        }
+
+        bool insert = false;
+        if (due_filter == null) {
+            due_filter = new Objects.Filters.FilterItem ();
+            due_filter.filter_type = FilterItemType.DUE_DATE;
+            insert = true;
+        }
+
+        due_filter.name = due_date_name (selected);
+        due_filter.value = selected.to_string ();
+
+        if (insert) {
+            filter.add_filter (due_filter);
+        } else {
+            filter.update_filter (due_filter);
+        }
+    }
+
+    private string due_date_name (int selected) {
+        switch (selected) {
+            case 1:
+                return _("Today");
+
+            case 2:
+                return _("This Week");
+
+            case 3:
+                return _("Next 7 Days");
+
+            case 4:
+                return _("This Month");
+
+            case 5:
+                return _("Next 30 Days");
+
+            case 6:
+                return _("No Date");
+
+            default:
+                return _("All (default)");
+        }
+    }
+
+    private void show_labels_filter_dialog () {
+        Gee.ArrayList<Objects.Label> selected_labels = new Gee.ArrayList<Objects.Label> ();
+        foreach (Objects.Filters.FilterItem filter_item in filter.filters.values) {
+            if (filter_item.filter_type == FilterItemType.LABEL) {
+                Objects.Label ? label = Services.Store.instance ().get_label (filter_item.value);
+                if (label != null) {
+                    selected_labels.add (label);
+                }
+            }
+        }
+
+        var dialog = new Dialogs.LabelPicker ();
+        dialog.add_labels_list (Services.Store.instance ().labels);
+        dialog.labels = selected_labels;
+
+        // Scoped to the dialog, not the view's signal_map: handler ids are per-instance,
+        // so tracking a transient object there collides with an existing key and leaves the
+        // view disconnecting that id against the wrong instance.
+        ulong labels_handler = dialog.labels_changed.connect ((labels) => {
+            foreach (Objects.Label label in labels.values) {
+                var label_filter = new Objects.Filters.FilterItem ();
+                label_filter.filter_type = FilterItemType.LABEL;
+                label_filter.name = label.name;
+                label_filter.value = label.id;
+
+                filter.add_filter (label_filter);
+            }
+
+            var to_remove = new Gee.ArrayList<Objects.Filters.FilterItem> ();
+            foreach (Objects.Filters.FilterItem filter_item in filter.filters.values) {
+                if (filter_item.filter_type == FilterItemType.LABEL && !labels.has_key (filter_item.value)) {
+                    to_remove.add (filter_item);
+                }
+            }
+
+            foreach (Objects.Filters.FilterItem filter_item in to_remove) {
+                filter.remove_filter (filter_item);
+            }
+        });
+
+        dialog.closed.connect (() => {
+            if (GLib.SignalHandler.is_connected (dialog, labels_handler)) {
+                dialog.disconnect (labels_handler);
+            }
+        });
+
+        dialog.present (Planify._instance.main_window);
+    }
+
+    /**
+     * Restores the filters persisted for this view and syncs the menu widgets to them.
+     * Each entry is stored as "filter-type:value"; the display name is re-derived rather
+     * than persisted, so a renamed label shows its current name.
+     */
+    private void restore_filters () {
+        string[] stored = Services.Settings.get_default ().settings.get_strv (FILTERS_KEY);
+
+        foreach (string entry in stored) {
+            string[] parts = entry.split (":", 2);
+            if (parts.length != 2) {
+                continue;
+            }
+
+            string type = parts[0];
+            string value = parts[1];
+
+            var filter_item = new Objects.Filters.FilterItem ();
+            filter_item.value = value;
+
+            if (type == FilterItemType.PRIORITY.to_string ()) {
+                filter_item.filter_type = FilterItemType.PRIORITY;
+                filter_item.name = "P%d".printf (Constants.PRIORITY_1 - int.parse (value) + 1);
+            } else if (type == FilterItemType.LABEL.to_string ()) {
+                Objects.Label ? label = Services.Store.instance ().get_label (value);
+                if (label == null) {
+                    // The label was deleted since the filter was stored.
+                    continue;
+                }
+
+                filter_item.filter_type = FilterItemType.LABEL;
+                filter_item.name = label.name;
+            } else if (type == FilterItemType.DUE_DATE.to_string ()) {
+                filter_item.filter_type = FilterItemType.DUE_DATE;
+                filter_item.name = due_date_name (int.parse (value));
+            } else {
+                continue;
+            }
+
+            filter.add_filter (filter_item);
+        }
+
+        sync_menu_to_filters ();
+    }
+
+    private void sync_menu_to_filters () {
+        foreach (Objects.Filters.FilterItem filter_item in filter.filters.values) {
+            if (filter_item.filter_type == FilterItemType.PRIORITY) {
+                if (priority_filter.filters_map.has_key (filter_item.id)) {
+                    priority_filter.filters_map[filter_item.id].active = true;
+                }
+            } else if (filter_item.filter_type == FilterItemType.DUE_DATE) {
+                due_date_item.update_selected (filter_item.value);
+            }
+        }
+    }
+
+    private void save_filters () {
+        // Build a native string[] rather than going through Gee's generic to_array():
+        // for a reference-type generic that returns unowned element pointers, which are
+        // freed before set_strv() reads them (SIGSEGV inside g_utf8_validate).
+        string[] stored = {};
+
+        foreach (Objects.Filters.FilterItem filter_item in filter.filters.values) {
+            stored += "%s:%s".printf (filter_item.filter_type.to_string (), filter_item.value);
+        }
+
+        Services.Settings.get_default ().settings.set_strv (FILTERS_KEY, stored);
+    }
+
+    private bool show_completed () {
+        return sorting_supported && Services.Settings.get_default ().settings.get_boolean (SHOW_COMPLETED_KEY);
+    }
+
+    /**
+     * Reveals the dot on the view-settings button whenever the view is not showing
+     * its default sort and no filters, mirroring the project view's affordance.
+     */
+    private void check_default_filters () {
+        if (indicator_revealer == null) {
+            return;
+        }
+
+        bool has_filters = filter.filters.size > 0;
+        bool default_sort = sorted_by_project () &&
+            Services.Settings.get_default ().settings.get_boolean (SORT_ASCENDING_KEY);
+
+        indicator_revealer.reveal_child = has_filters || !default_sort || show_completed ();
+    }
+
+    private SortOrderType get_sort_order () {
+        return Services.Settings.get_default ().settings.get_boolean (SORT_ASCENDING_KEY)
+            ? SortOrderType.ASC : SortOrderType.DESC;
+    }
+
+    private bool sorted_by_project () {
+        return Services.Settings.get_default ().settings.get_string (SORT_ORDER_KEY) == SORT_BY_PROJECT;
+    }
+
+    private int sort_items_function (Objects.Item item1, Objects.Item item2) {
+        if (sorted_by_project ()) {
+            return Util.get_default ().set_item_project_sort_func (item1, item2, get_sort_order ());
+        }
+
+        return Util.get_default ().set_item_sort_func (
+            item1,
+            item2,
+            SortedByType.parse (Services.Settings.get_default ().settings.get_string (SORT_ORDER_KEY)),
+            get_sort_order ()
+        );
+    }
+
+    private void update_header_func () {
+        if (filter is Objects.Filters.Completed) {
+            listbox.set_header_func (header_completed_function);
+            return;
+        }
+
+        // Grouping headers only make sense while the list is grouped by project;
+        // under any other sort they would fragment the order into noise.
+        if (sorting_supported && !sorted_by_project ()) {
+            listbox.set_header_func (null);
+            return;
+        }
+
+        listbox.set_header_func (header_project_function);
+    }
+
     private void invalidate_listbox () {
         listbox.invalidate_sort ();
         listbox.invalidate_headers ();
@@ -727,6 +1266,11 @@ public class Views.Filter : Adw.Bin {
     }
 
     public void clean_up () {
+        if (rebuild_idle_id != 0) {
+            GLib.Source.remove (rebuild_idle_id);
+            rebuild_idle_id = 0;
+        }
+
         listbox.set_sort_func (null);
         listbox.set_header_func (null);
 
@@ -735,7 +1279,9 @@ public class Views.Filter : Adw.Bin {
         }
         
         foreach (var entry in signal_map.entries) {
-            entry.value.disconnect (entry.key);
+            if (entry.value != null && GLib.SignalHandler.is_connected (entry.value, entry.key)) {
+                entry.value.disconnect (entry.key);
+            }
         }
 
         signal_map.clear ();

--- a/test/core/test-item-sorting.vala
+++ b/test/core/test-item-sorting.vala
@@ -1,0 +1,193 @@
+/*
+ * Copyright © 2026 Alain M. (https://github.com/alainm23/planify)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA
+ */
+
+/**
+ * Item Sorting Tests
+ *
+ * Covers Util.set_item_project_sort_func, the comparator behind the All Tasks view's
+ * "Project" sort: tasks are grouped by project and ordered by priority inside each group.
+ *
+ * The fixtures never reach the database. Objects.Project only connects to Services.Store
+ * signals in its construct block, Services.Store loads its collections lazily, and
+ * Item.set_project () populates the backing field so Item.project never calls
+ * Store.get_project ().
+ */
+
+namespace Planify.Tests.ItemSorting {
+    private Objects.Project make_project (string id, string name) {
+        var project = new Objects.Project ();
+        project.id = id;
+        project.name = name;
+        return project;
+    }
+
+    /**
+     * Builds a task. Pass a null project to model an orphaned task, whose project row is
+     * gone but whose rows still show up in the All Tasks view (cf. upstream #2652).
+     */
+    private Objects.Item make_item (Objects.Project ? project, int priority, string added_at, string content) {
+        var item = new Objects.Item ();
+        item.content = content;
+        item.priority = priority;
+        item.added_at = added_at;
+
+        if (project != null) {
+            item.project_id = project.id;
+            item.set_project (project);
+        }
+
+        return item;
+    }
+
+    private int compare (Objects.Item item1, Objects.Item item2, SortOrderType sort_order) {
+        return Util.get_default ().set_item_project_sort_func (item1, item2, sort_order);
+    }
+
+    /**
+     * Asserts that first sorts ahead of second, and that the comparator is antisymmetric
+     * about that pair — a comparator that returns 0 both ways passes neither check.
+     */
+    private void assert_sorts_before (Objects.Item first, Objects.Item second, SortOrderType sort_order) {
+        int forward = compare (first, second, sort_order);
+        int backward = compare (second, first, sort_order);
+
+        if (forward >= 0 || backward <= 0) {
+            Test.fail_printf ("expected '%s' to sort before '%s' (got %d forward, %d backward)",
+                              first.content, second.content, forward, backward);
+        }
+    }
+
+    void test_orders_by_priority_within_the_same_project () {
+        var project = make_project ("project-a", "Alpha");
+        var high = make_item (project, Constants.PRIORITY_1, "2026-01-02T10:00:00Z", "high");
+        var low = make_item (project, Constants.PRIORITY_4, "2026-01-01T10:00:00Z", "low");
+
+        // Priority wins over date added, so the older low-priority task still sorts last.
+        assert_sorts_before (high, low, SortOrderType.ASC);
+    }
+
+    void test_breaks_a_priority_tie_by_date_added () {
+        var project = make_project ("project-a", "Alpha");
+        var older = make_item (project, Constants.PRIORITY_2, "2026-01-01T10:00:00Z", "older");
+        var newer = make_item (project, Constants.PRIORITY_2, "2026-01-05T10:00:00Z", "newer");
+
+        assert_sorts_before (older, newer, SortOrderType.ASC);
+    }
+
+    void test_groups_projects_alphabetically_when_ascending () {
+        var alpha = make_project ("project-a", "Alpha");
+        var zulu = make_project ("project-z", "Zulu");
+
+        // The low-priority Alpha task still precedes the high-priority Zulu one: the
+        // grouping is the outer sort, priority only orders within a group.
+        var alpha_low = make_item (alpha, Constants.PRIORITY_4, "2026-01-01T10:00:00Z", "alpha low");
+        var zulu_high = make_item (zulu, Constants.PRIORITY_1, "2026-01-01T10:00:00Z", "zulu high");
+
+        assert_sorts_before (alpha_low, zulu_high, SortOrderType.ASC);
+    }
+
+    void test_keeps_priority_highest_first_when_descending () {
+        var alpha = make_project ("project-a", "Alpha");
+        var zulu = make_project ("project-z", "Zulu");
+
+        var alpha_high = make_item (alpha, Constants.PRIORITY_1, "2026-01-01T10:00:00Z", "alpha high");
+        var alpha_low = make_item (alpha, Constants.PRIORITY_4, "2026-01-01T10:00:00Z", "alpha low");
+        var zulu_high = make_item (zulu, Constants.PRIORITY_1, "2026-01-01T10:00:00Z", "zulu high");
+
+        // Descending reverses the grouping …
+        assert_sorts_before (zulu_high, alpha_high, SortOrderType.DESC);
+
+        // … but not the ranking inside a group: P1 stays above P4 in both directions.
+        assert_sorts_before (alpha_high, alpha_low, SortOrderType.DESC);
+    }
+
+    void test_never_interleaves_two_projects_sharing_a_name () {
+        var first = make_project ("project-a", "Work");
+        var second = make_project ("project-b", "Work");
+
+        // Names collate equal, so only the project id keeps the two groups apart. Without
+        // it the rows interleave and the view emits a repeated "Work" header.
+        var first_low = make_item (first, Constants.PRIORITY_4, "2026-01-01T10:00:00Z", "first low");
+        var second_high = make_item (second, Constants.PRIORITY_1, "2026-01-01T10:00:00Z", "second high");
+
+        assert_sorts_before (first_low, second_high, SortOrderType.ASC);
+    }
+
+    void test_sorts_orphaned_tasks_by_priority_without_dereferencing_null () {
+        var high = make_item (null, Constants.PRIORITY_1, "2026-01-01T10:00:00Z", "orphan high");
+        var low = make_item (null, Constants.PRIORITY_4, "2026-01-01T10:00:00Z", "orphan low");
+
+        assert_sorts_before (high, low, SortOrderType.ASC);
+    }
+
+    void test_sorts_an_orphaned_task_against_one_with_a_project () {
+        var project = make_project ("project-a", "Alpha");
+        var orphan = make_item (null, Constants.PRIORITY_1, "2026-01-01T10:00:00Z", "orphan");
+        var owned = make_item (project, Constants.PRIORITY_1, "2026-01-01T10:00:00Z", "owned");
+
+        // An orphan collates under the empty name, which sorts first ascending.
+        assert_sorts_before (orphan, owned, SortOrderType.ASC);
+    }
+
+    void test_returns_zero_only_when_comparing_an_item_with_itself () {
+        var alpha = make_project ("project-a", "Alpha");
+        var zulu = make_project ("project-z", "Zulu");
+
+        Objects.Item[] items = {
+            make_item (alpha, Constants.PRIORITY_1, "2026-01-01T10:00:00Z", "a1"),
+            make_item (alpha, Constants.PRIORITY_1, "2026-01-02T10:00:00Z", "a2"),
+            make_item (alpha, Constants.PRIORITY_4, "2026-01-01T10:00:00Z", "a3"),
+            make_item (zulu, Constants.PRIORITY_2, "2026-01-01T10:00:00Z", "z1"),
+            make_item (null, Constants.PRIORITY_3, "2026-01-01T10:00:00Z", "orphan")
+        };
+
+        foreach (SortOrderType sort_order in new SortOrderType[] { SortOrderType.ASC, SortOrderType.DESC }) {
+            for (int i = 0; i < items.length; i++) {
+                for (int j = 0; j < items.length; j++) {
+                    int result = compare (items[i], items[j], sort_order);
+
+                    if ((i == j) != (result == 0)) {
+                        Test.fail_printf ("comparing '%s' with '%s' returned %d",
+                                          items[i].content, items[j].content, result);
+                        return;
+                    }
+                }
+            }
+        }
+    }
+
+    public void register_tests () {
+        Test.add_func ("/item-sorting/orders-by-priority-within-the-same-project",
+                       test_orders_by_priority_within_the_same_project);
+        Test.add_func ("/item-sorting/breaks-a-priority-tie-by-date-added",
+                       test_breaks_a_priority_tie_by_date_added);
+        Test.add_func ("/item-sorting/groups-projects-alphabetically-when-ascending",
+                       test_groups_projects_alphabetically_when_ascending);
+        Test.add_func ("/item-sorting/keeps-priority-highest-first-when-descending",
+                       test_keeps_priority_highest_first_when_descending);
+        Test.add_func ("/item-sorting/never-interleaves-two-projects-sharing-a-name",
+                       test_never_interleaves_two_projects_sharing_a_name);
+        Test.add_func ("/item-sorting/sorts-orphaned-tasks-by-priority-without-dereferencing-null",
+                       test_sorts_orphaned_tasks_by_priority_without_dereferencing_null);
+        Test.add_func ("/item-sorting/sorts-an-orphaned-task-against-one-with-a-project",
+                       test_sorts_an_orphaned_task_against_one_with_a_project);
+        Test.add_func ("/item-sorting/returns-zero-only-when-comparing-an-item-with-itself",
+                       test_returns_zero_only_when_comparing_an_item_with_itself);
+    }
+}

--- a/test/meson.build
+++ b/test/meson.build
@@ -24,3 +24,17 @@ test_cli = executable(
 )
 
 test('cli', test_cli, timeout: 30, suite: ['cli'])
+
+test_core_sources = [
+    'test-core-runner.vala',
+    'core/test-item-sorting.vala'
+]
+
+test_core = executable(
+    'test-core',
+    test_core_sources,
+    dependencies: [ core_dep, glib_dep ],
+    install: false
+)
+
+test('core', test_core, timeout: 30, suite: ['core'])

--- a/test/test-core-runner.vala
+++ b/test/test-core-runner.vala
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2026 Alain M. (https://github.com/alainm23/planify)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA
+ */
+
+/**
+ * Core Test Runner
+ *
+ * Main test runner for the core library. Each component has its own test file in the
+ * test/core/ directory.
+ */
+
+int main (string[] args) {
+    Test.init (ref args);
+
+    Planify.Tests.ItemSorting.register_tests ();
+
+    return Test.run ();
+}


### PR DESCRIPTION
### What changed

The All Tasks view gains the sort and filter controls that project views already have:

- **Sorting** — Project, Alphabetically, Due Date, Date Added, Date Modified, Priority, with an
  ascending/descending toggle. The comparison itself delegates to the existing
  `Util.set_item_sort_func`, so ordering semantics stay identical to the Today and Scheduled views.
- **Filters** — due-date range, priority (P1–P4) and labels, evaluated by the existing
  `Utils.TaskUtils.items_filter_func` and stored in the `filters` bag `Objects.BaseObject` already
  provides. Behaviour matches the project view, including its OR-across-filter-types semantics.
- An indicator dot on the view-settings button when the view is not in its default state, matching
  `Views.Project`.
- **Filter chips** above the list, one per active filter, each removable — the same affordance the
  project, Today and Scheduled views already offer. This reuses `Widgets.FilterFlowBox` unchanged:
  the All Tasks filters already live in the `Objects.BaseObject` filter bag the widget reads, so it
  needs nothing but its `base_object`, and removing a chip routes through the same
  `remove_filter ()` path the menu uses, leaving the pickers in step.

No new widgets were introduced — the popover is built from the existing
`Widgets.ContextMenu.{MenuPicker, MenuCheckPicker, MenuSwitch, MenuItem, MenuSeparator}`, and the
label filter reuses `Dialogs.LabelPicker`.

### Why

Closes #2431. It is hard to get an overview across projects to pick what to work on next, and the
view offered no ordering control at all.

The scope deliberately follows your comment on that issue:

> For now, I'll consider adding the same sort options that project views already support (by due
> date, priority, title, etc.) to the All Tasks view as a first step. The two-level sorting
> (primary + secondary key) is an interesting idea but adds significant UI complexity, I'll keep it
> in mind for a future iteration.

So this is parity with project views only — **no two-level sorting**, and no List/Board toggle
(board columns are sections, which has no obvious meaning across projects; happy to follow up if
you have a design in mind).

### Implementation notes

- **State lives in GSettings**, not the database, following the existing `today-sort-order` /
  `scheduled-sort-order` precedent — a filter view has no `Projects` row to hang columns off.
  Three new keys: `all-items-sort-order`, `all-items-sort-ascending`, `all-items-filters`.
  No schema migration is required.
- **The default is `project`, so existing behaviour is preserved** — the view still groups by
  project until the user chooses otherwise.
- Sorting by project *name* rather than raw `project_id` also fixes a small pre-existing mismatch:
  the list was ordered by UUID while `header_project_function` labelled the groups by name, so the
  grouping appeared arbitrary.

**Ordering within a project group.** Sorting by Project is a full ordering, not a project-name
comparison alone: project name, then project id, then priority (highest first, ties broken by
date added) within a group. Without the trailing keys the comparator returns `0` for any two tasks
in the same project, which leaves their relative order to the item load order and to `GtkListBox`'s
insertion for equal rows — arbitrary, and not stable across restarts. The project-id key also
keeps two projects that happen to share a name from interleaving under a single repeated header.
The ascending toggle flips the grouping only; priority stays highest-first in both directions, on
the reading that the toggle controls the grouping rather than the ranking inside it.

The comparator lives in `Util.set_item_project_sort_func` rather than inline in `Views.Filter`, so
it is unit-testable and available to the Label view if that follow-up lands. It delegates the
within-group comparison to the existing `Util.set_item_sort_func`, so priority semantics stay
identical to every other view. Tasks whose project row is gone collate under an empty name instead
of dereferencing null.
- Project headers are cleared under non-project sorts, where they would otherwise fragment the
  order into noise.
- The list is rebuilt on an idle callback rather than inline, because pagination selects which
  items load from the sorted backing list, and tearing rows down inside a signal emission is not
  safe. The idle source is cancelled in `clean_up ()`.
- The sort menu is gated behind a `sorting_supported` check so no other filter view is affected.
- The filters are applied to the backing list, not to the loaded rows. `add_items ()` pages that
  list `PAGE_SIZE` items at a time, so a filter evaluated only in the `GtkListBox` filter func can
  hide the whole first page while the matches sit behind it, unreachable without repeated
  *Load more*. The backing list now carries the filter the way it already carries the sort, so
  pagination pages over matching items and the *Load more* count means what it says.

### Testing instructions

1. Open **All Tasks** and use the new button in the header bar.
2. Each sort option reorders correctly, ascending and descending; the choice survives a restart.
3. Project headers appear only under the Project sort, and within each project the tasks run P1 to
   P4. Switching to descending reverses the project order while leaving priority highest-first.
   The order is identical after a restart.
4. Due-date, priority and label filters narrow the list; the indicator dot appears when the view is
   not in its default state; filters survive a restart.
5. Filter chips appear above the list, one per active due-date, priority or label filter, and are
   present immediately on restart. Removing a chip re-filters the list and clears the matching entry
   in the menu; removing the last one collapses the row.
6. With a filter active whose matches sort past the first page — e.g. *This Month* on a list of more
   than 30 tasks where the matching ones sort last — the matching tasks appear immediately rather
   than the list rendering empty, and *Load more* counts only matching tasks.
7. Regression check: Completed, Pinboard, Priority, Tomorrow, Anytime, Repeating and Unlabeled all
   share `Views.Filter`, and should be unchanged.

Manually tested on Fedora Asahi (aarch64) against a live Nextcloud CalDAV account, using the
Flatpak build from `build-aux/io.github.alainm23.planify.Devel.json`.

This also adds `test/core/`, covering the grouping comparator: priority ordering within a group, the
date-added tie-break, grouping under both sort directions, two projects sharing a name, orphaned
tasks, and that the comparator returns `0` only for an item compared with itself. It runs with
`meson test --suite core` alongside the existing `cli` and `caldav-integration` suites and needs no
database or display. The view code itself still has no harness and is covered manually. If you would
rather this PR stayed limited to the feature, I am happy to split the test target into its own.

Per `AI_POLICY.md`: this was developed with AI assistance. However, I have run and debugged the
result myself.



