### PR TITLE
feat: offer All Tasks and Labels as Home View options

### DIFF
--- a/src/Dialogs/Preferences/Pages/HomeView.vala
+++ b/src/Dialogs/Preferences/Pages/HomeView.vala
@@ -64,7 +64,9 @@ public class Dialogs.Preferences.Pages.HomeView : Dialogs.Preferences.Pages.Base
             Objects.Filters.Inbox.get_default (),
             Objects.Filters.Today.get_default (),
             Objects.Filters.Scheduled.get_default (),
-            Objects.Filters.Pinboard.get_default ()
+            Objects.Filters.Pinboard.get_default (),
+            Objects.Filters.Labels.get_default (),
+            Objects.Filters.AllItems.get_default ()
         };
 
         foreach (Objects.BaseObject object in filters) {


### PR DESCRIPTION
### What changed

Adds **All Tasks** and **Labels** to the Home View picker in Preferences. Two entries in the
existing filter list — `src/Dialogs/Preferences/Pages/HomeView.vala`:

```vala
Objects.BaseObject[] filters = {
    Objects.Filters.Inbox.get_default (),
    Objects.Filters.Today.get_default (),
    Objects.Filters.Scheduled.get_default (),
    Objects.Filters.Pinboard.get_default (),
    Objects.Filters.Labels.get_default (),
    Objects.Filters.AllItems.get_default ()
};
```

### Why

Both are ordinary sidebar views, and **startup routing already handled them** — only the picker
was missing them. `go_homepage ()` forwards the stored id unchanged to `pane_selected ()`, which
already dispatches `"labels"` (`MainWindow.vala:302`) and `"all-items-view"`
(`MainWindow.vala:316`). Setting `home-view` to either id by hand already worked before this
change; there was just no way to do it from the UI.

The omission looks accidental rather than deliberate: both filter objects predate the Home View
page — `Objects.Filters.Labels` since 2023-12-11, `Objects.Filters.AllItems` since 2024-05-29,
versus the Home View page in 2025-09-05. Labels is also in the default `views-order-visible`, so
it is a view most users can see in the sidebar but could not choose as their startup view.

Related context: #1528 asked for a home page showing "an aggregation of all lists", which is what
All Tasks provides; and #1192 ("Pinboard as the startpage") is precedent for adding a single filter
to this list. Both are already closed — this PR isn't claiming to close either.

### Notes

- **No schema change.** `home-view` is a free-form string key storing whatever `view_id` the
  selected row supplies, so nothing needed migrating.
- **Ordering** follows the neighbouring Sidebar preferences page
  (`src/Dialogs/Preferences/Pages/Sidebar.vala:68-78`), which lists Labels after Pinboard and
  All Tasks last.
- **One pre-existing quirk worth flagging**, which this change makes reachable from the UI: the
  sidebar highlights the active view via `FilterPaneChild.active ()`, which hides rows absent from
  `views-order-visible`. Since `all-items-view` is not in that list by default, choosing All Tasks
  as the home view opens the correct view but leaves no sidebar row highlighted until the user also
  enables it in the sidebar. This already applies to Completed, Tomorrow, Anytime, Repeating and
  Unlabeled; Labels is unaffected because it is in the default list. Happy to address it here or
  separately if you'd like it handled.

### Testing instructions

1. Preferences → Home View now lists All Tasks and Labels.
2. Select either, restart the app — it opens on that view.
3. Selecting a project, or one of the original four filters, still behaves as before.

Tested on Fedora Asahi (aarch64) with a Nextcloud CalDAV account.

Per `AI_POLICY.md`: this was developed with AI assistance. However, I have run and debugged the
result myself.
