### PR TITLE
fix: allow deleting a CalDAV section whose VTODO is already gone from the server

### DIFF
--- a/core/Services/CalDAV/CalDAVClient.vala
+++ b/core/Services/CalDAV/CalDAVClient.vala
@@ -821,8 +821,11 @@ public class Services.CalDAV.CalDAVClient : Services.CalDAV.WebDAVClient {
         HttpResponse response = new HttpResponse ();
 
         try {
+            // NOT_FOUND counts as success, as for sections and items: a calendar already removed
+            // on the server would otherwise leave a project that cannot be deleted here.
             yield send_request ("DELETE", project.calendar_url, "text/calendar", null, null, null,
-                                { Soup.Status.NO_CONTENT, Soup.Status.MULTI_STATUS, Soup.Status.OK });
+                                { Soup.Status.NO_CONTENT, Soup.Status.MULTI_STATUS, Soup.Status.OK,
+                                  Soup.Status.NOT_FOUND });
             response.status = true;
         } catch (Error e) {
             if ("HTTP 403" in e.message) {
@@ -979,7 +982,10 @@ public class Services.CalDAV.CalDAVClient : Services.CalDAV.WebDAVClient {
         HttpResponse response = new HttpResponse ();
 
         try {
-            yield send_request ("DELETE", item.ical_url, "", null, null, null, { Soup.Status.NO_CONTENT, Soup.Status.OK });
+            // NOT_FOUND counts as success, as for sections: an item already deleted elsewhere would
+            // otherwise be undeletable here.
+            yield send_request ("DELETE", item.ical_url, "", null, null, null,
+                                { Soup.Status.NO_CONTENT, Soup.Status.OK, Soup.Status.NOT_FOUND });
 
             response.status = true;
         } catch (Error e) {
@@ -1024,7 +1030,12 @@ public class Services.CalDAV.CalDAVClient : Services.CalDAV.WebDAVClient {
         HttpResponse response = new HttpResponse ();
 
         try {
-            yield send_request ("DELETE", section.ical_url, "", null, null, null, { Soup.Status.NO_CONTENT, Soup.Status.OK });
+            // NOT_FOUND counts as success: the section's VTODO may already have been deleted from
+            // another client, and treating that as a failure leaves a section that can never be
+            // removed here — the delete is refused every time because the server has nothing left
+            // to delete.
+            yield send_request ("DELETE", section.ical_url, "", null, null, null,
+                                { Soup.Status.NO_CONTENT, Soup.Status.OK, Soup.Status.NOT_FOUND });
             response.status = true;
         } catch (Error e) {
             Services.LogService.get_default ().error ("CalDAV", "Failed to delete section: %s".printf (e.message));


### PR DESCRIPTION
### What changed

`Services.CalDAV.CalDAVClient.delete_section ()` now treats `404 Not Found` as success, alongside
the `204` and `200` it already accepted. `delete_item ()` and `delete_project ()` get the same
treatment.

### Why

A section is stored on a CalDAV server as its own VTODO. If that VTODO is deleted from somewhere
else — a phone app, or the server's web interface — the section cannot be deleted in Planify at all.
`Objects.Section.delete_section ()` only calls `Services.Store.delete_section ()` when the CalDAV
response reports success, so a 404 produces an error toast and the section stays in the sidebar. Every
retry fails identically, because there is nothing left on the server to delete.

Reproduced against Nextcloud, from the log:

```
[CalDAV] Deleting section
[WebDAV] DELETE .../<section-uuid>.ics failed: HTTP 404 Not Found
[CalDAV] Failed to delete section: ... HTTP 404 Not Found
```

DELETE is idempotent — a 404 means the resource is already in the state the caller asked for, so the
local copy should go too. Items and projects strand in exactly the same way when they are removed on
the server first, so they are covered as well.

Only `404` is added. Everything else still fails as before: network errors, authentication failures,
and the `403`/`405` a server returns when it refuses calendar deletion, which `delete_project ()`
already turns into its own explanatory messages. A delete that genuinely did not happen is still
reported.

### Testing instructions

1. In a CalDAV (e.g. Nextcloud) list, create a section in Planify.
2. Delete that section's VTODO from another client — a phone app, or the server's web UI — leaving
   Planify's copy behind.
3. Delete the section in Planify. It is removed, rather than raising `HTTP 404 Not Found` and
   staying in the list.
4. Same for a task deleted on the server first, and for a whole list.
5. Regression: deleting a section, task or list that *does* still exist on the server behaves as
   before, and a delete attempted with the server unreachable still reports an error and keeps the
   local copy.

Manually tested on Fedora Asahi (aarch64) against a live Nextcloud CalDAV account, using a release
build of `main` plus this fix.

Per `AI_POLICY.md`: this was developed with AI assistance. However, I have run and debugged the
result myself.
