### PR TITLE
fix: no duplicate project header after a task is moved to another project

### DIFF
--- a/src/Views/Filter.vala
+++ b/src/Views/Filter.vala
@@ -774,7 +774,12 @@ public class Views.Filter : Adw.Bin {
         var row = (Layouts.ItemRow) lbrow;
         if (lbbefore != null && lbbefore is Layouts.ItemRow) {
             var before = (Layouts.ItemRow) lbbefore;
-            if (row.project_id == before.project_id) {
+            // Group on the item's own project, not Layouts.ItemRow's cached project_id: that copy
+            // is taken in construct and never refreshed, so after a task is moved to another
+            // project the row still carries the old id and is read as the start of a new group —
+            // a second header for a project that already has one. The header text below already
+            // comes from the live item, which is why the duplicate is labelled identically.
+            if (row.item.project_id == before.item.project_id) {
                 row.set_header (null);
                 return;
             }


### PR DESCRIPTION
### What changed

`Views.Filter.header_project_function ()` now decides where a project group starts by comparing the
items' own `project_id`, rather than `Layouts.ItemRow`'s cached `project_id` property.

### Why

`Layouts.ItemRow` copies `project_id`, `section_id` and `parent_id` from its item in `construct` and
never refreshes them — `update_request ()` does not touch them. So after a task is moved to another
project, its row still carries the old project id.

The header function compared those cached ids to find group boundaries, but built the header *text*
from the live item. A moved row therefore read as the start of a new group and got a header of its
own, labelled with the name of the project it had just moved *into* — so the view showed two
identical headers, the second containing only the moved task, until it was rebuilt from the
database.

The row property is deliberately left as it is. It is not dead: the drag-and-drop handlers use it as
the position the row was built for and compare it against the live value to detect a move
(`ItemRow.vala`, in the drop handlers), so refreshing it would change behaviour well outside this
bug.

### Testing instructions

1. In All Tasks, sort by **Project** so the group headers appear.
2. Open a project, drag a task onto a different list in the sidebar to move it.
3. Go back to All Tasks: the moved task sits under the existing header for its new project, and
   there is no second header with the same name. Before this change, it appeared under a duplicate.
4. Regression: the headers are still correct on first load, after adding and deleting tasks, and
   after switching sort order and direction; a project whose name matches another still gets its own
   header, since the comparison is on ids.

Manually tested on Fedora Asahi (aarch64) against a live Nextcloud CalDAV account, using a release
build of `main` plus this fix.

Per `AI_POLICY.md`: this was developed with AI assistance. However, I have run and debugged the
result myself.
