### PR TITLE
Fix recurrence lost on reschedule and missing "No Date" button on scheduled items

### DIFF
--- a/core/Widgets/DateTimePicker/DateTimePicker.vala
+++ b/core/Widgets/DateTimePicker/DateTimePicker.vala
@@ -66,6 +66,7 @@ public class Widgets.DateTimePicker.DateTimePicker : Gtk.Popover {
             if (_duedate != null && _duedate.datetime != null) {
                 calendar_view.date = _duedate.datetime;
                 calendar_scroll_view.date = _duedate.datetime;
+                visible_no_date = true;
             }
 
             if (_duedate != null && time_picker != null && _duedate.datetime != null && Utils.Datetime.has_time (_duedate.datetime)) {
@@ -403,7 +404,7 @@ public class Widgets.DateTimePicker.DateTimePicker : Gtk.Popover {
         connect_suggested_date (next_week_item);
 
         no_date_button = new NoDateButton () {
-            visible = false
+            visible = _duedate != null && _duedate.datetime != null
         };
         box.append (no_date_button);
         no_date_button.clicked.connect (() => {
@@ -885,12 +886,16 @@ public class Widgets.DateTimePicker.DateTimePicker : Gtk.Popover {
                 ellipsize = END
             };
 
-            var date_box = new Gtk.Box (HORIZONTAL, 6);
+            var date_box = new Gtk.Box (HORIZONTAL, 6) {
+                margin_start = 6,
+                margin_end = 6
+            };
             date_box.append (date_icon);
             date_box.append (date_label);
 
             var button = new Gtk.Button () {
-                child = date_box
+                child = date_box,
+                css_classes = { "suggestion-chip" }
             };
 
             button.clicked.connect (() => clicked ());

--- a/core/Widgets/DeadlineButton.vala
+++ b/core/Widgets/DeadlineButton.vala
@@ -240,7 +240,8 @@ public class Widgets.DeadlineButton : Adw.Bin {
         suggested_box.append (in_a_month_item);
 
         var delete_button = new Gtk.Button.with_label (_("Delete")) {
-            margin_top = 12
+            margin_top = 12,
+            margin_bottom = 12,
         };
         delete_button.add_css_class ("destructive-action");
 
@@ -251,9 +252,9 @@ public class Widgets.DeadlineButton : Adw.Bin {
         };
 
         var content_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 0) {
-            margin_start = 9,
-            margin_end = 9,
-            margin_top = 9
+            margin_start = 12,
+            margin_end = 12,
+            margin_top = 12
         };
         content_box.append (suggested_box);
         content_box.append (new Widgets.ContextMenu.MenuSeparator ());
@@ -269,6 +270,7 @@ public class Widgets.DeadlineButton : Adw.Bin {
                 max_content_height = 425,
                 child = content_box
             },
+            css_classes = { "popover-contents" },
             position = Gtk.PositionType.BOTTOM
         };
 

--- a/src/Views/Scheduled/ScheduledOverdue.vala
+++ b/src/Views/Scheduled/ScheduledOverdue.vala
@@ -123,7 +123,10 @@ public class Views.Scheduled.ScheduledOverdue : Views.Scheduled.ScheduledSection
 
         signal_map[reschedule_button.duedate_changed.connect (() => {
             foreach (unowned Gtk.Widget child in Util.get_default ().get_children (listbox)) {
-                ((Layouts.ItemRow) child).update_due (reschedule_button.duedate);
+                var item = ((Layouts.ItemRow) child).item;
+                var new_due = item.due.duplicate ();
+                new_due.datetime = reschedule_button.duedate.datetime;
+                ((Layouts.ItemRow) child).update_due (new_due);
             }
         })] = reschedule_button;
 

--- a/src/Views/Today.vala
+++ b/src/Views/Today.vala
@@ -541,7 +541,10 @@ public class Views.Today : Adw.Bin {
 
         signal_map[reschedule_button.duedate_changed.connect (() => {
             foreach (unowned Gtk.Widget child in Util.get_default ().get_children (overdue_listbox)) {
-                ((Layouts.ItemRow) child).update_due (reschedule_button.duedate);
+                var item = ((Layouts.ItemRow) child).item;
+                var new_due = item.due.duplicate ();
+                new_due.datetime = reschedule_button.duedate.datetime;
+                ((Layouts.ItemRow) child).update_due (new_due);
             }
         })] = reschedule_button;
 


### PR DESCRIPTION
Fixes two date-picker bugs.

Rescheduling an overdue item wiped its repeat interval, because the shared Reschedule button applied an empty due date to every item, overwriting their recurrence. It now duplicates each item's own due date and only changes the
day, so the repeat is preserved. (#2662)

The "No Date" button also never showed when opening the picker on an item that already had a date, leaving no way to clear it — the button was built before the due date was applied, so its visibility was set too early and lost. It now initializes its visibility from the current due state. (#2601)