### PR TITLE
Follow system locale for date order instead of hardcoded month-day

### DIFF
--- a/core/Utils/Datetime.vala
+++ b/core/Utils/Datetime.vala
@@ -792,24 +792,67 @@ public class Utils.Datetime {
         var date_only = get_date_only (date);
         
         var day_name = date_only.format ("%a");
-        var day_month = date_only.format ("%e %b");
+        var day_month = date_only.format (day_month_format ());
 
         return "%s, %s".printf (day_name, day_month);
     }
 
+    // Whether the system locale writes the day before the month (e.g. en_GB
+    // "15 Dec"), as opposed to month before day (e.g. en_US "Dec 15"). Read once
+    // from the locale's short date format (LC_TIME) and cached.
+    private static int _day_first = -1; // -1 unknown, 0 month-first, 1 day-first
+    private static bool locale_day_before_month () {
+        if (_day_first == -1) {
+            _day_first = 0; // default to month-first if it can't be determined
+            unowned string d_fmt = Posix.NLItem.D_FMT.to_string ();
+            if (d_fmt != null && d_fmt != "") {
+                int day_pos = first_token_pos (d_fmt, "de");   // %d, %e
+                int month_pos = first_token_pos (d_fmt, "mbBh"); // %m, %b, %B, %h
+                if (day_pos >= 0 && month_pos >= 0 && day_pos < month_pos) {
+                    _day_first = 1;
+                }
+            }
+        }
+
+        return _day_first == 1;
+    }
+
+    // Position of the first %<token> in `fmt` whose letter is in `tokens`,
+    // or -1 if none is present.
+    private static int first_token_pos (string fmt, string tokens) {
+        int best = -1;
+        for (int i = 0; i < fmt.length - 1; i++) {
+            if (fmt[i] == '%') {
+                char c = fmt[i + 1];
+                if (tokens.index_of_char (c) >= 0) {
+                    if (best == -1 || i < best) {
+                        best = i;
+                    }
+                }
+                i++; // skip the token letter
+            }
+        }
+
+        return best;
+    }
+
+    // Day + abbreviated month in the order the system locale prefers.
+    private static string day_month_format () {
+        return locale_day_before_month () ? "%-e %b" : "%b %-e";
+    }
+
     public static string get_default_date_format (bool with_weekday = false, bool with_day = true, bool with_year = false) {
+        string dm = day_month_format ();
+
         if (with_weekday == true && with_day == true && with_year == true) {
-            /// TRANSLATORS: a GLib.DateTime format showing the weekday, date, and year
-            return _("%a, %b %-e, %Y");
+            return "%%a, %s, %%Y".printf (dm);
         } else if (with_weekday == false && with_day == true && with_year == true) {
-            /// TRANSLATORS: a GLib.DateTime format showing the date and year
-            return _("%b %-e %Y");
+            return "%s %%Y".printf (dm);
         } else if (with_weekday == false && with_day == false && with_year == true) {
             /// TRANSLATORS: a GLib.DateTime format showing the year
             return _("%Y");
         } else if (with_weekday == false && with_day == true && with_year == false) {
-            /// TRANSLATORS: a GLib.DateTime format showing the date
-            return _("%b %-e");
+            return dm;
         } else if (with_weekday == true && with_day == false && with_year == true) {
             /// TRANSLATORS: a GLib.DateTime format showing the weekday and year.
             return _("%a %Y");
@@ -817,8 +860,7 @@ public class Utils.Datetime {
             /// TRANSLATORS: a GLib.DateTime format showing the weekday
             return _("%a");
         } else if (with_weekday == true && with_day == true && with_year == false) {
-            /// TRANSLATORS: a GLib.DateTime format showing the weekday and date
-            return _("%a, %b %-e");
+            return "%%a, %s".printf (dm);
         } else if (with_weekday == false && with_day == false && with_year == false) {
             /// TRANSLATORS: a GLib.DateTime format showing the month.
             return _("%b");

--- a/meson.build
+++ b/meson.build
@@ -59,6 +59,11 @@ if is_libical4
   add_project_arguments('-D', 'IS_LIBICAL4', language: 'vala')
 endif
 
+# Datetime.vala reads the locale's short date format via Posix.nl_langinfo, so
+# the posix vapi must be linked for every build variant (it is otherwise only
+# pulled in transitively by the evolution-only CalendarEvents.vala).
+add_project_arguments(['--pkg=posix'], language: 'vala')
+
 if icu_uc_dep.found ()
   add_project_arguments(['--vapidir=' + meson.project_source_root() / 'vapi'], language: 'vala')
 endif

--- a/src/Dialogs/ProductivityReport/HeatMap.vala
+++ b/src/Dialogs/ProductivityReport/HeatMap.vala
@@ -115,7 +115,7 @@ public class Dialogs.ProductivityReport.HeatMap : Adw.Bin {
                     width_request = CELL_SIZE,
                     height_request = CELL_SIZE,
                     tooltip_text = "%s — %s".printf (
-                        cell_date.format ("%a, %b %d"),
+                        cell_date.format (Utils.Datetime.get_default_date_format (true, true, false)),
                         ngettext ("%d task", "%d tasks", count).printf (count)
                     )
                 };

--- a/src/Widgets/EventRow.vala
+++ b/src/Widgets/EventRow.vala
@@ -124,12 +124,13 @@ public class Widgets.EventRow : Gtk.ListBoxRow {
 
     private void update_timelabel () {
         string time_format = Utils.Datetime.is_clock_format_12h () ? "%I:%M %p" : "%H:%M";
-        
+        string date_format = Utils.Datetime.get_default_date_format (false, true, false);
+
         if (show_date) {
             if (is_allday) {
-                time_label.label = start_time.format ("%d %b");
+                time_label.label = start_time.format (date_format);
             } else {
-                time_label.label = start_time.format ("%d %b · ") + get_time_range_for_day (display_date ?? start_time, time_format);
+                time_label.label = start_time.format (date_format + " · ") + get_time_range_for_day (display_date ?? start_time, time_format);
             }
         } else {
             if (is_allday) {
@@ -162,8 +163,9 @@ public class Widgets.EventRow : Gtk.ListBoxRow {
         } else if (is_last_day) {
             result = start_of_day + " - " + end_time.format (time_format);
         } else {
-            result = start_time.format ("%d %b ") + start_time.format (time_format) + " - " + 
-                     end_time.format ("%d %b ") + end_time.format (time_format);
+            string date_format = Utils.Datetime.get_default_date_format (false, true, false);
+            result = start_time.format (date_format + " ") + start_time.format (time_format) + " - " +
+                     end_time.format (date_format + " ") + end_time.format (time_format);
         }
         
         return result;
@@ -209,14 +211,15 @@ public class Widgets.EventRow : Gtk.ListBoxRow {
 
         string date_text;
         if (is_allday) {
-            date_text = start_time.format ("%A, %e de %B");
+            date_text = start_time.format ("%A, " + Utils.Datetime.get_default_date_format (false, true, false));
         } else {
             string time_format = Utils.Datetime.is_clock_format_12h () ? "%I:%M %p" : "%H:%M";
             
             if (start_time.get_day_of_year () == end_time.get_day_of_year () && start_time.get_year () == end_time.get_year ()) {
-                date_text = start_time.format ("%A, %e de %B · ") + start_time.format (time_format) + " - " + end_time.format (time_format);
+                date_text = start_time.format ("%A, " + Utils.Datetime.get_default_date_format (false, true, false) + " · ") + start_time.format (time_format) + " - " + end_time.format (time_format);
             } else {
-                date_text = start_time.format ("%e %b ") + start_time.format (time_format) + " - " + end_time.format ("%e %b ") + end_time.format (time_format);
+                string dm = Utils.Datetime.get_default_date_format (false, true, false);
+                date_text = start_time.format (dm + " ") + start_time.format (time_format) + " - " + end_time.format (dm + " ") + end_time.format (time_format);
             }
         }
 


### PR DESCRIPTION
Dates were always shown month-day (e.g. "Dec 15"), even on systems whose locale uses day-month (e.g. British English expects "15 Dec"). The order was hardcoded rather than following the system locale.

The day/month order is now read from the locale's short date format (LC_TIME) and applied everywhere dates are shown — task deadlines, project deadlines, calendar events and the productivity heatmap. A hardcoded Spanish "de" separator in the event detail label was fixed along the way. The month name stays
localized as before; only the order follows the system.

Closes #2107