### PR TITLE
fix: update All Tasks when an edit changes whether an item matches the filters

### DIFF
--- a/src/Views/Filter.vala
+++ b/src/Views/Filter.vala
@@ -615,7 +615,10 @@ public class Views.Filter : Adw.Bin {
         } else if (filter is Objects.Filters.Unlabeled) {
             should_add = item.labels.size <= 0;
         } else if (filter is Objects.Filters.AllItems) {
-            should_add = true;
+            // Unchecked only, matching what add_items () loads. A newly added item is never
+            // checked, but this path is also reached from valid_update_item (), where the item may
+            // be a completed one whose content changed.
+            should_add = !item.checked;
         }
 
         if (should_add && item_matches_filters (item)) {
@@ -703,6 +706,20 @@ public class Views.Filter : Adw.Bin {
             if (items.has_key (item.id) && item.labels.size > 0) {
                 items[item.id].hide_destroy ();
                 items.unset (item.id);
+                Services.EventBus.get_default ().unfocus_item ();
+            }
+
+            valid_add_item (item);
+        } else if (filter is Objects.Filters.AllItems) {
+            // Membership of this view is conditional now that it carries filters, so an edit can
+            // move an item into or out of the list: an item added before it matched arrives here
+            // still absent, and one that no longer matches has to go. The view is kept alive in
+            // MainWindow's stack between visits, so this signal is the only thing that reaches it.
+            if (items.has_key (item.id) && !item_matches_filters (item)) {
+                items[item.id].hide_destroy ();
+                items.unset (item.id);
+                items_list.remove (item);
+                update_load_more_button_label ();
                 Services.EventBus.get_default ().unfocus_item ();
             }
 


### PR DESCRIPTION
### What changed

`Views.Filter.valid_update_item ()` gains the `Objects.Filters.AllItems` branch it was missing,
following the shape the sibling filters already use: drop the row if the item no longer matches the
active filters, then offer it to `valid_add_item ()`, which re-checks them itself. The item is
dropped from `items_list` as well, so the *Load more* count stays right — the same thing
`valid_delete_item ()` does.

The All Tasks add condition also becomes `should_add = !item.checked` instead of an unconditional
`true`, matching what `add_items ()` loads.

### Why

A regression from #2654, which gave the All Tasks view its own filters. Before that the view showed
every item, so nothing an edit could change affected an item's membership of it, and the missing
branch was dormant — completion and deletion have their own handlers. Filters made membership
conditional, and there was no path into or out of the list for an item whose priority, labels or due
date changed after it was added.

Concretely: with the P1 filter on, create a task in any project and only then raise it to P1. The
`item_added` signal arrives while the task is still the default priority and is correctly declined;
the `item_updated` that follows is dropped on the floor. The task stays invisible until the app is
restarted and the view is rebuilt from the database — the view is kept alive in `MainWindow`'s stack
between visits, so switching away and back does not rebuild it. The same in reverse: a visible P1
task edited down to P3 keeps its row.

The `!item.checked` part is needed by the first part rather than being an independent fix: routing
updates through `valid_add_item ()` newly exposes it to completed items, because
`Services.Store.complete_item ()` emits `item_updated` before `checked_toggled`. Without it,
editing a completed task would insert it into All Tasks.

### Testing instructions

1. In All Tasks, filter by **P1**. In any project, create a task, then raise it to P1 — it appears
   in All Tasks immediately, with no restart.
2. Reverse: with the P1 filter still on, edit a visible P1 task down to P3 — its row disappears.
3. Repeat both with a **label** filter and a **due date** filter; all three go through the same
   predicate.
4. The *Load more* count still counts only matching tasks across those edits.
5. Complete a task in All Tasks — it leaves the list, and editing an already-completed task does not
   pull it back in.
6. Regression: with no filter active, editing a task neither hides nor duplicates it; and the
   Completed, Pinboard, Priority, Tomorrow, Anytime, Repeating and Unlabeled views, which share
   `Views.Filter`, are unchanged.

Manually tested on Fedora Asahi (aarch64) against a live Nextcloud CalDAV account, using a release
build of `main` plus this fix. No unit test: `Views.Filter` needs GTK, a populated store and a
settings backend, where the `test/core/` suite added in #2654 covers pure functions.

Per `AI_POLICY.md`: this was developed with AI assistance. However, I have run and debugged the
result myself.
