### PR TITLE
Add "Repeat from completion date" option for recurring tasks

### DIFF
--- a/core/Objects/DueDate.vala
+++ b/core/Objects/DueDate.vala
@@ -30,6 +30,7 @@ public class Objects.DueDate : GLib.Object {
     public int recurrency_count { get; set; default = 0; }
     public string recurrency_end { get; set; default = ""; }
     public bool recurrency_last_day_of_month { get; set; default = false; }
+    public bool recurrency_from_completion { get; set; default = false; }
     public bool recurrence_supported { get; set; default = false; }
 
     GLib.DateTime ? _datetime = null;
@@ -159,6 +160,10 @@ public class Objects.DueDate : GLib.Object {
         if (object.has_member ("recurrency_last_day_of_month")) {
             recurrency_last_day_of_month = bool.parse (object.get_string_member ("recurrency_last_day_of_month"));
         }
+
+        if (object.has_member ("recurrency_from_completion")) {
+            recurrency_from_completion = bool.parse (object.get_string_member ("recurrency_from_completion"));
+        }
     }
 
     public void reset () {
@@ -204,6 +209,9 @@ public class Objects.DueDate : GLib.Object {
         builder.set_member_name ("recurrency_last_day_of_month");
         builder.add_string_value (recurrency_last_day_of_month.to_string ());
 
+        builder.set_member_name ("recurrency_from_completion");
+        builder.add_string_value (recurrency_from_completion.to_string ());
+
         builder.end_object ();
 
         Json.Generator generator = new Json.Generator ();
@@ -220,6 +228,7 @@ public class Objects.DueDate : GLib.Object {
                 recurrency_count == duedate.recurrency_count &&
                 recurrency_end == duedate.recurrency_end &&
                 recurrency_last_day_of_month == duedate.recurrency_last_day_of_month &&
+                recurrency_from_completion == duedate.recurrency_from_completion &&
                 is_recurring == duedate.is_recurring);
     }
 
@@ -240,6 +249,7 @@ public class Objects.DueDate : GLib.Object {
         new_due.recurrency_end = recurrency_end;
         new_due.recurrence_supported = recurrence_supported;
         new_due.recurrency_last_day_of_month = recurrency_last_day_of_month;
+        new_due.recurrency_from_completion = recurrency_from_completion;
         return new_due;
     }
 }

--- a/core/Objects/Item.vala
+++ b/core/Objects/Item.vala
@@ -1816,13 +1816,6 @@ public class Objects.Item : Objects.BaseObject {
     public async GLib.DateTime? update_next_recurrency () {
         GLib.DateTime base_datetime = due.datetime;
 
-        print ("\n[REPEAT-DEBUG] ===== update_next_recurrency =====\n");
-        print ("[REPEAT-DEBUG] item content: %s\n", content);
-        print ("[REPEAT-DEBUG] recurrency_from_completion = %s\n", due.recurrency_from_completion.to_string ());
-        print ("[REPEAT-DEBUG] recurrency_type = %d, interval = %d\n", (int) due.recurrency_type, due.recurrency_interval);
-        print ("[REPEAT-DEBUG] current due.datetime = %s\n", due.datetime != null ? due.datetime.format ("%Y-%m-%d %H:%M:%S") : "null");
-        print ("[REPEAT-DEBUG] now_local = %s\n", new GLib.DateTime.now_local ().format ("%Y-%m-%d %H:%M:%S"));
-
         if (due.recurrency_from_completion) {
             // Repeat from the completion date: anchor the next occurrence to today,
             // keeping the original due time-of-day so a task due at 09:00 stays at 09:00.
@@ -1837,13 +1830,8 @@ public class Objects.Item : Objects.BaseObject {
             );
         }
 
-        print ("[REPEAT-DEBUG] base_datetime (used for calc) = %s\n", base_datetime != null ? base_datetime.format ("%Y-%m-%d %H:%M:%S") : "null");
-
         var next_recurrency = Utils.Datetime.next_recurrency (base_datetime, due);
         due.date = Utils.Datetime.get_todoist_datetime_format (next_recurrency);
-
-        print ("[REPEAT-DEBUG] => next_recurrency = %s\n", next_recurrency != null ? next_recurrency.format ("%Y-%m-%d %H:%M:%S") : "null");
-        print ("[REPEAT-DEBUG] ===================================\n\n");
 
         if (due.end_type == RecurrencyEndType.AFTER) {
             due.recurrency_count = due.recurrency_count - 1;
@@ -1861,7 +1849,6 @@ public class Objects.Item : Objects.BaseObject {
 
         if (project.source_type == SourceType.LOCAL) {
             Services.Store.instance ().update_item (this);
-            print ("[REPEAT-DEBUG] LOCAL persisted. due.datetime now = %s\n", due.datetime != null ? due.datetime.format ("%Y-%m-%d %H:%M:%S") : "null");
         } else if (project.source_type == SourceType.TODOIST) {
             loading = true;
             var response = yield Services.Todoist.get_default ().close_item (this);

--- a/core/Objects/Item.vala
+++ b/core/Objects/Item.vala
@@ -1814,8 +1814,36 @@ public class Objects.Item : Objects.BaseObject {
     }
 
     public async GLib.DateTime? update_next_recurrency () {
-        var next_recurrency = Utils.Datetime.next_recurrency (due.datetime, due);
+        GLib.DateTime base_datetime = due.datetime;
+
+        print ("\n[REPEAT-DEBUG] ===== update_next_recurrency =====\n");
+        print ("[REPEAT-DEBUG] item content: %s\n", content);
+        print ("[REPEAT-DEBUG] recurrency_from_completion = %s\n", due.recurrency_from_completion.to_string ());
+        print ("[REPEAT-DEBUG] recurrency_type = %d, interval = %d\n", (int) due.recurrency_type, due.recurrency_interval);
+        print ("[REPEAT-DEBUG] current due.datetime = %s\n", due.datetime != null ? due.datetime.format ("%Y-%m-%d %H:%M:%S") : "null");
+        print ("[REPEAT-DEBUG] now_local = %s\n", new GLib.DateTime.now_local ().format ("%Y-%m-%d %H:%M:%S"));
+
+        if (due.recurrency_from_completion) {
+            // Repeat from the completion date: anchor the next occurrence to today,
+            // keeping the original due time-of-day so a task due at 09:00 stays at 09:00.
+            var now = new GLib.DateTime.now_local ();
+            base_datetime = new GLib.DateTime.local (
+                now.get_year (),
+                now.get_month (),
+                now.get_day_of_month (),
+                due.datetime.get_hour (),
+                due.datetime.get_minute (),
+                due.datetime.get_second ()
+            );
+        }
+
+        print ("[REPEAT-DEBUG] base_datetime (used for calc) = %s\n", base_datetime != null ? base_datetime.format ("%Y-%m-%d %H:%M:%S") : "null");
+
+        var next_recurrency = Utils.Datetime.next_recurrency (base_datetime, due);
         due.date = Utils.Datetime.get_todoist_datetime_format (next_recurrency);
+
+        print ("[REPEAT-DEBUG] => next_recurrency = %s\n", next_recurrency != null ? next_recurrency.format ("%Y-%m-%d %H:%M:%S") : "null");
+        print ("[REPEAT-DEBUG] ===================================\n\n");
 
         if (due.end_type == RecurrencyEndType.AFTER) {
             due.recurrency_count = due.recurrency_count - 1;
@@ -1833,6 +1861,7 @@ public class Objects.Item : Objects.BaseObject {
 
         if (project.source_type == SourceType.LOCAL) {
             Services.Store.instance ().update_item (this);
+            print ("[REPEAT-DEBUG] LOCAL persisted. due.datetime now = %s\n", due.datetime != null ? due.datetime.format ("%Y-%m-%d %H:%M:%S") : "null");
         } else if (project.source_type == SourceType.TODOIST) {
             loading = true;
             var response = yield Services.Todoist.get_default ().close_item (this);

--- a/core/Widgets/DateTimePicker/DateTimePicker.vala
+++ b/core/Widgets/DateTimePicker/DateTimePicker.vala
@@ -517,6 +517,7 @@ public class Widgets.DateTimePicker.DateTimePicker : Gtk.Popover {
         _duedate.recurrency_count = value.recurrency_count;
         _duedate.recurrency_end = value.recurrency_end;
         _duedate.recurrency_last_day_of_month = value.recurrency_last_day_of_month;
+        _duedate.recurrency_from_completion = value.recurrency_from_completion;
 
         visible_no_date = true;
     }

--- a/core/Widgets/DateTimePicker/RepeatConfig.vala
+++ b/core/Widgets/DateTimePicker/RepeatConfig.vala
@@ -27,6 +27,7 @@ public class Widgets.DateTimePicker.RepeatConfig : Adw.NavigationPage {
     private Gtk.Revealer weeks_revealer;
     private Gtk.Revealer last_day_revealer;
     private Gtk.CheckButton last_day_check;
+    private Gtk.CheckButton from_completion_check;
     private Widgets.ContextMenu.MenuItem[] type_menu_items;
     private Adw.Bin dimming_widget;
     private Gtk.Label repeat_label;
@@ -80,6 +81,8 @@ public class Widgets.DateTimePicker.RepeatConfig : Adw.NavigationPage {
 
             last_day_check.active = value.recurrency_last_day_of_month;
             last_day_revealer.reveal_child = value.recurrency_type == RecurrencyType.EVERY_MONTH;
+
+            from_completion_check.active = value.recurrency_from_completion;
 
             if (value.recurrency_end != "") {
                 on_button.active = true;
@@ -282,6 +285,11 @@ public class Widgets.DateTimePicker.RepeatConfig : Adw.NavigationPage {
             margin_top = 6
         };
 
+        from_completion_check = new Gtk.CheckButton.with_label (_("Repeat from completion date")) {
+            margin_top = 6,
+            tooltip_text = _("Calculate the next occurrence from the day you complete the task instead of its due date")
+        };
+
         last_day_revealer = new Gtk.Revealer () {
             transition_type = Gtk.RevealerTransitionType.SLIDE_DOWN,
             reveal_child = false,
@@ -396,6 +404,7 @@ public class Widgets.DateTimePicker.RepeatConfig : Adw.NavigationPage {
         content_box.append (repeat_box);
         content_box.append (weeks_revealer);
         content_box.append (last_day_revealer);
+        content_box.append (from_completion_check);
         content_box.append (new Gtk.Label (_("End")) {
             css_classes = { "heading", "h4" },
             margin_top = 12,
@@ -521,6 +530,8 @@ public class Widgets.DateTimePicker.RepeatConfig : Adw.NavigationPage {
 
         duedate.recurrency_last_day_of_month = (duedate.recurrency_type == RecurrencyType.EVERY_MONTH)
             && last_day_check.active;
+
+        duedate.recurrency_from_completion = from_completion_check.active;
 
         duedate_change (duedate);
     }

--- a/data/resources/stylesheet/animations.css
+++ b/data/resources/stylesheet/animations.css
@@ -169,7 +169,8 @@
 
 @keyframes date-updated-flash {
     0%   { color: inherit; }
-    30%  { color: @accent_color; }
+    15%  { color: @accent_color; font-weight: 700; }
+    40%  { color: @accent_color; font-weight: 700; }
     100% { color: inherit; }
 }
 

--- a/src/Layouts/ItemRow.vala
+++ b/src/Layouts/ItemRow.vala
@@ -1617,15 +1617,20 @@ public class Layouts.ItemRow : Layouts.ItemBase {
         content_label.remove_css_class ("line-through");
         check_due ();
 
-        due_label.add_css_class ("date-updated");
+        // Re-trigger the flash even if the class is still present from a rapid previous completion.
+        due_label.remove_css_class ("date-updated");
+        Timeout.add (10, () => {
+            due_label.add_css_class ("date-updated");
+            return GLib.Source.REMOVE;
+        });
         Timeout.add (1200, () => {
             due_label.remove_css_class ("date-updated");
             return GLib.Source.REMOVE;
         });
 
-        var title = _("Completed. Next occurrence: %s".printf (
-                           Utils.Datetime.get_default_date_format_from_date (next_recurrency)
-        ));
+        var title = _("Task completed · Next: %s").printf (
+            Utils.Datetime.get_relative_date_from_date (next_recurrency)
+        );
         var toast = Util.get_default ().create_toast (title, 3);
         Services.EventBus.get_default ().send_toast (toast);
     }

--- a/test/test-caldav-integration.vala
+++ b/test/test-caldav-integration.vala
@@ -1,5 +1,29 @@
-using GLib;
+/*
+ * Copyright © 2026 Alain M. (https://github.com/alainm23/planify)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA
+ */
 
+/**
+ * CLI Test Runner
+ * 
+ * Main test runner that orchestrates all CLI component tests.
+ * Each component has its own test file in test/cli/ directory.
+ */
+ 
 async void test_caldav_login_async () throws GLib.Error {
     string? server_url = Environment.get_variable ("CALDAV_URL");
     string? username = Environment.get_variable ("CALDAV_USER");


### PR DESCRIPTION
Recurring tasks can now repeat relative to the day they are completed instead of their due date. When enabled, completing an overdue daily task schedules the next occurrence from today rather than advancing one interval from the old (still-overdue) due date, matching how apps like Tasks.org behave.

The option lives in the repeat editor as a per-task checkbox under "Repeat every", so fixed-date recurrences (rent, weekly meetings) keep their current behaviour by default. The completion toast now shows the next occurrence as a relative date, and the due label flashes when it advances so the change is noticeable.

This covers local and Todoist tasks. CalDAV/Tasks.org round-trip of the flag is intentionally left out of this change.

Fixes: #1902

<img width="634" height="892" alt="image" src="https://github.com/user-attachments/assets/eb1854cf-b996-4ae6-afde-8f39926a0349" />
