### PR TITLE
fix(caldav): route sectioned tasks to their section on sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ planify*txt
 .flatpak
 .buildconfig
 .DS_Store
+.kiro

--- a/.kiro/settings/cli.json
+++ b/.kiro/settings/cli.json
@@ -1,0 +1,5 @@
+{
+  "toolSearch.enabled": true,
+  "toolSearch.minPct": 5,
+  "toolSearch.minTokens": 50000
+}

--- a/core/Services/CalDAV/CalDAVClient.vala
+++ b/core/Services/CalDAV/CalDAVClient.vala
@@ -589,6 +589,8 @@ public class Services.CalDAV.CalDAVClient : Services.CalDAV.WebDAVClient {
                                 } else {
                                     project.add_item_if_not_exists (new_item);
                                 }
+                            } else if (new_item.section_id != "" && new_item.section != null) {
+                                new_item.section.add_item_if_not_exists (new_item);
                             } else {
                                 project.add_item_if_not_exists (new_item);
                             }

--- a/src/Layouts/SectionRow.vala
+++ b/src/Layouts/SectionRow.vala
@@ -570,6 +570,10 @@ public class Layouts.SectionRow : Gtk.ListBoxRow {
     }
 
     public void add_item (Objects.Item item) {
+        if (item.section_id != section.id) {
+            return;
+        }
+
         if (item.checked) {
             return;
         }


### PR DESCRIPTION
A new VTODO with a section but no parent fell into the project branch of upsert_vtodo_content, so the ungrouped SectionRow rendered a phantom duplicate alongside the correct section row. Add the section dispatch
(mirroring Util.insert_duplicate_item) and guard SectionRow.add_item against mismatched section_id.

Fixes #2657