### PR TITLE
Detect and import CalDAV accounts from GNOME Online Accounts

### DIFF
--- a/.github/workflows/caldav-test.yml
+++ b/.github/workflows/caldav-test.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install dependencies
         run: |
           apt-get update
-          apt-get install -y sudo pipx git apache2-utils valac meson ninja-build gettext desktop-file-utils libgtk-4-dev libadwaita-1-dev libgee-0.8-dev libgranite-7-dev libjson-glib-dev libecal2.0-dev libsoup-3.0-dev libwebkitgtk-6.0-dev libgtksourceview-5-dev libportal-dev libportal-gtk4-dev libspelling-1-dev dbus-x11 evolution-data-server
+          apt-get install -y sudo pipx git apache2-utils valac meson ninja-build gettext desktop-file-utils libgtk-4-dev libadwaita-1-dev libgee-0.8-dev libgranite-7-dev libjson-glib-dev libecal2.0-dev libsoup-3.0-dev libwebkitgtk-6.0-dev libgtksourceview-5-dev libportal-dev libportal-gtk4-dev libspelling-1-dev libgoa-1.0-dev dbus-x11 evolution-data-server
 
       - name: Install Radicale with pipx
         run: |

--- a/build-aux/io.github.alainm23.planify.Devel.json
+++ b/build-aux/io.github.alainm23.planify.Devel.json
@@ -163,6 +163,62 @@
             ]
         },
         {
+            "name" : "librest",
+            "buildsystem" : "meson",
+            "config-opts" : [
+                "-Dexamples=false",
+                "-Dtests=false",
+                "-Dgtk_doc=false",
+                "-Dintrospection=false",
+                "-Dvapi=false"
+            ],
+            "sources" : [
+                {
+                    "type" : "archive",
+                    "url" : "https://download.gnome.org/sources/librest/0.10/librest-0.10.2.tar.xz",
+                    "sha256" : "7b6cb912bb3a22cfa7dcf005925dcb62883024db0c09099486e7d6851185c9b8",
+                    "x-checker-data" : {
+                        "type" : "gnome",
+                        "name" : "librest"
+                    }
+                }
+            ]
+        },
+        {
+            "name" : "gnome-online-accounts",
+            "buildsystem" : "meson",
+            "config-opts" : [
+                "-Dgoabackend=true",
+                "-Downcloud=true",
+                "-Dwebdav=true",
+                "-Dexchange=false",
+                "-Dgoogle=false",
+                "-Dimap_smtp=false",
+                "-Dkerberos=false",
+                "-Dms_graph=false",
+                "-Ddocumentation=false",
+                "-Dman=false",
+                "-Dvapi=true",
+                "-Dintrospection=true"
+            ],
+            "cleanup" : [
+                "/bin",
+                "/share/dbus-1",
+                "/share/GConf"
+            ],
+            "sources" : [
+                {
+                    "type" : "archive",
+                    "url" : "https://download.gnome.org/sources/gnome-online-accounts/3.58/gnome-online-accounts-3.58.1.tar.xz",
+                    "sha256" : "9ec1900cc51409c2067c07c828c10be06fe3bf68d2999bb72d7d5ed325ed9bbc",
+                    "x-checker-data" : {
+                        "type" : "gnome",
+                        "name" : "gnome-online-accounts"
+                    }
+                }
+            ]
+        },
+        {
             "name" : "planify",
             "builddir" : true,
             "buildsystem" : "meson",

--- a/build-aux/io.github.alainm23.planify.Devel.json
+++ b/build-aux/io.github.alainm23.planify.Devel.json
@@ -15,6 +15,7 @@
         "--socket=wayland",
         "--talk-name=org.gnome.evolution.dataserver.Calendar8",
         "--talk-name=org.gnome.evolution.dataserver.Sources5",
+        "--talk-name=org.gnome.OnlineAccounts",
         "--talk-name=org.gnome.ScreenSaver",
         "--talk-name=io.github.alainm23.planify",
         "--talk-name=io.github.alainm23.planify.quick-add",

--- a/build-aux/no-evolution.json
+++ b/build-aux/no-evolution.json
@@ -15,6 +15,7 @@
         "--socket=wayland",
         "--talk-name=org.gnome.evolution.dataserver.Calendar8",
         "--talk-name=org.gnome.evolution.dataserver.Sources5",
+        "--talk-name=org.gnome.OnlineAccounts",
         "--talk-name=org.gnome.ScreenSaver",
         "--talk-name=io.github.alainm23.planify",
         "--talk-name=io.github.alainm23.planify.quick-add",

--- a/build-aux/no-evolution.json
+++ b/build-aux/no-evolution.json
@@ -120,6 +120,62 @@
             ]
         },
         {
+            "name" : "librest",
+            "buildsystem" : "meson",
+            "config-opts" : [
+                "-Dexamples=false",
+                "-Dtests=false",
+                "-Dgtk_doc=false",
+                "-Dintrospection=false",
+                "-Dvapi=false"
+            ],
+            "sources" : [
+                {
+                    "type" : "archive",
+                    "url" : "https://download.gnome.org/sources/librest/0.10/librest-0.10.2.tar.xz",
+                    "sha256" : "7b6cb912bb3a22cfa7dcf005925dcb62883024db0c09099486e7d6851185c9b8",
+                    "x-checker-data" : {
+                        "type" : "gnome",
+                        "name" : "librest"
+                    }
+                }
+            ]
+        },
+        {
+            "name" : "gnome-online-accounts",
+            "buildsystem" : "meson",
+            "config-opts" : [
+                "-Dgoabackend=true",
+                "-Downcloud=true",
+                "-Dwebdav=true",
+                "-Dexchange=false",
+                "-Dgoogle=false",
+                "-Dimap_smtp=false",
+                "-Dkerberos=false",
+                "-Dms_graph=false",
+                "-Ddocumentation=false",
+                "-Dman=false",
+                "-Dvapi=true",
+                "-Dintrospection=true"
+            ],
+            "cleanup" : [
+                "/bin",
+                "/share/dbus-1",
+                "/share/GConf"
+            ],
+            "sources" : [
+                {
+                    "type" : "archive",
+                    "url" : "https://download.gnome.org/sources/gnome-online-accounts/3.58/gnome-online-accounts-3.58.1.tar.xz",
+                    "sha256" : "9ec1900cc51409c2067c07c828c10be06fe3bf68d2999bb72d7d5ed325ed9bbc",
+                    "x-checker-data" : {
+                        "type" : "gnome",
+                        "name" : "gnome-online-accounts"
+                    }
+                }
+            ]
+        },
+        {
             "name" : "planify",
             "builddir" : true,
             "buildsystem" : "meson",

--- a/core/Services/GOA.vala
+++ b/core/Services/GOA.vala
@@ -1,0 +1,205 @@
+/*
+ * Copyright © 2026 Alain M. (https://github.com/alainm23/planify)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA
+ *
+ * Authored by: Alain M. <alainmh23@gmail.com>
+ */
+
+public class Services.GOA : Object {
+    private static GLib.Once<Services.GOA> _instance;
+    public static unowned Services.GOA get_default () {
+        return _instance.once (() => {
+            return new Services.GOA ();
+        });
+    }
+
+    public class DetectedAccount : Object {
+        public string id { get; construct; }
+        public string provider_type { get; construct; }
+        public string display_name { get; construct; }
+        public string identity { get; construct; }
+        public string server_uri { get; construct; }
+        public bool accept_ssl_errors { get; construct; }
+
+        public DetectedAccount (string id, string provider_type, string display_name,
+                                string identity, string server_uri, bool accept_ssl_errors) {
+            Object (
+                id: id,
+                provider_type: provider_type,
+                display_name: display_name,
+                identity: identity,
+                server_uri: server_uri,
+                accept_ssl_errors: accept_ssl_errors
+            );
+        }
+
+        public bool is_nextcloud () {
+            return provider_type == "nextcloud" || provider_type == "owncloud";
+        }
+
+        public string username {
+            get {
+                _username = compute_username ();
+                return _username;
+            }
+        }
+        private string _username;
+
+        private string compute_username () {
+            if (identity == null || identity == "") {
+                return "";
+            }
+
+            int at = identity.last_index_of_char ('@');
+            if (at < 0) {
+                return identity;
+            }
+
+            string local_part = identity.substring (0, at);
+            string host_part = identity.substring (at + 1);
+
+            string server_host = "";
+            try {
+                var uri = GLib.Uri.parse (server_uri, GLib.UriFlags.NONE);
+                server_host = uri.get_host () ?? "";
+            } catch (Error e) {
+                server_host = "";
+            }
+
+            if (server_host != "" && host_part.has_prefix (server_host)) {
+                return local_part;
+            }
+
+            return identity;
+        }
+    }
+
+    private Goa.Client? client = null;
+    private bool tried_init = false;
+
+
+    private async Goa.Client? get_client () {
+        if (client != null) {
+            return client;
+        }
+
+        if (tried_init) {
+            return client;
+        }
+        tried_init = true;
+
+        try {
+            client = yield new Goa.Client (null);
+        } catch (Error e) {
+            Services.LogService.get_default ().info (
+                "GOA", "GNOME Online Accounts not available: %s".printf (e.message)
+            );
+            client = null;
+        }
+
+        return client;
+    }
+
+    public async bool is_available () {
+        return (yield get_client ()) != null;
+    }
+
+    private const string[] SUPPORTED_PROVIDERS = { "nextcloud", "owncloud", "webdav" };
+
+    private static bool is_supported_provider (string provider_type) {
+        foreach (unowned string p in SUPPORTED_PROVIDERS) {
+            if (p == provider_type) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static string normalize_server_uri (string raw) {
+        try {
+            var uri = GLib.Uri.parse (raw, GLib.UriFlags.NONE);
+            var scheme = uri.get_scheme ();
+            var host = uri.get_host ();
+
+            if (host == null || host == "") {
+                return raw;
+            }
+
+            string server = "%s://%s".printf (scheme, host);
+
+            int port = uri.get_port ();
+            bool default_port = (scheme == "https" && port == 443)
+                || (scheme == "http" && port == 80);
+            if (port > 0 && !default_port) {
+                server += ":%d".printf (port);
+            }
+
+            string path = uri.get_path ();
+            if (path != null && path != "" && path != "/"
+                && !path.has_prefix ("/remote.php")
+                && !path.has_prefix ("/dav")) {
+                if (path.has_suffix ("/")) {
+                    path = path.substring (0, path.length - 1);
+                }
+                server += path;
+            }
+
+            return server;
+        } catch (Error e) {
+            Services.LogService.get_default ().warn (
+                "GOA", "Could not normalize URI '%s': %s".printf (raw, e.message)
+            );
+            return raw;
+        }
+    }
+
+    public async Gee.ArrayList<DetectedAccount> list_caldav_accounts () {
+        var result = new Gee.ArrayList<DetectedAccount> ();
+
+        var goa_client = yield get_client ();
+        if (goa_client == null) {
+            return result;
+        }
+
+        foreach (unowned Goa.Object object in goa_client.get_accounts ()) {
+            var account = object.get_account ();
+            if (account == null || account.calendar_disabled) {
+                continue;
+            }
+
+            if (!is_supported_provider (account.provider_type)) {
+                continue;
+            }
+
+            var calendar = object.get_calendar ();
+            if (calendar == null || calendar.uri == null || calendar.uri == "") {
+                continue;
+            }
+
+            result.add (new DetectedAccount (
+                account.id,
+                account.provider_type,
+                account.provider_name,
+                account.presentation_identity,
+                normalize_server_uri (calendar.uri),
+                calendar.accept_ssl_errors
+            ));
+        }
+
+        return result;
+    }
+}

--- a/core/meson.build
+++ b/core/meson.build
@@ -117,6 +117,10 @@ if get_option('evolution')
     core_files += 'Services/CalendarEvents/Util.vala'
 endif
 
+if get_option('goa')
+    core_files += 'Services/GOA.vala'
+endif
+
 chrono_dep = dependency('chrono', fallback: ['chrono', 'libchrono_dep'])
 
 core_deps = [
@@ -140,6 +144,12 @@ if get_option('evolution')
     if libecal_dep.found()
         core_deps += libecal_dep
         core_deps += libedataserver_dep
+    endif
+endif
+
+if get_option('goa')
+    if goa_dep.found()
+        core_deps += goa_dep
     endif
 endif
 

--- a/meson.build
+++ b/meson.build
@@ -90,6 +90,15 @@ if get_option('evolution')
     endif
 endif
 
+if get_option('goa')
+    goa_dep = dependency('goa-1.0', required: true)
+    add_project_arguments('-D', 'WITH_GOA', language: 'vala')
+    add_project_arguments('-DGOA_API_IS_SUBJECT_TO_CHANGE', language: 'c')
+    if not goa_dep.found()
+        error('goa-1.0 requested but not found')
+    endif
+endif
+
 ############
 # Resources #
 ############

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -3,4 +3,5 @@ option('profile', type: 'combo', choices: ['default', 'development'], value: 'de
 option('spelling', type: 'feature')
 option('portal', type : 'boolean', description: 'build with xdg-portal support for ')
 option('evolution', type : 'boolean', description: 'build with evolution for integration with evolution calendars')
+option('goa', type : 'boolean', description: 'build with GNOME Online Accounts support for detecting linked Nextcloud/CalDAV accounts')
 option('manpage', type: 'boolean', value: false, description: 'install man page')

--- a/src/Dialogs/Preferences/Pages/Accounts/Accounts.vala
+++ b/src/Dialogs/Preferences/Pages/Accounts/Accounts.vala
@@ -22,6 +22,12 @@
 public class Dialogs.Preferences.Pages.Accounts : Dialogs.Preferences.Pages.BasePage {
     private Layouts.HeaderItem sources_group;
     private Gtk.Label inbox_page_name;
+#if WITH_GOA
+    private Adw.BottomSheet bottom_sheet;
+    private Gtk.Revealer import_link_revealer;
+    private Gtk.Label import_link_label;
+    private Gtk.ListBox detected_listbox;
+#endif
 
     public Accounts (Adw.PreferencesDialog preferences_dialog) {
         Object (
@@ -63,7 +69,8 @@ public class Dialogs.Preferences.Pages.Accounts : Dialogs.Preferences.Pages.Base
         sources_group = new Layouts.HeaderItem (_("Accounts")) {
             card = true,
             reveal = true,
-            listbox_margin_top = 6
+            listbox_margin_top = 6,
+            subheader_title = _("Task sources you sync with. Drag to reorder.")
         };
 
         sources_group.add_widget_end (add_source_button);
@@ -102,10 +109,38 @@ public class Dialogs.Preferences.Pages.Accounts : Dialogs.Preferences.Pages.Base
             margin_end = 12
         };
         content_box.append (sources_group);
-        content_box.append (new Gtk.Label (_("You can sort your accounts by dragging and dropping")) {
-            css_classes = { "caption", "dimmed" },
-            halign = START
+#if WITH_GOA
+        import_link_label = new Gtk.Label (null) {
+            halign = END,
+            css_classes = { "caption" }
+        };
+
+        var import_link_box = new Gtk.Box (HORIZONTAL, 3) {
+            halign = END
+        };
+        import_link_box.append (import_link_label);
+        import_link_box.append (new Gtk.Image.from_icon_name ("go-next-symbolic") {
+            pixel_size = 12
         });
+
+        var import_link_button = new Gtk.Button () {
+            child = import_link_box,
+            css_classes = { "flat", "accent" },
+            halign = END,
+            margin_top = 3
+        };
+        import_link_button.clicked.connect (() => {
+            bottom_sheet.open = true;
+        });
+
+        import_link_revealer = new Gtk.Revealer () {
+            transition_type = Gtk.RevealerTransitionType.SLIDE_DOWN,
+            child = import_link_button,
+            halign = END,
+            reveal_child = false
+        };
+        content_box.append (import_link_revealer);
+#endif
         content_box.append (inbox_group);
 
         var toolbar_view = new Adw.ToolbarView () {
@@ -113,7 +148,11 @@ public class Dialogs.Preferences.Pages.Accounts : Dialogs.Preferences.Pages.Base
         };
         toolbar_view.add_top_bar (new Adw.HeaderBar ());
 
+#if WITH_GOA
+        child = build_goa_bottom_sheet (toolbar_view);
+#else
         child = toolbar_view;
+#endif
         update_inbox_page_name ();
 
         Gee.HashMap<string, SourceRow> sources_hashmap = new Gee.HashMap<string, SourceRow> ();
@@ -160,7 +199,153 @@ public class Dialogs.Preferences.Pages.Accounts : Dialogs.Preferences.Pages.Base
         destroy.connect (() => {
             clean_up ();
         });
+
+#if WITH_GOA
+        load_detected_accounts.begin ();
+
+        signal_map[Services.Store.instance ().source_added.connect (() => {
+            load_detected_accounts.begin ();
+        })] = Services.Store.instance ();
+
+        signal_map[Services.Store.instance ().source_deleted.connect (() => {
+            load_detected_accounts.begin ();
+        })] = Services.Store.instance ();
+#endif
     }
+
+#if WITH_GOA
+    private Gtk.Widget build_goa_bottom_sheet (Gtk.Widget content) {
+        detected_listbox = new Gtk.ListBox () {
+            selection_mode = Gtk.SelectionMode.NONE,
+            css_classes = { "boxed-list" },
+            margin_start = 12,
+            margin_end = 12,
+            margin_top = 12,
+            margin_bottom = 12
+        };
+
+        var sheet_title = new Gtk.Label (_("Detected Accounts")) {
+            halign = START,
+            margin_start = 12,
+            margin_top = 12,
+            css_classes = { "title-4" }
+        };
+
+        var sheet_subtitle = new Gtk.Label (_("Accounts configured in GNOME Online Accounts")) {
+            halign = START,
+            margin_start = 12,
+            wrap = true,
+            xalign = 0,
+            css_classes = { "caption", "dimmed" }
+        };
+
+        var sheet_box = new Gtk.Box (VERTICAL, 6);
+        sheet_box.append (sheet_title);
+        sheet_box.append (sheet_subtitle);
+        sheet_box.append (detected_listbox);
+
+        bottom_sheet = new Adw.BottomSheet () {
+            content = content,
+            sheet = sheet_box,
+            show_drag_handle = true,
+            modal = true
+        };
+
+        return bottom_sheet;
+    }
+
+    private async void load_detected_accounts () {
+        if (detected_listbox == null) {
+            return;
+        }
+
+        Gtk.Widget? child = detected_listbox.get_first_child ();
+        while (child != null) {
+            Gtk.Widget? next = child.get_next_sibling ();
+            detected_listbox.remove (child);
+            child = next;
+        }
+
+        var accounts = yield Services.GOA.get_default ().list_caldav_accounts ();
+
+        int shown = 0;
+        foreach (var account in accounts) {
+            if (is_already_added (account.server_uri)) {
+                continue;
+            }
+
+            detected_listbox.append (build_detected_row (account));
+            shown++;
+        }
+
+        string text = ngettext (
+            "%d account available to import from GNOME Online Accounts",
+            "%d accounts available to import from GNOME Online Accounts",
+            shown
+        ).printf (shown);
+        import_link_label.label = text;
+        import_link_revealer.reveal_child = shown > 0;
+
+        if (shown == 0) {
+            bottom_sheet.open = false;
+        }
+    }
+
+    private bool is_already_added (string server_uri) {
+        string host = uri_host (server_uri);
+        if (host == "") {
+            return false;
+        }
+
+        foreach (Objects.Source source in Services.Store.instance ().sources) {
+            if (source.source_type == SourceType.CALDAV &&
+                uri_host (source.caldav_data.server_url) == host) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static string uri_host (string url) {
+        try {
+            var uri = GLib.Uri.parse (url, GLib.UriFlags.NONE);
+            var host = uri.get_host ();
+            return host ?? "";
+        } catch (Error e) {
+            return "";
+        }
+    }
+
+    private Adw.ActionRow build_detected_row (Services.GOA.DetectedAccount account) {
+        var row = new Adw.ActionRow () {
+            title = account.display_name,
+            subtitle = account.identity
+        };
+        row.add_prefix (new Gtk.Image.from_icon_name ("cloud-outline-thick-symbolic"));
+
+        var import_button = new Gtk.Button.with_label (_("Import")) {
+            valign = CENTER,
+            css_classes = { "suggested-action" }
+        };
+        row.add_suffix (import_button);
+
+        import_button.clicked.connect (() => {
+            bottom_sheet.open = false;
+
+            if (account.is_nextcloud ()) {
+                var setup = new NextcloudSetup (preferences_dialog, this);
+                preferences_dialog.push_subpage (setup);
+                setup.prefill (account.server_uri);
+            } else {
+                var setup = new CalDAVSetup (preferences_dialog, this);
+                preferences_dialog.push_subpage (setup);
+                setup.prefill (account.server_uri, account.username);
+            }
+        });
+
+        return row;
+    }
+#endif
 
     private void add_source_row (Objects.Source source, Gee.HashMap<string, SourceRow> sources_hashmap) {
         if (!sources_hashmap.has_key (source.id)) {

--- a/src/Dialogs/Preferences/Pages/Accounts/CalDAVSetup.vala
+++ b/src/Dialogs/Preferences/Pages/Accounts/CalDAVSetup.vala
@@ -216,6 +216,15 @@ public class Dialogs.Preferences.Pages.CalDAVSetup : Dialogs.Preferences.Pages.B
         });
     }
 
+    public void prefill (string url, string? username = null) {
+        server_entry.text = url;
+        if (username != null && username != "") {
+            username_entry.text = username;
+        }
+        validate_entries ();
+        password_entry.grab_focus ();
+    }
+
     private void validate_entries () {
         bool valid = server_entry.text != null && server_entry.text != "" &&
                      username_entry.text != null && username_entry.text != "" &&

--- a/src/Dialogs/Preferences/Pages/Accounts/NextcloudSetup.vala
+++ b/src/Dialogs/Preferences/Pages/Accounts/NextcloudSetup.vala
@@ -187,6 +187,10 @@ public class Dialogs.Preferences.Pages.NextcloudSetup : Dialogs.Preferences.Page
         });
     }
 
+    public void prefill (string url) {
+        server_entry.text = url;
+    }
+
     private void on_login_button_clicked () {
         Services.LogService.get_default ().info ("NextcloudSetup", "Login button clicked");
         GLib.Cancellable cancellable = new GLib.Cancellable ();

--- a/src/meson.build
+++ b/src/meson.build
@@ -22,6 +22,12 @@ if get_option('evolution')
     endif
 endif
 
+if get_option('goa')
+    if goa_dep.found()
+        deps += goa_dep
+    endif
+endif
+
 
 sources = files(
   'App.vala',


### PR DESCRIPTION
Detects CalDAV-capable accounts already set up in GNOME Online Accounts and offers to import them, so the user doesn't retype the server URL.

A subtle link under the account list opens a sheet of detected accounts, each
with an Import button:
- Nextcloud / ownCloud → Nextcloud setup with the URL prefilled (Login Flow v2).
- Generic CalDAV → CalDAV setup with URL + username prefilled; user enters only
  the password.

Closes #1145

<img width="479" height="630" alt="image" src="https://github.com/user-attachments/assets/41e938c0-917b-43bb-b4e8-8cd6d8d69582" />
