### PR TITLE
feat: keyboard shortcuts to jump to and cycle through projects

### DIFF
--- a/core/Services/Store.vala
+++ b/core/Services/Store.vala
@@ -315,15 +315,22 @@ public class Services.Store : GLib.Object {
 
     /**
      * Returns every project in the order the sidebar displays it: visible sources by child_order,
-     * and within each source its top-level, non-archived projects.
+     * and within each source its top-level, non-archived projects, again by child_order.
+     *
+     * Both orderings have to be computed rather than read off the store's own list: that list is
+     * ordered once at load, while reordering a project by dragging it writes the new child_order
+     * onto the live Objects.Project and to the database without moving anything in the list. Custom
+     * order taken from the list order would therefore stay on the pre-drag order until the next
+     * restart, while the sidebar showed the new one.
      *
      * Matches what the sidebar actually shows, so callers that address projects by position agree
      * with what the user sees. That is two conditions, not one: Layouts.SidebarSourceRow's
      * add_row_project () decides which rows are built, and Layouts.ProjectRow then keeps the
      * designated inbox hidden (main_revealer.reveal_child = !project.is_inbox_project), so a row
      * existing in the sidebar's list box does not mean it is visible. The alphabetical mode is the
-     * same as projects_sort_func (). Subprojects are excluded because they are rendered nested
-     * inside their parent, not as siblings in this list.
+     * same as projects_sort_func (); custom order ignores the projects-ordered direction exactly as
+     * the sidebar does, which installs no sort function at all in that mode. Subprojects are
+     * excluded because they are rendered nested inside their parent, not as siblings in this list.
      */
     public Gee.ArrayList<Objects.Project> get_projects_display_order () {
         Gee.ArrayList<Objects.Project> return_value = new Gee.ArrayList<Objects.Project> ();
@@ -354,6 +361,10 @@ public class Services.Store : GLib.Object {
             if (alphabetically) {
                 source_projects.sort ((a, b) => {
                     return ordered == 0 ? b.name.collate (a.name) : a.name.collate (b.name);
+                });
+            } else {
+                source_projects.sort ((a, b) => {
+                    return a.child_order - b.child_order;
                 });
             }
 

--- a/core/Services/Store.vala
+++ b/core/Services/Store.vala
@@ -313,6 +313,56 @@ public class Services.Store : GLib.Object {
         }
     }
 
+    /**
+     * Returns every project in the order the sidebar displays it: visible sources by child_order,
+     * and within each source its top-level, non-archived projects.
+     *
+     * Matches what the sidebar actually shows, so callers that address projects by position agree
+     * with what the user sees. That is two conditions, not one: Layouts.SidebarSourceRow's
+     * add_row_project () decides which rows are built, and Layouts.ProjectRow then keeps the
+     * designated inbox hidden (main_revealer.reveal_child = !project.is_inbox_project), so a row
+     * existing in the sidebar's list box does not mean it is visible. The alphabetical mode is the
+     * same as projects_sort_func (). Subprojects are excluded because they are rendered nested
+     * inside their parent, not as siblings in this list.
+     */
+    public Gee.ArrayList<Objects.Project> get_projects_display_order () {
+        Gee.ArrayList<Objects.Project> return_value = new Gee.ArrayList<Objects.Project> ();
+
+        var visible_sources = new Gee.ArrayList<Objects.Source> ();
+        foreach (var source in sources) {
+            if (source.is_visible) {
+                visible_sources.add (source);
+            }
+        }
+
+        visible_sources.sort ((a, b) => {
+            return a.child_order - b.child_order;
+        });
+
+        bool alphabetically = Services.Settings.get_default ().settings.get_enum ("projects-sort-by") == 1;
+        int ordered = Services.Settings.get_default ().settings.get_enum ("projects-ordered");
+
+        foreach (var source in visible_sources) {
+            var source_projects = new Gee.ArrayList<Objects.Project> ();
+
+            foreach (var project in get_projects_by_source (source.id)) {
+                if (project.parent_id == "" && !project.is_archived && !project.is_inbox_project) {
+                    source_projects.add (project);
+                }
+            }
+
+            if (alphabetically) {
+                source_projects.sort ((a, b) => {
+                    return ordered == 0 ? b.name.collate (a.name) : a.name.collate (b.name);
+                });
+            }
+
+            return_value.add_all (source_projects);
+        }
+
+        return return_value;
+    }
+
     public async void delete_project (Objects.Project project) {
         var sections = get_sections_by_project (project);
         var items = get_items_by_project (project);

--- a/data/resources/ui/shortcuts.ui
+++ b/data/resources/ui/shortcuts.ui
@@ -129,6 +129,27 @@
                 <property name="title" translatable="yes" context="shortcut window">Open Pinboard</property>
               </object>
             </child>
+
+            <child>
+              <object class="GtkShortcutsShortcut" id="project-number">
+                <property name="accelerator">&lt;ctrl&gt;1...&lt;ctrl&gt;9</property>
+                <property name="title" translatable="yes" context="shortcut window">Open the Nth Project</property>
+              </object>
+            </child>
+
+            <child>
+              <object class="GtkShortcutsShortcut" id="next-project">
+                <property name="accelerator">&lt;ctrl&gt;Page_Down</property>
+                <property name="title" translatable="yes" context="shortcut window">Open Next Project</property>
+              </object>
+            </child>
+
+            <child>
+              <object class="GtkShortcutsShortcut" id="prev-project">
+                <property name="accelerator">&lt;ctrl&gt;Page_Up</property>
+                <property name="title" translatable="yes" context="shortcut window">Open Previous Project</property>
+              </object>
+            </child>
           </object>
         </child>
       </object>

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -747,6 +747,20 @@ public class MainWindow : Adw.ApplicationWindow {
         }
     }
 
+    /**
+     * The project currently on screen, or null when the visible view is not a project.
+     */
+    public Objects.Project ? get_current_project () {
+        if (views_stack.visible_child is Views.Project) {
+            Views.Project ? project_view = (Views.Project) views_stack.visible_child;
+            if (project_view != null) {
+                return project_view.project;
+            }
+        }
+
+        return null;
+    }
+
     private void update_productivity_visibility (Widgets.ContextMenu.MenuItem item, Widgets.ProductivityMiniWidget mini) {
         bool show_mini = Services.ProductivityService.instance ().has_goals ();
         item.visible = !show_mini;

--- a/src/Services/ActionManager.vala
+++ b/src/Services/ActionManager.vala
@@ -44,6 +44,13 @@ public class Services.ActionManager : Object {
     public const string ACTION_VIEW_LABELS = "action_view_labels";
     public const string ACTION_VIEW_HOME = "action_view_home";
     public const string ACTION_SHOW_HIDE_SIDEBAR = "action_show_hide_sidebar";
+    public const string ACTION_VIEW_PROJECT = "action_view_project";
+    public const string ACTION_NEXT_PROJECT = "action_next_project";
+    public const string ACTION_PREV_PROJECT = "action_prev_project";
+
+    // Ctrl+1..8 select that position in the sidebar order; Ctrl+9 always selects the last project,
+    // following the convention used by browsers and chat apps for numbered tab shortcuts.
+    private const int PROJECT_SHORTCUTS = 9;
 
     public static Gee.MultiMap<string, string> action_accelerators = new Gee.HashMultiMap<string, string> ();
     public static Gee.MultiMap<string, string> typing_accelerators = new Gee.HashMultiMap<string, string> ();
@@ -66,7 +73,10 @@ public class Services.ActionManager : Object {
         { ACTION_VIEW_PINBOARD, action_view_pinboard },
         { ACTION_VIEW_LABELS, action_view_labels },
         { ACTION_VIEW_HOME, action_view_home },
-        { ACTION_SHOW_HIDE_SIDEBAR, action_show_hide_sidebar }
+        { ACTION_SHOW_HIDE_SIDEBAR, action_show_hide_sidebar },
+        { ACTION_VIEW_PROJECT, action_view_project, "i" },
+        { ACTION_NEXT_PROJECT, action_next_project },
+        { ACTION_PREV_PROJECT, action_prev_project }
     };
 
     public ActionManager (Planify app, MainWindow window) {
@@ -89,6 +99,15 @@ public class Services.ActionManager : Object {
         action_accelerators.set (ACTION_VIEW_SCHEDULED, "<Control>u");
         action_accelerators.set (ACTION_VIEW_LABELS, "<Control>l");
         action_accelerators.set (ACTION_VIEW_PINBOARD, "<Control>p");
+        action_accelerators.set (ACTION_NEXT_PROJECT, "<Control>Page_Down");
+        action_accelerators.set (ACTION_PREV_PROJECT, "<Control>Page_Up");
+
+        // Keyed by detailed action name ("action_view_project(1)") rather than a bare action name.
+        // The enable/disable loops below only prepend ACTION_PREFIX, and "win.action_view_project(1)"
+        // is a valid detailed name, so the numbered shortcuts need no special handling there.
+        for (int i = 1; i <= PROJECT_SHORTCUTS; i++) {
+            action_accelerators.set ("%s(%d)".printf (ACTION_VIEW_PROJECT, i), "<Control>%d".printf (i));
+        }
 
         typing_accelerators.set (ACTION_ADD_TASK, "a");
         typing_accelerators.set (ACTION_ADD_TASK_PASTE, "<Control>v");
@@ -239,5 +258,75 @@ public class Services.ActionManager : Object {
 
     private void action_view_home () {
         window.go_homepage ();
+    }
+
+    private void action_view_project (SimpleAction action, Variant ? parameter) {
+        if (parameter == null) {
+            return;
+        }
+
+        var projects = Services.Store.instance ().get_projects_display_order ();
+        if (projects.size <= 0) {
+            return;
+        }
+
+        int position = parameter.get_int32 ();
+
+        // The highest shortcut jumps to the last project, however many there are; the rest are
+        // positional and simply do nothing when there is no project at that position.
+        int index = position >= PROJECT_SHORTCUTS ? projects.size - 1 : position - 1;
+
+        if (index < 0 || index >= projects.size) {
+            return;
+        }
+
+        open_project (projects[index]);
+    }
+
+    private void action_next_project () {
+        move_project_selection (1);
+    }
+
+    private void action_prev_project () {
+        move_project_selection (-1);
+    }
+
+    /**
+     * Moves to the project offset places away from the current one, wrapping at both ends. When the
+     * visible view is not a project, moves to the first or last one depending on the direction.
+     */
+    private void move_project_selection (int offset) {
+        var projects = Services.Store.instance ().get_projects_display_order ();
+        if (projects.size <= 0) {
+            return;
+        }
+
+        Objects.Project ? current = window.get_current_project ();
+        int index = -1;
+
+        if (current != null) {
+            for (int i = 0; i < projects.size; i++) {
+                if (projects[i].id == current.id) {
+                    index = i;
+                    break;
+                }
+            }
+        }
+
+        if (index < 0) {
+            open_project (offset > 0 ? projects[0] : projects[projects.size - 1]);
+            return;
+        }
+
+        int next = (index + offset) % projects.size;
+        if (next < 0) {
+            next += projects.size;
+        }
+
+        open_project (projects[next]);
+    }
+
+    private void open_project (Objects.Project project) {
+        Services.EventBus.get_default ().pane_selected (PaneType.PROJECT, project.id);
     }
 }


### PR DESCRIPTION
### What changed

Projects can now be reached from the keyboard:

- **`Ctrl+1`–`Ctrl+8`** open the project at that position in the sidebar; **`Ctrl+9`** opens the
  last one, whatever the count.
- **`Ctrl+Page Down` / `Ctrl+Page Up`** move to the next and previous project, wrapping at both
  ends. From a non-project view they open the first or last project.

### Why

Six shortcuts already jump to a view (`Ctrl+I` Inbox, `Ctrl+T` Today, `Ctrl+U` Scheduled, `Ctrl+L`
Labels, `Ctrl+P` Pinboard, `Ctrl+H` Home), but there was no way to reach a **project** without the
mouse — the sidebar has no key handling at all. This closes that gap and is the request in #1220.

### How the numbering is defined

#1220 asked whether list numbers would be configurable. This implementation takes the approach the
reporter suggested there — **the sidebar order defines the number** — which needs no configuration,
no new settings and no UI:

- `Store.get_projects_display_order ()` reproduces exactly what the sidebar renders: visible sources
  by `child_order`, then each source's top-level, non-archived projects, honouring the
  Alphabetically sort setting. Numbering therefore always matches what the user sees, and follows
  drag-reordering automatically.
- Subprojects are excluded, since they render nested inside their parent rather than as siblings.
- The list is recomputed on each keypress, so adding, archiving, reordering or hiding a source takes
  effect immediately without a restart.

**The designated inbox is excluded from the numbering.** `Layouts.SidebarSourceRow.add_row_project
()` builds a row for the inbox project like any other, and `Layouts.ProjectRow` then keeps that row
hidden behind its revealer (`main_revealer.reveal_child = !project.is_inbox_project`). Counting the
rows the sidebar *builds* rather than the ones it *shows* therefore puts a position under a list the
user cannot see, and every list after the inbox comes out off by one. `Ctrl+I` already opens the
Inbox, so excluding it makes nothing unreachable. Because `is_inbox_project` is derived from the
`local-inbox-project-id` setting and the list is rebuilt on each keypress, changing which list is
the default is picked up immediately, with no cache to invalidate.

One consequence worth stating: while viewing the Inbox, `Ctrl+Page_Down` opens the first project and
`Ctrl+Page_Up` the last, rather than continuing from the inbox's old position. The inbox sits
outside the cycle in the same way it sits outside the sidebar list.

If you would prefer numbers to be user-assignable, that could be layered on later without changing
these bindings.

### Why these keys

- **`Ctrl`+number** is the jump-to-nth convention in Chrome, Slack, Discord, VS Code and Obsidian,
  and it matches Planify's own `Ctrl`+letter view shortcuts. **`Ctrl+9` = last** follows the same
  convention browsers use.
- **`Ctrl+Page Down`/`Up`** is the GNOME next/previous convention (Terminal, Nautilus, Text Editor).
- `Alt`+number was avoided because the HIG reserves `Alt+←/→/↑` for navigation and discourages `Alt`
  for app shortcuts; `Super` belongs to the shell; `Ctrl+Tab` is GTK focus traversal.

None of these combinations were previously bound anywhere in the app.

### Implementation notes

- The numbered jump is a **single parameterised action** registered by detailed action name
  (`win.action_view_project(1)`), rather than nine near-identical actions. Because the existing
  enable/disable loops in `ActionManager` only prepend `ACTION_PREFIX`, this needed no changes to
  that machinery.
- All new accelerators are `Ctrl` chords and so live in `action_accelerators`, not
  `typing_accelerators` — they are safe while typing.
- Navigation reuses `pane_selected (PaneType.PROJECT, id)`, the same call `ProjectRow` makes on
  click, so the sidebar highlight updates reactively with no extra work.
- Added a small `MainWindow.get_current_project ()` accessor, needed to know where to cycle from.
- The three bindings are added to the shortcuts window (`shortcuts.ui`) so they are discoverable.

### Testing instructions

1. `Ctrl+1`–`Ctrl+8` open the 1st–8th project top to bottom across source groups; `Ctrl+9` opens the
   last. Numbers with no project do nothing.
2. `Ctrl+Page Down`/`Up` cycle both ways and wrap; from Today or Labels they jump to the first or
   last project.
3. The Inbox is skipped: with an inbox present, `Ctrl+1` opens the first list shown in the sidebar
   and cycling never lands on the Inbox. `Ctrl+I` still opens it. Designating a different list as
   the default in Preferences moves the exclusion to that list immediately.
4. Switch Preferences to sort projects Alphabetically — the numbering follows the re-ordered sidebar.
5. Reorder by drag, add, archive a project, or hide a source — numbering updates without restart.
6. Digits typed in a task title or Quick Add do not trigger navigation.
7. `F1` lists the new shortcuts; the existing 15 still work.

Tested on Fedora Asahi (aarch64) with a Nextcloud CalDAV account.

Per `AI_POLICY.md`: this was developed with AI assistance. However, I have run and debugged the
result myself.

